### PR TITLE
feat: enhance budget management and UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ PROPOSED_FIXES.md
 local/
 test_output.txt
 scripts/verify-counts.ts
+marketing/

--- a/src/core/ai-credits.test.ts
+++ b/src/core/ai-credits.test.ts
@@ -32,11 +32,8 @@ function sess(requests: SessionRequest[]): Session {
     sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
     workspaceId: 'ws-1',
     workspaceName: 'proj',
-    // 'Claude (via GHCP)' is in AI_CREDIT_HARNESSES (so getAiCredits picks
-    // these up) but NOT in GHCP_BILLABLE_HARNESSES (so claude-* model IDs
-    // don't get tagged as `delegated`). This lets these tests exercise the
-    // credit-math paths cleanly regardless of the request's model.
-    harness: 'Claude (via GHCP)',
+    // All Claude sessions now use the unified 'Claude' harness.
+    harness: 'Claude',
     requests,
   });
 }
@@ -214,7 +211,7 @@ describe('getAiCreditBurndown — missing-token handling', () => {
       sessionId: 's-pending',
       workspaceId: 'ws-1',
       workspaceName: 'proj',
-      harness: 'Claude (via GHCP)',
+      harness: 'Claude',
       requests: [
         createRequest({
           messageText: 'hi', responseText: 'in progress',
@@ -276,7 +273,7 @@ describe('getAiCredits — new bucket semantics', () => {
       sessionId: 's-mix',
       workspaceId: 'ws-1',
       workspaceName: 'proj',
-      harness: 'Claude (via GHCP)',
+      harness: 'Claude',
       requests: [
         createRequest({ messageText: 'a', responseText: 'b', requestId: 'r1',
           timestamp: BASE_TS, modelId: 'claude-sonnet-4',
@@ -308,7 +305,7 @@ describe('getAiCredits — new bucket semantics', () => {
       sessionId: 's-allpending',
       workspaceId: 'ws-1',
       workspaceName: 'proj',
-      harness: 'Claude (via GHCP)',
+      harness: 'Claude',
       requests: [
         createRequest({ messageText: 'a', responseText: 'b', requestId: 'p1',
           timestamp: BASE_TS, modelId: 'claude-sonnet-4', endState: 'pending' }),
@@ -528,7 +525,7 @@ describe('getAiCredits — dailyTokensByWorkspace', () => {
       sessionId: `s-${Math.random().toString(36).slice(2, 8)}`,
       workspaceId: wsName,
       workspaceName: wsName,
-      harness: 'Claude (via GHCP)',
+      harness: 'Claude',
       requests,
     });
   }

--- a/src/core/analyzer-base.ts
+++ b/src/core/analyzer-base.ts
@@ -73,4 +73,15 @@ export class AnalyzerBase {
       return true;
     });
   }
+
+  /** Ensure the day-key array includes fromDate so fillDayRange starts
+   *  from the filter boundary, keeping all charts aligned on the same x-axis. */
+  protected anchorFromDate(keys: string[], f?: DateFilter): string[] {
+    if (!f?.fromDate || f.fromDate <= '0001-01-01') return keys;
+    const sorted = keys.length > 0 ? [...keys].sort() : [];
+    if (sorted.length === 0 || f.fromDate < sorted[0]) {
+      return [f.fromDate, ...keys];
+    }
+    return keys;
+  }
 }

--- a/src/core/analyzer-consumption.ts
+++ b/src/core/analyzer-consumption.ts
@@ -8,39 +8,6 @@
 import { DateFilter, ConsumptionData, BurndownConfig, BurndownData, SKU_BUDGETS, AiCreditData, AiCreditBurndownData, Session, SessionRequest, ModelUsage, TokenCoverageData, TokenCoverageHarness, TokenCoverageWorkspace, TokenCoverageSession, TokenCoverageTimeline, TokenCoverageTimelineCell } from './types';
 import { toDateStr, normalizeModel, modelMultiplier, isoWeek, resolveTokens, tokenCostInCredits, fillDayRange, fillWeekRange, fillMonthRange } from './helpers';
 import { AnalyzerBase } from './analyzer-base';
-import { SKU_AI_CREDITS } from './constants';
-
-/** Harnesses whose requests count toward GitHub Copilot's premium-request
- *  budget (`SKU_BUDGETS`). Allow-list rather than deny-list so new harnesses
- *  default to "not GHCP-billable" — safer than the alternative.
- *
- *  Excludes:
- *  - `Claude` / `Claude (via GHCP)` — Claude JSONL records work that is either
- *    paid via Anthropic plan (interactive) or already billed on the GHCP side
- *    via the VS Code chatSessions log (programmatic). Counting them here
- *    would double-count.
- *  - `Codex` / `OpenCode` — paid through OpenAI plan / BYO key, not GHCP. */
-const GHCP_BILLABLE_HARNESSES: ReadonlySet<string> = new Set([
-  'GitHub Copilot',
-  'Local Agent',
-  'Local Agent (Insiders)',
-  'GitHub Copilot CLI',
-  'Xcode',
-]);
-
-/** Harnesses whose requests count toward the GitHub Copilot AI Credit
- *  (`SKU_AI_CREDITS`) budget. Includes `Claude (via GHCP)` because that
- *  harness *is* GHCP work, just observed from the Claude JSONL side.
- *  Excludes interactive `Claude`, `Codex`, `OpenCode` because those are
- *  paid through other plans. */
-const AI_CREDIT_HARNESSES: ReadonlySet<string> = new Set([
-  'GitHub Copilot',
-  'Local Agent',
-  'Local Agent (Insiders)',
-  'GitHub Copilot CLI',
-  'Xcode',
-  'Claude (via GHCP)',
-]);
 
 /** Per-request billing token attribution.
  *
@@ -54,11 +21,6 @@ const AI_CREDIT_HARNESSES: ReadonlySet<string> = new Set([
  *  - `pending`    — the parent session is still active or was aborted before
  *                   any model response. Excluded from the missing% denominator
  *                   because token data was never finalizable.
- *  - `delegated`  — VS Code request routed to a `claude-*` model. The
- *                   authoritative token data lives on the Claude (via GHCP)
- *                   side, so we intentionally skip the VS Code-side tokens to
- *                   avoid double-counting. Excluded from credits and from the
- *                   missing% denominator (it's not a parser gap).
  *  - `missing`    — no token data and no excuse — a real coverage gap. */
 interface RequestBilling {
   uncachedInput: number;
@@ -71,12 +33,10 @@ interface RequestBilling {
    *    complete   — both input and output token counts are known.
    *    partial    — only output is known (e.g. VS Code top-level r.completionTokens).
    *    pending    — request not yet finalized; tokens may still arrive.
-   *    delegated  — VS Code claude-* request whose tokens are owned by the
-   *                 Claude (via GHCP) side. Skipped to avoid double-count.
    *    no-data    — request finalized but the harness/source did not record token
    *                 usage (Xcode never captures, some VS Code copilot/auto reqs,
    *                 CLI turns aborted before any model output). Permanent. */
-  status: 'complete' | 'partial' | 'pending' | 'delegated' | 'no-data' | 'missing';
+  status: 'complete' | 'partial' | 'pending' | 'no-data' | 'missing';
   /** Output tokens captured for partial requests (output-only data). 0 otherwise. */
   partialOutput: number;
   /** Provenance of the input/output values when `status === 'complete'`. */
@@ -91,53 +51,11 @@ interface RequestBilling {
 function harnessUsesSessionAggregated(harness: string | undefined): boolean {
   return harness === 'GitHub Copilot CLI' || harness === 'Codex';
 }
-
-/** Detect a VS Code-side request that was routed to Claude. The model
- *  actually executed the work via the Claude SDK, which writes its own
- *  high-fidelity token record under `~/.claude/projects/` (parsed as
- *  `Claude (via GHCP)`). Counting tokens on both sides would double-bill, so
- *  these requests are flagged `delegated` and contribute zero credits.
- *
- *  Limited to GHCP-billable harnesses so that, e.g., a `Claude (via GHCP)`
- *  session itself is not labeled "delegated" — it owns its tokens. */
-function isDelegatedClaudeRequest(session: Session, request: SessionRequest): boolean {
-  if (!GHCP_BILLABLE_HARNESSES.has(session.harness)) return false;
-  const model = request.modelId;
-  if (typeof model !== 'string') return false;
-  return normalizeModel(model).startsWith('claude-');
-}
-
-function makeDelegatedBilling(): RequestBilling {
-  return {
-    uncachedInput: 0,
-    totalInput: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    credits: 0,
-    status: 'delegated',
-    partialOutput: 0,
-    kind: 'exact',
-  };
-}
-
 function computeBilling(sessions: Session[]): Map<SessionRequest, RequestBilling> {
   const map = new Map<SessionRequest, RequestBilling>();
   for (const session of sessions) {
-    // Tag GHCP-side claude-* requests as delegated upfront so neither the
-    // session-aggregated path nor the per-request path attributes their
-    // tokens. The authoritative count comes from the matching
-    // Claude (via GHCP) session parsed from `~/.claude`.
-    const delegatedRequests = new Set<SessionRequest>();
-    for (const r of session.requests) {
-      if (isDelegatedClaudeRequest(session, r)) {
-        map.set(r, makeDelegatedBilling());
-        delegatedRequests.add(r);
-      }
-    }
-
     if (session.modelUsage) {
-      attributeSessionLevel(session, session.modelUsage, map, delegatedRequests);
+      attributeSessionLevel(session, session.modelUsage, map, new Set());
     } else {
       const isPending = session.endReason === 'active' || session.endReason === 'aborted';
       // For session-aggregated harnesses with no shutdown totals yet, treat
@@ -145,7 +63,6 @@ function computeBilling(sessions: Session[]): Map<SessionRequest, RequestBilling
       // per-request output entirely once the session shuts down.
       const preferPending = isPending && harnessUsesSessionAggregated(session.harness);
       for (const r of session.requests) {
-        if (delegatedRequests.has(r)) continue;
         attributePerRequest(r, map, isPending, preferPending);
       }
     }
@@ -160,19 +77,10 @@ function computeBilling(sessions: Session[]): Map<SessionRequest, RequestBilling
  *  `0` when the denominator is zero — callers should check `finalizable`
  *  separately to distinguish "0% missing because perfect coverage" from
  *  "no finalizable requests in this slice." */
-/** Compute "missing %" using the same denominator semantics as Token Coverage:
- *  pending and no-data requests are excluded from the denominator because
- *  neither category can ever produce token data (pending = in-flight, may yet
- *  arrive; no-data = harness/source structurally cannot record). `delegated`
- *  requests are also excluded — the tokens exist, just on the
- *  `Claude (via GHCP)` side. Returns `0` when the denominator is zero —
- *  callers should check `finalizable` separately to distinguish "0% missing
- *  because perfect coverage" from "no finalizable requests in this slice." */
 export function computeMissingPct(
   requests: number, counted: number, partial: number, pending: number, noData: number,
-  delegated: number = 0,
 ): number {
-  const denom = requests - pending - noData - delegated;
+  const denom = requests - pending - noData;
   if (denom <= 0) return 0;
   const missing = denom - counted - partial;
   return Math.round((missing / denom) * 100);
@@ -184,8 +92,6 @@ interface AiCreditModelEntry {
   partialRequests: number;
   pendingRequests: number;
   noDataRequests: number;
-  /** VS Code claude-* requests delegated to Claude (via GHCP). */
-  delegatedRequests: number;
   missingRequests: number;
   uncachedInputTokens: number;
   inputTokens: number;
@@ -304,23 +210,8 @@ function attributePerRequest(
 
 export class ConsumptionAnalyzer extends AnalyzerBase {
 
-  /** True if the request belongs to a session whose harness counts toward
-   *  GitHub Copilot's premium-request budget. */
-  private isGhcpBillable(request: SessionRequest): boolean {
-    const session = this.requestSessionMap.get(request);
-    return session ? GHCP_BILLABLE_HARNESSES.has(session.harness) : false;
-  }
-
-  /** True if the request belongs to a session whose harness counts toward
-   *  GitHub Copilot's AI Credit budget. Includes `Claude (via GHCP)` because
-   *  that's the authoritative token source for GHCP-spawned Claude work. */
-  private isAiCreditBillable(request: SessionRequest): boolean {
-    const session = this.requestSessionMap.get(request);
-    return session ? AI_CREDIT_HARNESSES.has(session.harness) : false;
-  }
-
   getConsumption(f?: DateFilter): ConsumptionData {
-    const reqs = this.filter(f).filter(r => this.isGhcpBillable(r));
+    const reqs = this.filter(f);
     const modelTotals = new Map<string, number>();
     const dailyMap = new Map<string, Map<string, number>>();
     const weeklyMap = new Map<string, Map<string, number>>();
@@ -394,8 +285,7 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     const monthStart = `${targetMonth}-01`;
     const monthEnd = `${targetMonth}-${String(daysInMonth).padStart(2, '0')}`;
 
-    const reqs = this.filter({ ...f, fromDate: monthStart, toDate: monthEnd })
-      .filter(r => this.isGhcpBillable(r));
+    const reqs = this.filter({ ...f, fromDate: monthStart, toDate: monthEnd });
     const dailyReqs = new Map<number, number>();
     for (const r of reqs) {
       const d = new Date(r.timestamp!).getDate();
@@ -438,8 +328,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       recommendation = `Healthy usage. ${remaining} requests remaining. Projected ${Math.round(projected)} of ${budget}.`;
     }
 
-    const harnessExcluded = !!(f?.harness && !GHCP_BILLABLE_HARNESSES.has(f.harness));
-
     return {
       currentMonth: targetMonth,
       daysInMonth, dayOfMonth, budget,
@@ -447,14 +335,13 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       dailyConsumption: { labels, values, cumulative },
       projectedLine, budgetLine,
       status, recommendation,
-      harnessExcluded,
     };
   }
 
   /* ---- AI Credit (usage-based billing) analytics ---- */
 
   getAiCredits(f?: DateFilter): AiCreditData {
-    const reqs = this.filter(f).filter(r => this.isAiCreditBillable(r));
+    const reqs = this.filter(f);
     const billing = computeBilling(this.sessions);
     const summary = this.createAiCreditSummary();
 
@@ -462,7 +349,7 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       this.applyAiCreditRequest(summary, request, billing.get(request));
     }
 
-    summary.topRequests.sort((a, b) => b.credits - a.credits);
+    summary.topRequests.sort((a, b) => (b.inputTokens + b.outputTokens) - (a.inputTokens + a.outputTokens));
     summary.topRequests.splice(10);
     const allModels = Array.from(summary.costByModel.keys()).sort((a, b) =>
       (summary.costByModel.get(b)?.credits || 0) - (summary.costByModel.get(a)?.credits || 0)
@@ -482,15 +369,16 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       partialRequests: summary.partialCount,
       pendingRequests: summary.pendingCount,
       noDataRequests: summary.noDataCount,
-      delegatedRequests: summary.delegatedCount,
-      finalizableRequests: reqs.length - summary.pendingCount - summary.noDataCount - summary.delegatedCount,
-      missingPct: computeMissingPct(reqs.length, summary.countedCount, summary.partialCount, summary.pendingCount, summary.noDataCount, summary.delegatedCount),
+      delegatedRequests: 0,
+      finalizableRequests: reqs.length - summary.pendingCount - summary.noDataCount,
+      missingPct: computeMissingPct(reqs.length, summary.countedCount, summary.partialCount, summary.pendingCount, summary.noDataCount),
       avgCreditsPerRequest: summary.countedCount > 0 ? Math.round((summary.totalCredits / summary.countedCount) * 100) / 100 : 0,
       avgCreditsPerDay: Math.round((summary.totalCredits / Math.max(countedDays.size, 1)) * 100) / 100,
       costByModel: this.buildAiCreditCostByModel(summary.costByModel),
-      daily: this.buildAiCreditSeries(summary.dailyMap, allModels, fillDayRange),
+      daily: this.buildAiCreditSeries(summary.dailyMap, allModels, keys => fillDayRange(this.anchorFromDate(keys, f))),
       weekly: this.buildAiCreditSeries(summary.weeklyMap, allModels, fillWeekRange),
-      dailyTokensByWorkspace: this.buildDailyTokensByWorkspace(summary.dailyTokensByWorkspace, fillDayRange),
+      dailyTokensByWorkspace: this.buildDailyTokensByWorkspace(summary.dailyTokensByWorkspace, keys => fillDayRange(this.anchorFromDate(keys, f))),
+      dailyTokensByHarness: this.buildDailyTokensByHarness(summary.dailyTokensByHarness, keys => fillDayRange(this.anchorFromDate(keys, f))),
       topRequests: summary.topRequests,
     };
   }
@@ -501,6 +389,8 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     weeklyMap: Map<string, Map<string, number>>;
     /** workspace → day → total tokens (input + output). */
     dailyTokensByWorkspace: Map<string, Map<string, number>>;
+    /** harness → day → total tokens (input + output). */
+    dailyTokensByHarness: Map<string, Map<string, number>>;
     totalInputTokens: number;
     totalOutputTokens: number;
     totalCacheReadTokens: number;
@@ -510,7 +400,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     partialCount: number;
     pendingCount: number;
     noDataCount: number;
-    delegatedCount: number;
     topRequests: AiCreditData['topRequests'];
   } {
     return {
@@ -518,6 +407,7 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       dailyMap: new Map<string, Map<string, number>>(),
       weeklyMap: new Map<string, Map<string, number>>(),
       dailyTokensByWorkspace: new Map<string, Map<string, number>>(),
+      dailyTokensByHarness: new Map<string, Map<string, number>>(),
       totalInputTokens: 0,
       totalOutputTokens: 0,
       totalCacheReadTokens: 0,
@@ -527,7 +417,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       partialCount: 0,
       pendingCount: 0,
       noDataCount: 0,
-      delegatedCount: 0,
       topRequests: [],
     };
   }
@@ -576,7 +465,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     else if (billing.status === 'partial') summary.partialCount++;
     else if (billing.status === 'pending') summary.pendingCount++;
     else if (billing.status === 'no-data') summary.noDataCount++;
-    else if (billing.status === 'delegated') summary.delegatedCount++;
 
     if (billing.status !== 'complete') return;
     summary.totalInputTokens += billing.totalInput;
@@ -598,7 +486,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       partialRequests: 0,
       pendingRequests: 0,
       noDataRequests: 0,
-      delegatedRequests: 0,
       missingRequests: 0,
       uncachedInputTokens: 0,
       inputTokens: 0,
@@ -625,8 +512,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       entry.pendingRequests++;
     } else if (billing.status === 'no-data') {
       entry.noDataRequests++;
-    } else if (billing.status === 'delegated') {
-      entry.delegatedRequests++;
     } else {
       entry.missingRequests++;
     }
@@ -639,19 +524,28 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     request: SessionRequest,
     billing: RequestBilling,
   ): void {
-    if (billing.status !== 'complete') return;
+    if (billing.status !== 'complete' && billing.status !== 'partial') return;
     const day = toDateStr(request.timestamp!);
     const week = isoWeek(new Date(request.timestamp!));
+    const totalTokens = billing.status === 'complete'
+      ? billing.totalInput + billing.output
+      : billing.partialOutput;
     for (const [mapRef, key] of [[summary.dailyMap, day], [summary.weeklyMap, week]] as const) {
       if (!mapRef.has(key)) mapRef.set(key, new Map());
       const inner = mapRef.get(key)!;
-      inner.set(model, (inner.get(model) || 0) + billing.credits);
+      inner.set(model, (inner.get(model) || 0) + totalTokens);
     }
-    // Accumulate total tokens (input + output) per workspace per day
-    const ws = this.requestSessionMap.get(request)?.workspaceName || 'unknown';
+    // Accumulate total tokens (input + output) per workspace and per harness per day
+    const session = this.requestSessionMap.get(request);
+    const ws = session?.workspaceName || 'unknown';
     if (!summary.dailyTokensByWorkspace.has(ws)) summary.dailyTokensByWorkspace.set(ws, new Map());
     const wsDay = summary.dailyTokensByWorkspace.get(ws)!;
-    wsDay.set(day, (wsDay.get(day) || 0) + billing.totalInput + billing.output);
+    wsDay.set(day, (wsDay.get(day) || 0) + totalTokens);
+
+    const harness = session?.harness || 'unknown';
+    if (!summary.dailyTokensByHarness.has(harness)) summary.dailyTokensByHarness.set(harness, new Map());
+    const hDay = summary.dailyTokensByHarness.get(harness)!;
+    hDay.set(day, (hDay.get(day) || 0) + totalTokens);
   }
 
   private buildAiCreditSeries(
@@ -669,11 +563,11 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       const inner = map.get(label);
       let dayTotal = 0;
       if (inner) { for (const value of inner.values()) dayTotal += value; }
-      credits.push(Math.round(dayTotal * 100) / 100);
+      credits.push(Math.round(dayTotal));
       runningTotal += dayTotal;
-      cumulative.push(Math.round(runningTotal * 100) / 100);
+      cumulative.push(Math.round(runningTotal));
       for (const model of allModels) {
-        byModel[model].push(Math.round((inner?.get(model) || 0) * 100) / 100);
+        byModel[model].push(Math.round(inner?.get(model) || 0));
       }
     }
     return { labels, credits, cumulative, byModel };
@@ -695,19 +589,35 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     return { labels, byWorkspace };
   }
 
+  private buildDailyTokensByHarness(
+    harnessMap: Map<string, Map<string, number>>,
+    fillRange: (keys: string[]) => string[],
+  ): AiCreditData['dailyTokensByHarness'] {
+    const allDays = new Set<string>();
+    for (const dayMap of harnessMap.values()) {
+      for (const day of dayMap.keys()) allDays.add(day);
+    }
+    const labels = fillRange(Array.from(allDays));
+    const byHarness: Record<string, number[]> = {};
+    for (const [harness, dayMap] of harnessMap) {
+      byHarness[harness] = labels.map(d => Math.round(dayMap.get(d) || 0));
+    }
+    return { labels, byHarness };
+  }
+
   private buildAiCreditCostByModel(
     costByModel: Map<string, AiCreditModelEntry>,
   ): Record<string, AiCreditData['costByModel'][string]> {
     const out: Record<string, AiCreditData['costByModel'][string]> = {};
     for (const [model, entry] of costByModel) {
-      const finalizableRequests = entry.requests - entry.pendingRequests - entry.noDataRequests - entry.delegatedRequests;
+      const finalizableRequests = entry.requests - entry.pendingRequests - entry.noDataRequests;
       out[model] = {
         requests: entry.requests,
         countedRequests: entry.countedRequests,
         partialRequests: entry.partialRequests,
         pendingRequests: entry.pendingRequests,
         noDataRequests: entry.noDataRequests,
-        delegatedRequests: entry.delegatedRequests,
+        delegatedRequests: 0,
         finalizableRequests,
         uncachedInputTokens: Math.round(entry.uncachedInputTokens),
         inputTokens: Math.round(entry.inputTokens),
@@ -715,7 +625,7 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
         cacheReadTokens: Math.round(entry.cacheReadTokens),
         cacheWriteTokens: Math.round(entry.cacheWriteTokens),
         credits: entry.credits,
-        missingPct: computeMissingPct(entry.requests, entry.countedRequests, entry.partialRequests, entry.pendingRequests, entry.noDataRequests, entry.delegatedRequests),
+        missingPct: computeMissingPct(entry.requests, entry.countedRequests, entry.partialRequests, entry.pendingRequests, entry.noDataRequests),
         harnesses: Array.from(entry.harnesses).sort(),
       };
     }
@@ -723,7 +633,8 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
   }
 
   getAiCreditBurndown(config: BurndownConfig, f?: DateFilter): AiCreditBurndownData {
-    const budget = config.customBudget ?? SKU_AI_CREDITS[config.sku] ?? 1900;
+    const modelBudgetsIn = config.modelBudgets ?? {};
+    const budget = config.customBudget ?? Object.values(modelBudgetsIn).reduce((a, b) => a + b, 0);
     const now = new Date();
     const targetMonth = config.month || `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
     const [yr, mo] = targetMonth.split('-').map(Number);
@@ -731,20 +642,20 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     const dayOfMonth = (yr === now.getFullYear() && mo === now.getMonth() + 1) ? now.getDate() : daysInMonth;
     const monthStart = `${targetMonth}-01`;
     const monthEnd = `${targetMonth}-${String(daysInMonth).padStart(2, '0')}`;
-    const reqs = this.filter({ ...f, fromDate: monthStart, toDate: monthEnd })
-      .filter(r => this.isAiCreditBillable(r));
+    const reqs = this.filter({ ...f, fromDate: monthStart, toDate: monthEnd });
     const burndown = this.buildAiCreditBurndownData(reqs, computeBilling(this.sessions), daysInMonth);
-    const series = this.buildAiCreditBurndownSeries(burndown.dailyCredits, daysInMonth);
-    const consumed = Math.round(series.total * 100) / 100;
+    const series = this.buildAiCreditBurndownSeries(burndown.dailyTokens, daysInMonth);
+    const consumed = Math.round(series.total);
     const dailyRate = dayOfMonth > 0 ? consumed / dayOfMonth : 0;
-    const projected = Math.round(dailyRate * daysInMonth * 100) / 100;
-    const projectedLine = series.labels.map((_, i) => Math.round(dailyRate * (i + 1) * 100) / 100);
-    const budgetLine = series.labels.map((_, i) => Math.round((budget / daysInMonth) * (i + 1) * 100) / 100);
-    const remaining = budget - consumed;
-    const safeDailyBudget = daysInMonth > dayOfMonth ? Math.round((remaining / (daysInMonth - dayOfMonth)) * 100) / 100 : 0;
-    const daysUntilExhaustion = dailyRate > 0 ? Math.round(remaining / dailyRate) : null;
-    const projectedOverageUsd = Math.round(Math.max(0, projected - budget)) / 100;
-    const missingPct = computeMissingPct(reqs.length, burndown.countedCount, burndown.partialCount, burndown.pendingCount, burndown.noDataCount, burndown.delegatedCount);
+    const projected = Math.round(dailyRate * daysInMonth);
+    const projectedLine = series.labels.map((_, i) => Math.round(dailyRate * (i + 1)));
+    // Budget line is a flat horizontal line at the budget value (a ceiling)
+    const budgetLine = series.labels.map(() => budget);
+    const remaining = budget > 0 ? budget - consumed : 0;
+    const safeDailyBudget = budget > 0 && daysInMonth > dayOfMonth ? Math.round(remaining / (daysInMonth - dayOfMonth)) : 0;
+    const daysUntilExhaustion = budget > 0 && dailyRate > 0 ? Math.round(remaining / dailyRate) : null;
+    const projectedOverage = budget > 0 ? Math.max(0, projected - budget) : 0;
+    const missingPct = computeMissingPct(reqs.length, burndown.countedCount, burndown.partialCount, burndown.pendingCount, burndown.noDataCount);
     const recommendation = this.getAiCreditBurndownRecommendation({
       budget,
       consumed,
@@ -757,6 +668,18 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       missingPct,
       remaining,
     });
+
+    // Build per-model cumulative data
+    const byModel: Record<string, { cumulative: number[]; budget: number }> = {};
+    for (const [model, dayMap] of burndown.dailyTokensByModel) {
+      const cumulative: number[] = [];
+      let running = 0;
+      for (let day = 1; day <= daysInMonth; day++) {
+        running += dayMap.get(day) || 0;
+        cumulative.push(Math.round(running));
+      }
+      byModel[model] = { cumulative, budget: modelBudgetsIn[model] || 0 };
+    }
 
     return {
       currentMonth: targetMonth,
@@ -772,16 +695,17 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       recommendation: recommendation.recommendation,
       daysUntilExhaustion,
       safeDailyBudget,
-      projectedOverageUsd,
+      projectedOverage,
       missingPct,
       totalRequests: reqs.length,
       countedRequests: burndown.countedCount,
       partialRequests: burndown.partialCount,
       pendingRequests: burndown.pendingCount,
       noDataRequests: burndown.noDataCount,
-      delegatedRequests: burndown.delegatedCount,
-      finalizableRequests: reqs.length - burndown.pendingCount - burndown.noDataCount - burndown.delegatedCount,
+      delegatedRequests: 0,
+      finalizableRequests: reqs.length - burndown.pendingCount - burndown.noDataCount,
       coverageByDay: burndown.coverageByDay,
+      byModel,
     };
   }
 
@@ -790,15 +714,16 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     billing: Map<SessionRequest, RequestBilling>,
     daysInMonth: number,
   ): {
-    dailyCredits: Map<number, number>;
+    dailyTokens: Map<number, number>;
+    dailyTokensByModel: Map<string, Map<number, number>>;
     coverageByDay: AiCreditBurndownData['coverageByDay'];
     countedCount: number;
     partialCount: number;
     pendingCount: number;
     noDataCount: number;
-    delegatedCount: number;
   } {
-    const dailyCredits = new Map<number, number>();
+    const dailyTokens = new Map<number, number>();
+    const dailyTokensByModel = new Map<string, Map<number, number>>();
     const coverageByDay = {
       complete: Array<number>(daysInMonth).fill(0),
       partial: Array<number>(daysInMonth).fill(0),
@@ -811,7 +736,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     let partialCount = 0;
     let pendingCount = 0;
     let noDataCount = 0;
-    let delegatedCount = 0;
 
     for (const request of reqs) {
       const requestBilling = billing.get(request);
@@ -823,29 +747,31 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
           status === 'partial' ? 'partial' :
           status === 'pending' ? 'pending' :
           status === 'no-data' ? 'noData' :
-          status === 'delegated' ? 'delegated' :
           'missing';
         coverageByDay[bucket][dayIdx]++;
       }
       if (status === 'complete') {
         countedCount++;
-        dailyCredits.set(dayIdx + 1, (dailyCredits.get(dayIdx + 1) || 0) + (requestBilling?.credits ?? 0));
+        const tokens = (requestBilling?.totalInput ?? 0) + (requestBilling?.output ?? 0);
+        dailyTokens.set(dayIdx + 1, (dailyTokens.get(dayIdx + 1) || 0) + tokens);
+        const model = normalizeModel(request.modelId ?? 'unknown');
+        if (!dailyTokensByModel.has(model)) dailyTokensByModel.set(model, new Map());
+        const modelDay = dailyTokensByModel.get(model)!;
+        modelDay.set(dayIdx + 1, (modelDay.get(dayIdx + 1) || 0) + tokens);
       } else if (status === 'partial') {
         partialCount++;
       } else if (status === 'pending') {
         pendingCount++;
       } else if (status === 'no-data') {
         noDataCount++;
-      } else if (status === 'delegated') {
-        delegatedCount++;
       }
     }
 
-    return { dailyCredits, coverageByDay, countedCount, partialCount, pendingCount, noDataCount, delegatedCount };
+    return { dailyTokens, dailyTokensByModel, coverageByDay, countedCount, partialCount, pendingCount, noDataCount };
   }
 
   private buildAiCreditBurndownSeries(
-    dailyCredits: Map<number, number>,
+    dailyTokens: Map<number, number>,
     daysInMonth: number,
   ): { labels: string[]; values: number[]; cumulative: number[]; total: number } {
     const labels: string[] = [];
@@ -854,10 +780,10 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     let total = 0;
     for (let day = 1; day <= daysInMonth; day++) {
       labels.push(String(day));
-      const value = dailyCredits.get(day) || 0;
-      values.push(Math.round(value * 100) / 100);
+      const value = dailyTokens.get(day) || 0;
+      values.push(Math.round(value));
       total += value;
-      cumulative.push(Math.round(total * 100) / 100);
+      cumulative.push(Math.round(total));
     }
     return { labels, values, cumulative, total };
   }
@@ -890,29 +816,29 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
       if (params.noDataCount === params.totalRequests) {
         return {
           status: 'no-data',
-          recommendation: `All ${params.totalRequests} request${params.totalRequests === 1 ? '' : 's'} in this period are from sources that don't record token usage (e.g. Xcode). Credit math is not possible for this slice.`,
+          recommendation: `All ${params.totalRequests} request${params.totalRequests === 1 ? '' : 's'} in this period are from sources that don't record token usage (e.g. Xcode). Token budget tracking is not possible for this slice.`,
         };
       }
       return {
         status: 'no-data',
-        recommendation: `No native token data available for any of the ${params.totalRequests} requests in this period — the harness did not report token counts, so credit usage cannot be computed.`,
+        recommendation: `No native token data available for any of the ${params.totalRequests} requests in this period — the harness did not report token counts, so token usage cannot be computed.`,
       };
     }
     if (params.consumed > params.budget) {
       return {
         status: 'will-exceed',
-        recommendation: `Over budget by ${Math.round(params.consumed - params.budget)} credits ($${((params.consumed - params.budget) / 100).toFixed(2)}). Consider using lighter models or shorter prompts.${partialNote}`,
+        recommendation: `Over budget by ${Math.round(params.consumed - params.budget).toLocaleString()} tokens. Consider using lighter models or shorter prompts.${partialNote}`,
       };
     }
     if (params.projected > params.budget * 0.9) {
       return {
         status: 'warning',
-        recommendation: `On pace to exceed budget. ${Math.round(params.remaining)} credits remaining, ~${Math.round(params.safeDailyBudget)}/day safe. Consider switching to GPT-5 mini or Gemini Flash.${partialNote}`,
+        recommendation: `On pace to exceed budget. ${Math.round(params.remaining).toLocaleString()} tokens remaining, ~${Math.round(params.safeDailyBudget).toLocaleString()}/day safe. Consider switching to GPT-5 mini or Gemini Flash.${partialNote}`,
       };
     }
     return {
       status: 'on-track',
-      recommendation: `Healthy usage. ${Math.round(params.remaining)} credits remaining. Projected ${Math.round(params.projected)} of ${params.budget}.${partialNote}`,
+      recommendation: `Healthy usage. ${Math.round(params.remaining).toLocaleString()} tokens remaining. Projected ${Math.round(params.projected).toLocaleString()} of ${params.budget.toLocaleString()}.${partialNote}`,
     };
   }
 
@@ -1061,17 +987,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
         harnessEntry.noData++;
         workspaceEntry.noData++;
         sessionEntry.noData++;
-      } else if (status === 'delegated') {
-        // VS Code claude-* request whose tokens live in Claude (via GHCP).
-        // Bucket alongside no-data: same effect on the missing% denominator
-        // (excluded), and the user can drill into the Claude (via GHCP)
-        // session for the actual data. Tracking a distinct UI bucket can
-        // come later — for now keep the token-coverage view focused on
-        // genuine parser gaps.
-        noDataRequests++;
-        harnessEntry.noData++;
-        workspaceEntry.noData++;
-        sessionEntry.noData++;
       } else {
         missingRequests++;
       }
@@ -1164,10 +1079,6 @@ export class ConsumptionAnalyzer extends AnalyzerBase {
     else if (status === 'partial') cell.partial++;
     else if (status === 'pending') cell.pending++;
     else if (status === 'no-data') cell.noData++;
-    // `delegated` is bucketed with no-data for missing% math (see comment in
-    // buildTokenCoverageMap). The bucket itself stays separate in the
-    // delegated-tracking code paths used by AI Credits.
-    else if (status === 'delegated') cell.noData++;
   }
 
   private getTokenCoverageSource(hasCounted: number, hasPartial: number, hasExact: boolean, hasAggregated: boolean): TokenCoverageHarness['source'] {

--- a/src/core/analyzer-production.ts
+++ b/src/core/analyzer-production.ts
@@ -6,7 +6,7 @@
 /* Code production analytics */
 
 import { DateFilter, CodeProductionData } from './types';
-import { toDateStr, fillDayRange } from './helpers';
+import { toDateStr, fillDayRange, normalizeModel } from './helpers';
 import { LOC_COST_2010 } from './constants';
 import { AnalyzerBase } from './analyzer-base';
 
@@ -20,16 +20,23 @@ export class ProductionAnalyzer extends AnalyzerBase {
     const dailyAi = new Map<string, number>();
     const wsAi = new Map<string, number>();
     const dailyWsAi = new Map<string, Map<string, number>>();
+    const dailyModelAi = new Map<string, Map<string, number>>();
+    const dailyHarnessAi = new Map<string, Map<string, number>>();
 
     for (const request of reqs) {
       const day = toDateStr(request.timestamp!);
-      const workspaceName = this.requestSessionMap.get(request)?.workspaceName || '';
+      const session = this.requestSessionMap.get(request);
+      const workspaceName = session?.workspaceName || '';
+      const model = normalizeModel(request.modelId || 'unknown');
+      const harness = session?.harness || 'unknown';
       for (const block of request.aiCode) {
         totalAiLoc += block.loc;
         aiBlocks++;
         this.addProductionLoc(langAi, block.language, block.loc);
         this.addProductionLoc(dailyAi, day, block.loc);
         this.addWorkspaceProductionLoc(wsAi, dailyWsAi, workspaceName, day, block.loc);
+        this.addDailyGroupLoc(dailyModelAi, model, day, block.loc);
+        this.addDailyGroupLoc(dailyHarnessAi, harness, day, block.loc);
       }
     }
 
@@ -37,12 +44,19 @@ export class ProductionAnalyzer extends AnalyzerBase {
       const editLocs = this.editLocIndex.get(request.requestId);
       if (!editLocs) continue;
       const day = request.timestamp ? toDateStr(request.timestamp) : null;
-      const workspaceName = this.requestSessionMap.get(request)?.workspaceName || '';
+      const session = this.requestSessionMap.get(request);
+      const workspaceName = session?.workspaceName || '';
+      const model = normalizeModel(request.modelId || 'unknown');
+      const harness = session?.harness || 'unknown';
       for (const [file, loc] of editLocs) {
         totalAiLoc += loc;
         this.addProductionLoc(langAi, file.split('.').pop()?.toLowerCase() || 'unknown', loc);
         if (day) this.addProductionLoc(dailyAi, day, loc);
         this.addWorkspaceProductionLoc(wsAi, dailyWsAi, workspaceName, day, loc);
+        if (day) {
+          this.addDailyGroupLoc(dailyModelAi, model, day, loc);
+          this.addDailyGroupLoc(dailyHarnessAi, harness, day, loc);
+        }
       }
     }
 
@@ -52,7 +66,12 @@ export class ProductionAnalyzer extends AnalyzerBase {
       (langAi.get(b) || 0) - (langAi.get(a) || 0)
     ).slice(0, 15);
 
-    const dayArr = fillDayRange(Array.from(dailyAi.keys()));
+    const dayKeys = Array.from(dailyAi.keys());
+    // Anchor the day range to fromDate so the x-axis aligns with other charts.
+    if (f?.fromDate && f.fromDate > '0001-01-01' && (dayKeys.length === 0 || f.fromDate < dayKeys.sort()[0])) {
+      dayKeys.push(f.fromDate);
+    }
+    const dayArr = fillDayRange(dayKeys);
 
     const wsArr = Array.from(wsAi.keys()).sort((a, b) =>
       (wsAi.get(b) || 0) - (wsAi.get(a) || 0)
@@ -85,11 +104,32 @@ export class ProductionAnalyzer extends AnalyzerBase {
           ws, dayArr.map(d => dm.get(d) || 0),
         ])
       ),
+      dailyByModel: Object.fromEntries(
+        Array.from(dailyModelAi.entries()).map(([m, dm]) => [
+          m, dayArr.map(d => dm.get(d) || 0),
+        ])
+      ),
+      dailyByHarness: Object.fromEntries(
+        Array.from(dailyHarnessAi.entries()).map(([h, dm]) => [
+          h, dayArr.map(d => dm.get(d) || 0),
+        ])
+      ),
     };
   }
 
   private addProductionLoc(target: Map<string, number>, key: string, loc: number): void {
     target.set(key, (target.get(key) || 0) + loc);
+  }
+
+  private addDailyGroupLoc(
+    groupMap: Map<string, Map<string, number>>,
+    key: string,
+    day: string,
+    loc: number,
+  ): void {
+    if (!groupMap.has(key)) groupMap.set(key, new Map());
+    const dayMap = groupMap.get(key)!;
+    dayMap.set(day, (dayMap.get(day) || 0) + loc);
   }
 
   private addWorkspaceProductionLoc(

--- a/src/core/analyzer.test.ts
+++ b/src/core/analyzer.test.ts
@@ -231,14 +231,13 @@ describe('Analyzer', () => {
           requests: [makeRequest({ timestamp: ts }), makeRequest({ timestamp: ts + 1000 })] }),
         makeSession({ sessionId: 's2', harness: 'GitHub Copilot CLI', creationDate: ts, workspaceName: 'proj',
           requests: [makeRequest({ timestamp: ts })] }),
-        // Non-GHCP harness — getConsumption excludes this from premium-request counts.
         makeSession({ sessionId: 's3', harness: 'Codex', creationDate: ts, workspaceName: 'proj',
           requests: [makeRequest({ timestamp: ts })] }),
       ];
       const a = new Analyzer(sessions);
-      // getConsumption only counts GHCP-billable harnesses (Codex excluded).
+      // getConsumption now counts all harnesses.
       const all = a.getConsumption();
-      expect(all.totalRequests).toBe(3);
+      expect(all.totalRequests).toBe(4);
 
       const filtered = a.getConsumption({ harness: 'Local Agent' });
       expect(filtered.totalRequests).toBe(2);
@@ -393,15 +392,15 @@ describe('Analyzer', () => {
 
     it('harness filter propagates to getConsumption', () => {
       const a = new Analyzer(sessions);
-      // Filter by Local Agent (a GHCP-billable harness) — s1 has 2 requests, s3 has 3.
+      // Filter by Local Agent — s1 has 2 requests, s3 has 3.
       const filter = validateDateFilter({ harness: 'Local Agent' } as Record<string, unknown>);
       const cons = a.getConsumption(filter);
       expect(cons.totalRequests).toBe(5); // s1(2) + s3(3)
 
-      // Filter by Claude (non-GHCP) — getConsumption excludes it from premium-request counts.
+      // Filter by Claude — only Claude sessions are included.
       const claudeFilter = validateDateFilter({ harness: 'Claude' } as Record<string, unknown>);
       const claudeCons = a.getConsumption(claudeFilter);
-      expect(claudeCons.totalRequests).toBe(0);
+      expect(claudeCons.totalRequests).toBe(1);
     });
 
     it('harness filter propagates to getWorkspaceBreakdown', () => {

--- a/src/core/parser-claude.test.ts
+++ b/src/core/parser-claude.test.ts
@@ -168,25 +168,25 @@ describe('parseClaudeSessions', () => {
     });
   });
 
-  it('classifies sdk-ts entrypoint as programmatic Claude (via GHCP) harness', () => {
+  it('classifies sdk-ts entrypoint as programmatic Claude harness', () => {
     withProjectsDir('s.jsonl', [
       makeUser('hi', '2025-06-15T10:00:00Z', { entrypoint: 'sdk-ts' }),
       makeAssistant('hello', '2025-06-15T10:00:01Z', { input_tokens: 10, output_tokens: 5 }),
     ], (projectsDir) => {
       const session = parseClaudeSessions(projectsDir)[0].sessions[0];
-      expect(session.harness).toBe('Claude (via GHCP)');
+      expect(session.harness).toBe('Claude');
       expect(session.launcherKind).toBe('programmatic');
       expect(session.entrypoint).toBe('sdk-ts');
     });
   });
 
-  it('defaults missing entrypoint to programmatic (Claude (via GHCP))', () => {
+  it('defaults missing entrypoint to programmatic Claude harness', () => {
     withProjectsDir('s.jsonl', [
       makeUser('hi'),  // no entrypoint field at all
       makeAssistant('hello', '2025-06-15T10:00:01Z', { input_tokens: 10, output_tokens: 5 }),
     ], (projectsDir) => {
       const session = parseClaudeSessions(projectsDir)[0].sessions[0];
-      expect(session.harness).toBe('Claude (via GHCP)');
+      expect(session.harness).toBe('Claude');
       expect(session.launcherKind).toBe('programmatic');
       expect(session.entrypoint).toBeUndefined();
     });
@@ -198,7 +198,7 @@ describe('parseClaudeSessions', () => {
       makeAssistant('hello', '2025-06-15T10:00:01Z', { input_tokens: 10, output_tokens: 5 }),
     ], (projectsDir) => {
       const session = parseClaudeSessions(projectsDir)[0].sessions[0];
-      expect(session.harness).toBe('Claude (via GHCP)');
+      expect(session.harness).toBe('Claude');
       expect(session.launcherKind).toBe('programmatic');
       expect(session.entrypoint).toBe('some-future-launcher');
     });
@@ -254,7 +254,7 @@ describe('parseClaudeSessions', () => {
     }
   });
 
-  it('emits orphan subagent (no parent session) as standalone Claude (via GHCP)', () => {
+  it('emits orphan subagent (no parent session) as standalone Claude', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-orphan-test-'));
     const projectsDir = path.join(root, 'projects');
     const projDir = path.join(projectsDir, '-Users-me-proj');
@@ -280,7 +280,7 @@ describe('parseClaudeSessions', () => {
       expect(sessions).toHaveLength(1);
       // Orphan session takes the parent dir name as its sessionId
       expect(sessions[0].sessionId).toBe('orphan-sess');
-      expect(sessions[0].harness).toBe('Claude (via GHCP)');
+      expect(sessions[0].harness).toBe('Claude');
       expect(sessions[0].launcherKind).toBe('programmatic');
       expect(sessions[0].requests).toHaveLength(1);
       expect(sessions[0].requests[0].messageText).toContain('orphan task');

--- a/src/core/parser-claude.ts
+++ b/src/core/parser-claude.ts
@@ -72,8 +72,8 @@ function classifyLauncher(entrypoint: string | undefined): 'interactive' | 'prog
   return entrypoint && INTERACTIVE_ENTRYPOINTS.has(entrypoint) ? 'interactive' : 'programmatic';
 }
 
-function harnessForLauncher(launcherKind: 'interactive' | 'programmatic'): string {
-  return launcherKind === 'interactive' ? 'Claude' : 'Claude (via GHCP)';
+function harnessForLauncher(_launcherKind: 'interactive' | 'programmatic'): string {
+  return 'Claude';
 }
 
 interface ClaudeAssistantData {
@@ -275,6 +275,18 @@ function collectClaudeAssistantData(lines: ClaudeLine[], startIndex: number, las
           continue;
         }
         applyClaudeToolBlock(block, data);
+        // Extract code content from write tools so extractCodeBlocks() can count LoC.
+        // Claude Write uses `content`, Edit uses `new_str`.
+        if (block.type === 'tool_use' && block.name && CLAUDE_WRITE_TOOLS.has(block.name) && block.input) {
+          const filePath = getInputPath(block.input, 'file_path');
+          const code = typeof block.input.content === 'string' ? block.input.content
+            : typeof block.input.new_str === 'string' ? block.input.new_str
+              : null;
+          if (code && filePath) {
+            const ext = filePath.split('.').pop() || 'unknown';
+            data.assistantTexts.push(`\`\`\`${ext}\n${code}\n\`\`\``);
+          }
+        }
       }
     }
     i++;

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -84,15 +84,11 @@ export function collectExternalHarnessesSync(workspaces: WorkspaceMap, sessions:
 }
 
 /** Harness values set on sessions by external harness collectors.
- *  A collector may emit more than one harness value (e.g. Claude Code emits
- *  `Claude` for interactive sessions and `Claude (via GHCP)` for sessions
- *  spawned programmatically by GitHub Copilot's agent mode). The cache
- *  reconciliation in parser.ts uses this set to identify and refresh cached
- *  external-harness sessions, so every value the collectors can produce must
- *  be listed here. */
+ *  The cache reconciliation in parser.ts uses this set to identify and
+ *  refresh cached external-harness sessions, so every value the collectors
+ *  can produce must be listed here. */
 export const EXTERNAL_HARNESS_SET = new Set<string>([
   'Claude',
-  'Claude (via GHCP)',
   'Codex',
   'OpenCode',
 ]);

--- a/src/core/parser-main.test.ts
+++ b/src/core/parser-main.test.ts
@@ -23,7 +23,7 @@ vi.mock('./parser-xcode', () => ({
 vi.mock('./parser-harnesses', () => ({
   collectExternalHarnessesSync: vi.fn(),
   collectExternalHarnessesAsync: vi.fn(() => Promise.resolve()),
-  EXTERNAL_HARNESS_SET: new Set(['Claude', 'Claude (via GHCP)', 'Codex', 'OpenCode']),
+  EXTERNAL_HARNESS_SET: new Set(['Claude', 'Codex', 'OpenCode']),
 }));
 
 vi.mock('./cache', () => ({
@@ -273,7 +273,7 @@ describe('parseAllLogsAsyncDetailed', () => {
     cachedResult.sessions.push(
       makeSession({ sessionId: 'kept', harness: 'VS Code' }),
       makeSession({ sessionId: 'claude', harness: 'Claude' }),
-      makeSession({ sessionId: 'claude-ghcp', harness: 'Claude (via GHCP)' }),
+      makeSession({ sessionId: 'claude-ghcp', harness: 'Claude' }),
       makeSession({ sessionId: 'codex', harness: 'Codex' }),
     );
 

--- a/src/core/parser-opencode.ts
+++ b/src/core/parser-opencode.ts
@@ -157,6 +157,17 @@ function applyOpenCodePart(part: OcPart, data: Pick<OpenCodeAssistantData, 'tool
   const toolLower = part.tool.toLowerCase();
   if (WRITE_TOOLS.has(toolLower)) {
     data.editedFiles.push(filePath);
+    // Include generated code content so extractCodeBlocks() can detect AI-produced code.
+    // Write tools store the code in various input fields; also check state.output.
+    const content = typeof input.content === 'string' ? input.content
+      : typeof input.code === 'string' ? input.code
+        : typeof input.new_string === 'string' ? input.new_string
+          : typeof part.state?.output === 'string' ? part.state.output
+            : null;
+    if (content) {
+      const ext = filePath.split('.').pop() || 'unknown';
+      textParts.push(`\n\`\`\`${ext}\n${content}\n\`\`\`\n`);
+    }
   } else if (READ_TOOLS.has(toolLower)) {
     data.referencedFiles.push(filePath);
   }

--- a/src/core/parser-vscode-cli.ts
+++ b/src/core/parser-vscode-cli.ts
@@ -210,7 +210,21 @@ function handleToolExecutionStart(ev: CLIEvent, state: CLIParseState): void {
 
   if (ts && turn.firstToolTs === null) turn.firstToolTs = ts;
   if (toolName && !META_TOOLS.has(toolName)) turn.toolNames.add(toolName);
-  if (FILE_EDIT_TOOLS.has(toolName) && typeof args.path === 'string') turn.editedFiles.add(args.path);
+  if (FILE_EDIT_TOOLS.has(toolName) && typeof args.path === 'string') {
+    turn.editedFiles.add(args.path);
+    // Include generated code content so extractCodeBlocks() can detect AI-produced code.
+    // CLI tools use snake_case field names: create → file_text, edit → new_str.
+    const code = typeof args.file_text === 'string' ? args.file_text
+      : typeof args.content === 'string' ? args.content
+        : typeof args.new_str === 'string' ? args.new_str
+          : typeof args.newString === 'string' ? args.newString
+            : typeof args.code === 'string' ? args.code
+              : null;
+    if (code) {
+      const ext = args.path.split('.').pop() || 'unknown';
+      turn.responseChunks.push(`\`\`\`${ext}\n${code}\n\`\`\``);
+    }
+  }
   if (FILE_REF_TOOLS.has(toolName) && typeof args.path === 'string') turn.referencedFiles.add(args.path);
   if (toolName === 'skill' && typeof args.skill === 'string') turn.skillsUsed.add(args.skill);
 }

--- a/src/core/types/analytics-types.ts
+++ b/src/core/types/analytics-types.ts
@@ -70,6 +70,8 @@ export interface CodeProductionData {
     userLoc: number[];
   };
   dailyByWorkspace: Record<string, number[]>;
+  dailyByModel: Record<string, number[]>;
+  dailyByHarness: Record<string, number[]>;
 }
 
 export interface ConsumptionData {
@@ -151,6 +153,7 @@ export interface WorkspaceBreakdown {
 export interface BurndownConfig {
   sku: string;
   customBudget?: number;
+  modelBudgets?: Record<string, number>;
   month?: string;
 }
 
@@ -166,9 +169,6 @@ export interface BurndownData {
   budgetLine: number[];
   status: 'on-track' | 'warning' | 'over-budget';
   recommendation: string;
-  /** True when the active harness filter selects a harness that is excluded
-   *  from premium-request counting (e.g. Claude, Codex, OpenCode). */
-  harnessExcluded?: boolean;
 }
 
 /* ---- AI Credit (usage-based billing) types ---- */
@@ -185,9 +185,7 @@ export interface AiCreditModelBreakdown {
   /** Requests where the harness/source structurally cannot record token data (Xcode, CLI abort-only, etc.).
    *  Permanent and excluded from `missingPct` denominator. */
   noDataRequests: number;
-  /** VS Code-side `claude-*` requests whose authoritative tokens live in the
-   *  matching `Claude (via GHCP)` session. Skipped to avoid double-count and
-   *  excluded from the `missingPct` denominator (it's not a parser gap). */
+  /** @deprecated No longer tracked (Claude harness unified). Always 0. */
   delegatedRequests: number;
   /** Uncached input tokens (subset of `inputTokens`) — used for input-rate billing math. */
   uncachedInputTokens: number;
@@ -223,10 +221,9 @@ export interface AiCreditData {
   pendingRequests: number;
   /** Permanently untracked requests (excluded from `missingPct`). */
   noDataRequests: number;
-  /** VS Code-side `claude-*` requests whose tokens live in `Claude (via GHCP)`.
-   *  Excluded from the `missingPct` denominator — not a coverage gap. */
+  /** @deprecated No longer tracked (Claude harness unified). Always 0. */
   delegatedRequests: number;
-  /** Finalizable requests = `totalRequests - pendingRequests - noDataRequests - delegatedRequests`. */
+  /** Finalizable requests = `totalRequests - pendingRequests - noDataRequests`. */
   finalizableRequests: number;
   /** % of *finalizable* requests with no token data (matches Token Coverage semantics). */
   missingPct: number;
@@ -238,6 +235,9 @@ export interface AiCreditData {
   /** Daily total-token (input + output) consumption broken down by workspace.
    *  `labels` matches `daily.labels`; each workspace key maps to an aligned array of token totals. */
   dailyTokensByWorkspace: { labels: string[]; byWorkspace: Record<string, number[]> };
+  /** Daily total-token (input + output) consumption broken down by harness.
+   *  `labels` matches `daily.labels`; each harness key maps to an aligned array of token totals. */
+  dailyTokensByHarness: { labels: string[]; byHarness: Record<string, number[]> };
   topRequests: Array<{
     timestamp: number;
     model: string;
@@ -245,7 +245,7 @@ export interface AiCreditData {
     outputTokens: number;
     credits: number;
     /** Per-request token-data classification (matches RequestBilling.status). */
-    status: 'complete' | 'partial' | 'pending' | 'delegated' | 'no-data' | 'missing';
+    status: 'complete' | 'partial' | 'pending' | 'no-data' | 'missing';
     /** "exact" = per-request native data; "session-aggregated" = derived from session-level totals (CLI). */
     aggregationKind: 'exact' | 'session-aggregated';
     preview: string;
@@ -403,7 +403,7 @@ export interface AiCreditBurndownData {
   status: 'on-track' | 'warning' | 'will-exceed' | 'no-data' | 'pending-only';
   daysUntilExhaustion: number | null;
   safeDailyBudget: number;
-  projectedOverageUsd: number;
+  projectedOverage: number;
   recommendation: string;
   /** % of *finalizable* requests (excluding pending + no-data) with no token data. */
   missingPct: number;
@@ -417,10 +417,9 @@ export interface AiCreditBurndownData {
   pendingRequests: number;
   /** Permanently untracked requests in the period. */
   noDataRequests: number;
-  /** VS Code-side `claude-*` requests whose tokens live in `Claude (via GHCP)`.
-   *  Excluded from the `missingPct` denominator. */
+  /** @deprecated No longer tracked (Claude harness unified). Always 0. */
   delegatedRequests: number;
-  /** Finalizable requests = total - pending - no-data - delegated. */
+  /** Finalizable requests = total - pending - no-data. */
   finalizableRequests: number;
   /** Per-day request counts in each coverage bucket (length = daysInMonth, index 0 = day 1).
    *  Drives the coverage strip in the Burndown view so users can see *where* in the month
@@ -430,10 +429,12 @@ export interface AiCreditBurndownData {
     partial: number[];
     pending: number[];
     noData: number[];
-    /** Per-day VS Code claude-* requests delegated to Claude (via GHCP). */
+    /** @deprecated No longer tracked. Always zeros. */
     delegated: number[];
     missing: number[];
   };
+  /** Per-model cumulative token consumption for the month. Each entry has daily cumulative values (length = daysInMonth). */
+  byModel: Record<string, { cumulative: number[]; budget: number }>;
 }
 
 export interface HarnessComparisonItem {

--- a/src/core/types/rpc-types.ts
+++ b/src/core/types/rpc-types.ts
@@ -129,6 +129,8 @@ export interface ExtensionMethodMap extends RpcMethodMap {
   getSdlcToolAnalysis: { params: { filter?: DateFilter } | Record<string, unknown>; result: { mcpServers: unknown[] } };
   getSdlcRepoScan: { params: Record<string, unknown> | undefined; result: { repos: unknown[] } };
   getSdlcGitHubData: { params: Record<string, unknown>; result: unknown };
+  saveModelBudgets: { params: { budgets: Record<string, number> }; result: { ok: boolean } };
+  loadModelBudgets: { params: Record<string, unknown> | undefined; result: Record<string, number> };
 }
 
 export type ExtensionMethodName = keyof ExtensionMethodMap;

--- a/src/core/types/session-types.ts
+++ b/src/core/types/session-types.ts
@@ -154,9 +154,8 @@ export interface Session {
    *    interactive  — user typed `claude` in a terminal or used Claude Desktop.
    *    programmatic — spawned by another tool via the SDK (e.g. GitHub Copilot
    *                   agent mode), MCP, GitHub Action, etc.
-   *  Drives the `Claude` vs `Claude (via GHCP)` harness split so token data
-   *  from GHCP-spawned Claude work can be attributed to GHCP without
-   *  cross-source matching. */
+   *  Stored for diagnostics; all Claude sessions use the `Claude` harness
+   *  regardless of launcher kind. */
   launcherKind?: 'interactive' | 'programmatic';
   /** Raw `entrypoint` value from Claude JSONL (`cli`, `sdk-ts`, `sdk-py`,
    *  `mcp`, `claude-code-github-action`, etc.). Stored for diagnostics so the

--- a/src/webview/app.ts
+++ b/src/webview/app.ts
@@ -5,7 +5,7 @@
 
 /* Webview entry -- runs in the browser context inside the VS Code webview */
 
-import { AntiPatternData, BurndownData, DateFilter, StatsResult } from '../core/types';
+import { AntiPatternData, DateFilter, StatsResult } from '../core/types';
 import { $, $$, rpc, destroyCharts, initMessageListener, withErrorBoundary } from './shared';
 import { html, render, unmount, ComponentChildren } from './render';
 import { renderDashboard } from './page-dashboard';
@@ -52,10 +52,6 @@ function refreshNavBadges(filter: DateFilter): void {
 
   void rpc<AntiPatternData>('getAntiPatterns', filter as Record<string, unknown>).then(d => {
     setBadge('badge-antipatterns', d.patterns.length);
-  }).catch(() => {});
-
-  void rpc<BurndownData>('getBurndown', { config: { sku: 'pro' }, filter: filter as Record<string, unknown> }).then(d => {
-    setBadge('badge-burndown', `${d.consumed}/${d.budget}`);
   }).catch(() => {});
 
   void rpc<{ summary: { totalAiLoc: number } }>('getCodeProduction', filter as Record<string, unknown>).then(d => {

--- a/src/webview/page-burndown.ts
+++ b/src/webview/page-burndown.ts
@@ -3,13 +3,14 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/* Burndown page renderer */
+/* Burndown page renderer — token consumption only */
 
 import { DateFilter } from '../core/types';
-import { rpc, createChart, destroyChartById, COLORS } from './shared';
-import { html, render, CanvasEl } from './render';
 
-interface BdData {
+import { rpc, createChart, destroyChartById, COLORS, formatNum, vscode } from './shared';
+import { html, render, CanvasEl, StatCard } from './render';
+
+interface AiCreditBdData {
   dayOfMonth: number;
   daysInMonth: number;
   dailyConsumption: { labels: string[]; cumulative: number[] };
@@ -20,12 +21,9 @@ interface BdData {
   budget: number;
   projected: number;
   recommendation: string;
-}
-
-interface AiCreditBdData extends BdData {
   daysUntilExhaustion: number | null;
   safeDailyBudget: number;
-  projectedOverageUsd: number;
+  projectedOverage: number;
   missingPct: number;
   totalRequests: number;
   countedRequests: number;
@@ -40,20 +38,21 @@ interface AiCreditBdData extends BdData {
     noData: number[];
     missing: number[];
   };
+  byModel: Record<string, { cumulative: number[]; budget: number }>;
 }
 
 function renderBurndownChartLater(renderBurndownChart: () => Promise<void>): void {
   void renderBurndownChart();
 }
 
-function CreditExtraInfo({ bd }: { bd: AiCreditBdData }) {
+function ExtraInfo({ bd }: { bd: AiCreditBdData }) {
   const trulyMissing = bd.finalizableRequests - bd.countedRequests - bd.partialRequests;
   return html`
     <p>
       ${bd.daysUntilExhaustion != null && html`<strong>Days to exhaustion:</strong> ${bd.daysUntilExhaustion} | `}
-      <strong>Safe daily budget:</strong> ${Math.round(bd.safeDailyBudget)} credits/day |${' '}
-      ${bd.projectedOverageUsd > 0 && html`<strong>Projected overage:</strong> $${bd.projectedOverageUsd.toFixed(2)} | `}
-      ${bd.finalizableRequests > 0 && bd.missingPct > 0 && html` <span class="missing-badge" title=${trulyMissing + ' of ' + bd.finalizableRequests + ' finalizable requests have no token data and were not counted toward credit usage.'}>missing ${bd.missingPct}%</span>`}
+      <strong>Safe daily budget:</strong> ${formatNum(Math.round(bd.safeDailyBudget))} tokens/day |${' '}
+      ${bd.projectedOverage > 0 && html`<strong>Projected overage:</strong> ${formatNum(Math.round(bd.projectedOverage))} tokens | `}
+      ${bd.finalizableRequests > 0 && bd.missingPct > 0 && html` <span class="missing-badge" title=${trulyMissing + ' of ' + bd.finalizableRequests + ' finalizable requests have no token data and were not counted.'}>missing ${bd.missingPct}%</span>`}
       ${bd.partialRequests > 0 && html` <span class="pending-badge" title=${bd.partialRequests + ' output-only requests in this period (excluded from missing %)'}>+${bd.partialRequests} partial</span>`}
       ${bd.pendingRequests > 0 && html` <span class="pending-badge" title=${bd.pendingRequests + ' requests in active/aborted sessions (excluded from missing %)'}>+${bd.pendingRequests} pending</span>`}
       ${bd.noDataRequests > 0 && html` <span class="pending-badge" title=${bd.noDataRequests + ' requests where the harness/source did not record token data (excluded from missing %)'}>+${bd.noDataRequests} no-data</span>`}
@@ -65,9 +64,63 @@ function CreditExtraInfo({ bd }: { bd: AiCreditBdData }) {
 const _now = new Date();
 let selectedYear = _now.getFullYear();
 let selectedMonth = _now.getMonth() + 1;
+let activeBurndownTab: 'chart' | 'budget' = 'chart';
+
+/** Per-model monthly token budgets — persisted to disk via extension globalState. */
+const modelBudgets: Record<string, number> = loadModelBudgetsFromWebviewState();
+
+/** Whether disk budgets have been loaded into modelBudgets yet. */
+let diskBudgetsLoaded = false;
+
+/** Selected model filter for burndown chart: 'all' or a model name. */
+let selectedBurndownModel = 'all';
+
+/** Fast local restore from webview state (survives tab switches). */
+function loadModelBudgetsFromWebviewState(): Record<string, number> {
+  const s = vscode.getState() as Record<string, unknown> | null;
+  return (s?.modelBudgets as Record<string, number>) ?? {};
+}
+
+/** Save to both webview state (fast) and disk (persistent). */
+function saveModelBudgets(): void {
+  const toSave: Record<string, number> = {};
+  for (const [k, v] of Object.entries(modelBudgets)) {
+    if (v > 0) toSave[k] = v;
+  }
+  // Webview state (fast, survives tab switch)
+  const s = (vscode.getState() as Record<string, unknown>) ?? {};
+  vscode.setState({ ...s, modelBudgets: toSave });
+  // Disk persistence (survives reload/restart)
+  rpc('saveModelBudgets', { budgets: toSave }).catch(() => { /* best effort */ });
+}
+
+/** Load budgets from disk (extension globalState) on first use. */
+async function loadModelBudgetsFromDisk(): Promise<void> {
+  if (diskBudgetsLoaded) return;
+  diskBudgetsLoaded = true;
+  try {
+    const saved = await rpc<Record<string, number>>('loadModelBudgets', {});
+    if (saved && typeof saved === 'object') {
+      // Merge: disk values win over in-memory zeros, but don't overwrite user edits from this session
+      for (const [k, v] of Object.entries(saved)) {
+        if (v > 0 && !(k in modelBudgets && modelBudgets[k] > 0)) {
+          modelBudgets[k] = v;
+        }
+      }
+      // Also update webview state with merged result
+      const s = (vscode.getState() as Record<string, unknown>) ?? {};
+      const toSave: Record<string, number> = {};
+      for (const [k2, v2] of Object.entries(modelBudgets)) {
+        if (v2 > 0) toSave[k2] = v2;
+      }
+      vscode.setState({ ...s, modelBudgets: toSave });
+    }
+  } catch { /* first load, no data yet */ }
+}
 
 export function renderBurndown(container: HTMLElement, currentFilter: DateFilter): void {
-  const skus = ['pro', 'pro-plus', 'business', 'enterprise'];
+  // Load disk-persisted budgets on first render
+  loadModelBudgetsFromDisk();
 
   const now = new Date();
 
@@ -88,88 +141,463 @@ export function renderBurndown(container: HTMLElement, currentFilter: DateFilter
     renderBurndownChartLater(renderBurndownChart);
   }
 
+  async function fetchHistoricalBudgets(): Promise<Record<string, number>> {
+    const now = new Date();
+    const months: string[] = [];
+    // Include current month + last 3 months
+    months.push(`${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`);
+    for (let i = 1; i <= 3; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      months.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
+    }
+    const peakByModel: Record<string, number> = {};
+    for (const m of months) {
+      const [yr, mo] = m.split('-').map(Number);
+      const daysInMonth = new Date(yr, mo, 0).getDate();
+      const fromDate = `${m}-01`;
+      const toDate = `${m}-${String(daysInMonth).padStart(2, '0')}`;
+      try {
+        const data = await rpc<{ costByModel: Record<string, { inputTokens: number; outputTokens: number }> }>('getAiCredits', { fromDate, toDate });
+        for (const [model, entry] of Object.entries(data.costByModel)) {
+          const tokens = Math.ceil(entry.inputTokens + entry.outputTokens);
+          if (tokens > (peakByModel[model] || 0)) peakByModel[model] = tokens;
+        }
+      } catch { /* month may have no data */ }
+    }
+    return peakByModel;
+  }
+
+  /** Discovered models from history — cached across budget tab re-renders. */
+  let discoveredModels: Record<string, number> = {};
+  let modelsLoaded = false;
+
+  function renderBudgetTab(): void {
+    const target = document.getElementById('burndown-tab-content')!;
+
+    // Auto-discover models on first render
+    if (!modelsLoaded) {
+      render(html`<div class="budget-loading">Loading models\u2026</div>`, target);
+      fetchHistoricalBudgets().then(peak => {
+        discoveredModels = peak;
+        modelsLoaded = true;
+        // Seed modelBudgets with discovered models (keep existing budgets)
+        for (const model of Object.keys(peak)) {
+          if (!(model in modelBudgets)) modelBudgets[model] = 0;
+        }
+        renderBudgetTab();
+      });
+      return;
+    }
+
+    // Merge: all discovered models + any with budgets already set
+    const allModels = new Set([...Object.keys(discoveredModels), ...Object.keys(modelBudgets)]);
+    // Sort by peak usage desc, then alphabetically
+    const sortedModels = Array.from(allModels).sort((a, b) => {
+      const ua = discoveredModels[a] || 0, ub = discoveredModels[b] || 0;
+      return ub - ua || a.localeCompare(b);
+    });
+
+    const totalBudget = Object.values(modelBudgets).reduce((a, b) => a + b, 0);
+    const configuredCount = Object.values(modelBudgets).filter(v => v > 0).length;
+
+    render(html`
+      <div class="budget-header">
+        <div class="stat-grid" style="margin-bottom:0;">
+          <${StatCard} label="Total Monthly Budget" value=${formatNum(totalBudget) + ' tokens'} accent="var(--accent-blue)" />
+          <${StatCard} label="Models with Budget" value=${configuredCount + ' / ' + sortedModels.length} accent="var(--accent-green)" />
+        </div>
+      </div>
+
+      <div class="budget-actions">
+        <button class="dash-scan-btn budget-autofill-btn" id="btnAutoFill" onClick=${() => {
+          for (const [model, val] of Object.entries(discoveredModels)) {
+            modelBudgets[model] = Math.ceil(val * 1.2);
+          }
+          saveModelBudgets();
+          renderBudgetTab();
+        }}>Auto-fill (+20% of peak)</button>
+        <button class="dash-scan-btn budget-clear-btn" onClick=${() => {
+          for (const k of Object.keys(modelBudgets)) modelBudgets[k] = 0;
+          saveModelBudgets();
+          renderBudgetTab();
+        }}>Clear all</button>
+        <button class="dash-scan-btn" onClick=${() => {
+          activeBurndownTab = 'chart';
+          renderTabs();
+          renderBurndownChartLater(renderBurndownChart);
+        }}>Apply to Burndown \u2192</button>
+      </div>
+
+      <p class="budget-hint">
+        Models are auto-discovered from your usage history.
+        <strong>Peak usage</strong> shows the highest monthly consumption across the last 4 months.
+        Use <strong>Auto-fill</strong> to set budgets at peak + 20% buffer.
+      </p>
+
+      <table class="data-table budget-table" id="budgetTable">
+        <thead><tr>
+          <th>Model</th>
+          <th class="budget-usage-col">Peak Usage</th>
+          <th class="budget-col">Monthly Budget (tokens)</th>
+        </tr></thead>
+        <tbody>
+          ${sortedModels.map(model => {
+            const val = modelBudgets[model] || 0;
+            const peak = discoveredModels[model] || 0;
+            const pct = val > 0 && peak > 0 ? Math.min(100, Math.round(peak / val * 100)) : 0;
+            const barColor = pct >= 90 ? 'var(--accent-red)' : pct >= 70 ? 'var(--accent-orange)' : 'var(--accent-green)';
+            return html`<tr class=${val > 0 ? 'budget-row-active' : ''}>
+              <td class="budget-model-name">${model}</td>
+              <td class="budget-usage-col">
+                <div class="budget-usage-cell">
+                  <span class="budget-usage-value">${formatNum(peak)}</span>
+                  ${val > 0 && html`<div class="budget-usage-bar"><div class="budget-usage-bar-fill" style=${`width:${pct}%;background:${barColor}`}></div></div>`}
+                </div>
+              </td>
+              <td class="budget-col">
+                <input type="number" class="budget-input" data-model=${model}
+                  value=${val || ''}
+                  placeholder="\u2014" min="0"
+                  onInput=${(e: InputEvent) => {
+                    const v = Number((e.target as HTMLInputElement).value);
+                    if (v > 0) modelBudgets[model] = v;
+                    else { modelBudgets[model] = 0; }
+                    saveModelBudgets();
+                    const newTotal = Object.values(modelBudgets).reduce((a, b) => a + b, 0);
+                    const newCount = Object.values(modelBudgets).filter(x => x > 0).length;
+                    const totalEl = target.querySelector('.stat-grid .stat-card:first-child .stat-value');
+                    const countEl = target.querySelector('.stat-grid .stat-card:last-child .stat-value');
+                    if (totalEl) totalEl.textContent = formatNum(newTotal) + ' tokens';
+                    if (countEl) countEl.textContent = newCount + ' / ' + sortedModels.length;
+                    const row = (e.target as HTMLElement).closest('tr');
+                    if (row) row.classList.toggle('budget-row-active', v > 0);
+                  }} />
+              </td>
+            </tr>`;
+          })}
+        </tbody>
+      </table>
+    `, target);
+  }
+
+  function renderTabs(): void {
+    // Update tab active state
+    for (const btn of container.querySelectorAll<HTMLButtonElement>('#burndown-tabs .tab')) {
+      btn.classList.toggle('active', btn.dataset.tab === activeBurndownTab);
+    }
+    if (activeBurndownTab === 'budget') {
+      renderBudgetTab();
+    } else {
+      const target = document.getElementById('burndown-tab-content')!;
+      render(html`
+        <div class="approximation-notice">
+          <strong>Approximation only.</strong>
+          This shows token consumption across all harnesses and may not be fully
+          accurate. It cannot reflect activity on other devices, cloud-hosted
+          agents, or harnesses this extension doesn't ingest.
+          Use it as a workflow optimization signal, not as a billing reference.
+        </div>
+        <div class="burndown-controls">
+          <div class="month-nav">
+            <button id="prevMonth" title="Previous month" onClick=${() => navigateMonth(-1)}>\u2190</button>
+            <span id="monthLabel">${formatMonthLabel(selectedYear, selectedMonth)}</span>
+            <button id="nextMonth" title="Next month" disabled onClick=${() => navigateMonth(1)}>\u2192</button>
+          </div>
+          <select id="modelFilter" class="burndown-model-select" onChange=${() => {
+            selectedBurndownModel = (document.getElementById('modelFilter') as HTMLSelectElement).value;
+            renderBurndownChartLater(renderBurndownChart);
+          }}>
+            <option value="all" selected=${selectedBurndownModel === 'all'}>All Models</option>
+          </select>
+        </div>
+        <${CanvasEl} id="burndownChart" height=${350} />
+        <div id="burndownStatus"></div>
+      `, target);
+      renderBurndownChartLater(renderBurndownChart);
+    }
+  }
+
   render(html`
     <h1>Burndown</h1>
-    <div class="approximation-notice">
-      <strong>Approximation only.</strong>
-      Burndown projections are estimated from the session data this extension
-      can read on your machine. They cannot reflect activity on other devices,
-      cloud-hosted agents, or harnesses this extension doesn't ingest, so they
-      will never be fully accurate.
-      Use them as a workflow optimization signal, not as a billing reference.
-      For authoritative consumption numbers, see your
-      <a href="https://github.com/settings/copilot/features" target="_blank" rel="noopener">GitHub Copilot usage settings</a>.
+    <div class="tab-bar" id="burndown-tabs">
+      <button class=${`tab${activeBurndownTab === 'chart' ? ' active' : ''}`} data-tab="chart">Burndown Chart</button>
+      <button class=${`tab${activeBurndownTab === 'budget' ? ' active' : ''}`} data-tab="budget">Token Budget</button>
     </div>
-    <div class="burndown-controls">
-      <div class="month-nav">
-        <button id="prevMonth" title="Previous month" onClick=${() => navigateMonth(-1)}>\u2190</button>
-        <span id="monthLabel">${formatMonthLabel(selectedYear, selectedMonth)}</span>
-        <button id="nextMonth" title="Next month" disabled onClick=${() => navigateMonth(1)}>\u2192</button>
-      </div>
-      <label>Plan: <select id="skuSelect" onChange=${() => renderBurndownChartLater(renderBurndownChart)}>
-        ${skus.map(s => html`<option value=${s}>${s}</option>`)}
-      </select></label>
-      <label>Custom Budget: <input id="customBudget" type="number" placeholder="optional" style="width:80px"
-        onChange=${() => renderBurndownChartLater(renderBurndownChart)} /></label>
-      <label>Mode: <select id="burndownMode" onChange=${() => renderBurndownChartLater(renderBurndownChart)}>
-        <option value="premium">Premium Requests</option>
-        <option value="credits">AI Credits</option>
-      </select></label>
-    </div>
-    <${CanvasEl} id="burndownChart" height=${350} />
-    <div id="burndownStatus"></div>
+    <div id="burndown-tab-content"></div>
   `, container);
 
-  async function renderBurndownChart() {
-    const sku = (document.getElementById('skuSelect') as HTMLSelectElement).value;
-    const customVal = (document.getElementById('customBudget') as HTMLInputElement).value;
-    const mode = (document.getElementById('burndownMode') as HTMLSelectElement).value;
-    const month = `${selectedYear}-${String(selectedMonth).padStart(2, '0')}`;
-    const config: Record<string, unknown> = { sku, month };
-    if (customVal) config.customBudget = Number(customVal);
+  // Wire tab switching
+  container.querySelector('#burndown-tabs')!.addEventListener('click', (e) => {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('.tab');
+    if (!btn || !btn.dataset.tab) return;
+    activeBurndownTab = btn.dataset.tab as 'chart' | 'budget';
+    renderTabs();
+  });
 
-    const rpcMethod = mode === 'credits' ? 'getAiCreditBurndown' : 'getBurndown';
-    const bd = await rpc<AiCreditBdData>(rpcMethod, { config, filter: { ...currentFilter, workspaceId: undefined } });
+  renderTabs();
+
+  async function renderBurndownChart() {
+    const month = `${selectedYear}-${String(selectedMonth).padStart(2, '0')}`;
+    // Only send non-zero budgets to the backend
+    const activeBudgets: Record<string, number> = {};
+    for (const [k, v] of Object.entries(modelBudgets)) {
+      if (v > 0) activeBudgets[k] = v;
+    }
+    const hasBudgets = Object.keys(activeBudgets).length > 0;
+    const config: Record<string, unknown> = { sku: 'pro', month };
+    if (hasBudgets) config.modelBudgets = activeBudgets;
+
+    const bd = await rpc<AiCreditBdData>('getAiCreditBurndown', { config, filter: { ...currentFilter, workspaceId: undefined } });
     destroyChartById('burndownChart');
 
-    const unit = mode === 'credits' ? 'credits' : 'reqs';
+    const CHART_PALETTE = [COLORS.blue, COLORS.green, COLORS.purple, COLORS.yellow, '#f97316', '#06b6d4', '#ec4899', '#8b5cf6', '#14b8a6', '#f43f5e'];
 
-    const actualLine = bd.dailyConsumption.cumulative.map((value, index) =>
-      index < bd.dayOfMonth ? value : null,
-    );
+    // Populate model filter dropdown with actual models
+    const filterSelect = document.getElementById('modelFilter') as HTMLSelectElement | null;
+    if (filterSelect) {
+      const prevVal = selectedBurndownModel;
+      filterSelect.innerHTML = '';
+      const allOpt = document.createElement('option');
+      allOpt.value = 'all'; allOpt.textContent = 'All Models';
+      filterSelect.appendChild(allOpt);
+      const sortedModels = Object.entries(bd.byModel)
+        .sort((a, b) => (b[1].cumulative[bd.dayOfMonth - 1] || 0) - (a[1].cumulative[bd.dayOfMonth - 1] || 0));
+      for (const [model] of sortedModels) {
+        const opt = document.createElement('option');
+        opt.value = model; opt.textContent = model;
+        filterSelect.appendChild(opt);
+      }
+      // Restore previous selection if still valid
+      if (prevVal !== 'all' && bd.byModel[prevVal]) filterSelect.value = prevVal;
+      else { filterSelect.value = 'all'; selectedBurndownModel = 'all'; }
+    }
+
+    const isSingleModel = selectedBurndownModel !== 'all' && bd.byModel[selectedBurndownModel];
+    const datasets: Record<string, unknown>[] = [];
+
+    if (isSingleModel) {
+      // ---- Single model view ----
+      const entry = bd.byModel[selectedBurndownModel];
+      const data = entry.cumulative.map((value, idx) => idx < bd.dayOfMonth ? value : null);
+      datasets.push({
+        label: selectedBurndownModel,
+        data,
+        borderColor: CHART_PALETTE[0],
+        backgroundColor: CHART_PALETTE[0] + '30',
+        fill: true,
+        borderWidth: 2,
+        pointRadius: 1,
+        spanGaps: false,
+      });
+      // Model-specific projection
+      const modelConsumed = entry.cumulative[bd.dayOfMonth - 1] || 0;
+      const modelDailyRate = bd.dayOfMonth > 0 ? modelConsumed / bd.dayOfMonth : 0;
+      const modelProjectedLine = bd.dailyConsumption.labels.map((_, i) => Math.round(modelDailyRate * (i + 1)));
+      datasets.push({
+        label: 'Projected',
+        data: modelProjectedLine,
+        borderColor: COLORS.yellow,
+        borderDash: [5, 5],
+        borderWidth: 2,
+        pointRadius: 0,
+        fill: false,
+      });
+      // Model budget line
+      if (entry.budget > 0) {
+        datasets.push({
+          label: 'Budget',
+          data: bd.dailyConsumption.labels.map(() => entry.budget),
+          borderColor: COLORS.red,
+          borderDash: [10, 5],
+          borderWidth: 2,
+          pointRadius: 0,
+          fill: false,
+        });
+      }
+    } else {
+      // ---- All models view (stacked) ----
+      const modelEntries = Object.entries(bd.byModel)
+        .sort((a, b) => (b[1].cumulative[bd.dayOfMonth - 1] || 0) - (a[1].cumulative[bd.dayOfMonth - 1] || 0));
+      const topModels = modelEntries.slice(0, 10);
+      const otherModels = modelEntries.slice(10);
+
+      for (const [model, entry] of topModels) {
+        const i = topModels.findIndex(([m]) => m === model);
+        const data = entry.cumulative.map((value, idx) => idx < bd.dayOfMonth ? value : null);
+        datasets.push({
+          label: model,
+          data,
+          borderColor: CHART_PALETTE[i % CHART_PALETTE.length],
+          backgroundColor: CHART_PALETTE[i % CHART_PALETTE.length] + '30',
+          fill: true,
+          borderWidth: 2,
+          pointRadius: 0,
+          spanGaps: false,
+          stack: 'models',
+        });
+      }
+      if (otherModels.length > 0) {
+        const otherCumulative = bd.dailyConsumption.labels.map((_, i) =>
+          otherModels.reduce((sum, [, entry]) => sum + (entry.cumulative[i] || 0), 0)
+        );
+        const data = otherCumulative.map((value, idx) => idx < bd.dayOfMonth ? value : null);
+        datasets.push({
+          label: `Other (${otherModels.length})`,
+          data,
+          borderColor: COLORS.muted,
+          backgroundColor: COLORS.muted + '30',
+          fill: true,
+          borderWidth: 1,
+          pointRadius: 0,
+          spanGaps: false,
+          stack: 'models',
+        });
+      }
+
+      // Total projected
+      datasets.push({
+        label: 'Projected',
+        data: bd.projectedLine,
+        borderColor: COLORS.yellow,
+        borderDash: [5, 5],
+        borderWidth: 2,
+        pointRadius: 0,
+        fill: false,
+      });
+
+      // Total budget line
+      if (bd.budget > 0) {
+        datasets.push({
+          label: 'Budget',
+          data: bd.budgetLine,
+          borderColor: COLORS.red,
+          borderDash: [10, 5],
+          borderWidth: 2,
+          pointRadius: 0,
+          fill: false,
+        });
+      }
+
+      // Per-model budget annotations
+      for (const [model, entry] of topModels) {
+        if (entry.budget > 0) {
+          const color = CHART_PALETTE[topModels.findIndex(([m]) => m === model) % CHART_PALETTE.length];
+          datasets.push({
+            label: `${model} budget`,
+            data: bd.dailyConsumption.labels.map(() => entry.budget),
+            borderColor: color,
+            borderDash: [4, 4],
+            borderWidth: 1,
+            pointRadius: 0,
+            fill: false,
+          });
+        }
+      }
+    }
 
     createChart('burndownChart', 'line', {
       labels: bd.dailyConsumption.labels,
-      datasets: [
-        { label: `Cumulative (${unit})`, data: actualLine, borderColor: COLORS.blue, backgroundColor: COLORS.blue + '20', fill: true, borderWidth: 2, pointRadius: 1, spanGaps: false },
-        { label: 'Projected', data: bd.projectedLine, borderColor: COLORS.yellow, borderDash: [5, 5], borderWidth: 2, pointRadius: 0, fill: false },
-        { label: 'Budget', data: bd.budgetLine, borderColor: COLORS.red, borderDash: [10, 5], borderWidth: 2, pointRadius: 0, fill: false },
-      ],
+      datasets,
     }, {
-      plugins: { legend: { position: 'top' } },
-      scales: { y: { beginAtZero: true } },
+      plugins: {
+        legend: { position: 'top', labels: { filter: (item: { text: string }) => !item.text.endsWith(' budget') } },
+        tooltip: { callbacks: { label: (ctx: { dataset: { label: string }; raw: number | null }) => ctx.raw != null ? `${ctx.dataset.label}: ${formatNum(ctx.raw)} tokens` : '' } },
+      },
+      scales: {
+        x: { ticks: { maxTicksLimit: 31 } },
+        y: { beginAtZero: true, stacked: !isSingleModel, ticks: { callback: (v: number) => formatNum(v) } },
+      },
     });
 
-    const statusClass = bd.status === 'on-track' ? 'status-good'
-      : bd.status === 'warning' ? 'status-warn'
-      : bd.status === 'no-data' || bd.status === 'pending-only' ? 'status-nodata'
-      : 'status-bad';
-
-    const isPartial = mode === 'credits' && bd.missingPct > 0 && bd.status !== 'no-data' && bd.status !== 'pending-only';
-
+    // ---- Status section ----
     const statusEl = document.getElementById('burndownStatus')!;
-    render(html`
-      <div class=${'burndown-info ' + statusClass}>
-        ${(bd.status === 'no-data' || bd.status === 'pending-only')
-          ? html`<p><strong>Status:</strong> ${bd.status} \u2014 ${bd.status === 'pending-only' ? 'all requests in this period are still pending.' : 'no native token data available for this period.'}</p>`
-          : html`<p>
-              <strong>Status:</strong> ${bd.status} | <strong>Consumed:</strong> ${Math.round(bd.consumed)} / ${bd.budget} ${unit}${isPartial && html` <span class="missing-badge" title=${bd.missingPct + '% of finalizable requests in this period are missing native token data \u2014 these values are a lower bound.'}>lower bound</span>`} | <strong>Projected:</strong> ${Math.round(bd.projected)}${isPartial && html` <span class="missing-badge" title=${bd.missingPct + '% of finalizable requests in this period are missing native token data \u2014 these values are a lower bound.'}>lower bound</span>`}
-            </p>`
-        }
-        ${mode === 'credits' && html`<${CreditExtraInfo} bd=${bd} />`}
-        <p>${bd.recommendation}</p>
-      </div>
-    `, statusEl);
+
+    if (bd.status === 'no-data' || bd.status === 'pending-only') {
+      render(html`
+        <div class="burndown-info status-nodata">
+          <p><strong>Status:</strong> ${bd.status} \u2014 ${bd.status === 'pending-only' ? 'all requests in this period are still pending.' : 'no native token data available for this period.'}</p>
+          <${ExtraInfo} bd=${bd} />
+          <p>${bd.recommendation}</p>
+        </div>
+      `, statusEl);
+      return;
+    }
+
+    const isPartial = bd.missingPct > 0;
+
+    if (isSingleModel) {
+      // Single model status
+      const entry = bd.byModel[selectedBurndownModel];
+      const used = entry.cumulative[bd.dayOfMonth - 1] || 0;
+      const modelDailyRate = bd.dayOfMonth > 0 ? used / bd.dayOfMonth : 0;
+      const modelProjected = Math.round(modelDailyRate * bd.daysInMonth);
+      const modelBudget = entry.budget;
+      const remaining = modelBudget > 0 ? modelBudget - used : 0;
+      const modelSafeDailyBudget = modelBudget > 0 && bd.daysInMonth > bd.dayOfMonth
+        ? Math.round(remaining / (bd.daysInMonth - bd.dayOfMonth)) : 0;
+      const modelDaysToExhaustion = modelBudget > 0 && modelDailyRate > 0
+        ? Math.round(remaining / modelDailyRate) : null;
+      const modelOverage = modelBudget > 0 ? Math.max(0, modelProjected - modelBudget) : 0;
+      const pct = modelBudget > 0 ? Math.round(used / modelBudget * 100) : 0;
+      const modelStatus = modelBudget === 0 ? 'no-budget'
+        : pct >= 100 ? 'will-exceed'
+        : modelProjected > modelBudget ? 'warning' : 'on-track';
+      const statusClass = modelStatus === 'on-track' ? 'status-good'
+        : modelStatus === 'warning' ? 'status-warn'
+        : modelStatus === 'no-budget' ? 'status-nodata'
+        : 'status-bad';
+
+      render(html`
+        <div class=${'burndown-info ' + statusClass}>
+          <p>
+            <strong>${selectedBurndownModel}</strong> |
+            <strong>Status:</strong> ${modelStatus} |
+            <strong>Consumed:</strong> ${formatNum(Math.round(used))} tokens${modelBudget > 0 ? ` / ${formatNum(modelBudget)}` : ''}${modelBudget > 0 ? ` (${pct}%)` : ''}${isPartial && html` <span class="missing-badge">lower bound</span>`} |
+            <strong>Projected:</strong> ${formatNum(modelProjected)} tokens
+          </p>
+          ${modelBudget > 0 && html`<p>
+            ${modelDaysToExhaustion != null && html`<strong>Days to exhaustion:</strong> ${modelDaysToExhaustion} | `}
+            <strong>Safe daily budget:</strong> ${formatNum(modelSafeDailyBudget)} tokens/day
+            ${modelOverage > 0 && html` | <strong>Projected overage:</strong> ${formatNum(modelOverage)} tokens`}
+          </p>`}
+        </div>
+      `, statusEl);
+    } else {
+      // All models status with per-model breakdown
+      const statusClass = bd.status === 'on-track' ? 'status-good'
+        : bd.status === 'warning' ? 'status-warn'
+        : 'status-bad';
+
+      // Build per-model status rows for models with budgets
+      const budgetedModels = Object.entries(bd.byModel)
+        .filter(([, e]) => e.budget > 0)
+        .sort((a, b) => (b[1].cumulative[bd.dayOfMonth - 1] || 0) - (a[1].cumulative[bd.dayOfMonth - 1] || 0));
+
+      const modelRows = budgetedModels.map(([model, entry]) => {
+        const used = entry.cumulative[bd.dayOfMonth - 1] || 0;
+        const modelDailyRate = bd.dayOfMonth > 0 ? used / bd.dayOfMonth : 0;
+        const modelProjected = Math.round(modelDailyRate * bd.daysInMonth);
+        const remaining = entry.budget - used;
+        const safeDailyBudget = bd.daysInMonth > bd.dayOfMonth
+          ? Math.round(remaining / (bd.daysInMonth - bd.dayOfMonth)) : 0;
+        const pct = Math.round(used / entry.budget * 100);
+        const cls = pct >= 100 ? 'status-bad' : modelProjected > entry.budget ? 'status-warn' : 'status-good';
+        return html`<span class=${'model-budget-pill ' + cls} title=${`${model}: ${formatNum(used)} / ${formatNum(entry.budget)} (${pct}%) | safe: ${formatNum(safeDailyBudget)}/day`}>${model}: ${pct}%</span> `;
+      });
+
+      render(html`
+        <div class=${'burndown-info ' + statusClass}>
+          <p>
+            <strong>Status:</strong> ${bd.status} |
+            <strong>Consumed:</strong> ${formatNum(Math.round(bd.consumed))} tokens${bd.budget > 0 ? ` / ${formatNum(bd.budget)}` : ''}${isPartial && html` <span class="missing-badge">lower bound</span>`} |
+            <strong>Projected:</strong> ${formatNum(Math.round(bd.projected))} tokens
+          </p>
+          ${modelRows.length > 0 && html`<div class="model-budget-status">${modelRows}</div>`}
+          <${ExtraInfo} bd=${bd} />
+          <p>${bd.recommendation}</p>
+        </div>
+      `, statusEl);
+    }
   }
 
   renderBurndownChartLater(renderBurndownChart);

--- a/src/webview/page-dashboard.ts
+++ b/src/webview/page-dashboard.ts
@@ -5,7 +5,7 @@
 
 /* Dashboard page renderer */
 
-import { DateFilter, DailyActivity, PRACTICE_GROUPS, AntiPatternData, WorkflowOptimizationData, SkillTriageResult, CatalogDiscoverResult, CatalogTriageResult, GroupScore, CodeProductionData, BurndownData } from '../core/types';
+import { DateFilter, DailyActivity, PRACTICE_GROUPS, AntiPatternData, WorkflowOptimizationData, SkillTriageResult, CatalogDiscoverResult, CatalogTriageResult, GroupScore, CodeProductionData } from '../core/types';
 import { rpc, rpcAllSettled, createChart, formatNum, COLORS, PALETTE, harnessColor, destroyChartById, scoreColor, scoreLabel } from './shared';
 import { html, render, CanvasEl, ScoreRing, PctBadge } from './render';
 import { setSkillCache, getSkillCache } from './skill-cache';
@@ -93,24 +93,12 @@ function renderDashboardMarkup(
   totalReqs: number,
   totalSessions: number,
   totalLoc: number,
-  burndown: BurndownData,
-  burndownStatus: BurndownData['status'] | null,
-  burndownLabel: string,
-  burndownColor: string,
   skillCache: ReturnType<typeof getSkillCache>,
 ): void {
   const harnesses = harnessBreakdown.labels || [];
   const overallScore = scores.length > 0 ? Math.round(scores.reduce((s, g) => s + g.score, 0) / scores.length) : 0;
   const overallColor = scoreColor(overallScore);
   render(html`
-    <div class="token-billing-banner">
-      <div class="token-billing-banner-icon">\u2139</div>
-      <div class="token-billing-banner-text">
-        <strong>Usage-based billing is coming.</strong>
-        GitHub Copilot is transitioning from premium request counting to usage-based billing.
-        We are updating AI Engineer Coach to reflect these changes. Stay tuned!
-      </div>
-    </div>
     <div class="dash-hero">
       <div class="dash-hero-left">
         <div class="dash-identity">
@@ -131,8 +119,6 @@ function renderDashboardMarkup(
           <div class="dash-stat"><div class="dash-stat-val">${formatNum(totalSessions)}</div><div class="dash-stat-lbl">Sessions</div></div>
           <div class="dash-stat"><div class="dash-stat-val">${formatNum(totalLoc)}</div><div class="dash-stat-lbl">AI LoC</div></div>
           <div class="dash-stat"><div class="dash-stat-val">${stats.totalWorkspaces}</div><div class="dash-stat-lbl">Workspaces</div></div>
-          ${burndownStatus && !burndown.harnessExcluded && html`<div class="dash-stat" title="GitHub Copilot premium-request budget. Counts requests from Copilot harnesses (VS Code, CLI, Xcode) only — Claude/Codex/OpenCode are excluded because they're billed through other plans, and Claude (via GHCP) work is already counted on the GHCP side."><div class="dash-stat-val" style=${'color:' + burndownColor}>${burndown.consumed}/${burndown.budget}</div><div class="dash-stat-lbl">Premium Requests <span style="color:var(--text-muted);font-size:10px;">(GHCP only)</span> <span style=${'color:' + burndownColor + ';font-size:10px;'}>${burndownLabel}</span></div></div>`}
-          ${burndownStatus && burndown.harnessExcluded && html`<div class="dash-stat" title="Premium requests are only counted for GitHub Copilot harnesses (VS Code, CLI, Xcode). The currently selected harness is billed separately and does not count toward your GHCP premium-request budget."><div class="dash-stat-val" style="color:var(--text-muted);">N/A</div><div class="dash-stat-lbl">Premium Requests <span style="color:var(--text-muted);font-size:10px;">(not counted for this harness)</span></div></div>`}
         </div>
         ${harnesses.length > 0 && html`<div class="dash-harnesses dash-harnesses-right">${harnesses.map((h, i) => html`<span class="dash-harness-tag" style=${'border-color:' + harnessColor(h, i) + ';color:' + harnessColor(h, i)}>${h}</span>`)}</div>`}
       </div>
@@ -197,15 +183,14 @@ function renderDashboardSkillFinder(skillCache: ReturnType<typeof getSkillCache>
 
 export async function renderDashboard(container: HTMLElement, currentFilter: DateFilter): Promise<void> {
   const emptyDaily: DailyActivity = { labels: [], values: [], sessions: [], loc: [], workspaces: [], byHarness: [] };
-  const emptyCodeProd: CodeProductionData = { summary: { totalAiLoc: 0, totalUserLoc: 0, totalLoc: 0, aiBlocks: 0, userBlocks: 0, aiRatio: 0, locCost2010: 0, costPerLoc: 0 }, byLanguage: { labels: [], aiLoc: [], userLoc: [] }, dailyTimeline: { labels: [], aiLoc: [], userLoc: [] }, byWorkspace: { labels: [], aiLoc: [], userLoc: [] }, dailyByWorkspace: {} };
-  const [stats, daily, wsBreakdown, harnessBreakdown, antiPatterns, codeProd, burndown] = await rpcAllSettled([
+  const emptyCodeProd: CodeProductionData = { summary: { totalAiLoc: 0, totalUserLoc: 0, totalLoc: 0, aiBlocks: 0, userBlocks: 0, aiRatio: 0, locCost2010: 0, costPerLoc: 0 }, byLanguage: { labels: [], aiLoc: [], userLoc: [] }, dailyTimeline: { labels: [], aiLoc: [], userLoc: [] }, byWorkspace: { labels: [], aiLoc: [], userLoc: [] }, dailyByWorkspace: {}, dailyByModel: {}, dailyByHarness: {} };
+  const [stats, daily, wsBreakdown, harnessBreakdown, antiPatterns, codeProd] = await rpcAllSettled([
     rpc<{ totalSessions: number; totalWorkspaces: number; totalRequests: number }>('getStats', currentFilter as Record<string, unknown>),
     rpc<DailyActivity>('getDailyActivity', currentFilter as Record<string, unknown>),
     rpc<{ labels: string[]; values: number[] }>('getWorkspaceBreakdown', currentFilter as Record<string, unknown>),
     rpc<{ labels: string[]; requests: number[] }>('getHarnessBreakdown', currentFilter as Record<string, unknown>),
     rpc<AntiPatternData>('getAntiPatterns', currentFilter as Record<string, unknown>),
     rpc<CodeProductionData>('getCodeProduction', currentFilter as Record<string, unknown>),
-    rpc<BurndownData>('getBurndown', { config: { sku: 'pro' }, filter: currentFilter as Record<string, unknown> }),
   ] as const, [
     { totalSessions: 0, totalWorkspaces: 0, totalRequests: 0 },
     emptyDaily,
@@ -213,7 +198,6 @@ export async function renderDashboard(container: HTMLElement, currentFilter: Dat
     { labels: [], requests: [] },
     { patterns: [], totalOccurrences: 0, groupScores: [], weeklyScores: { labels: [], series: [] } } as unknown as AntiPatternData,
     emptyCodeProd,
-    { currentMonth: '', daysInMonth: 30, dayOfMonth: 1, budget: 0, consumed: 0, projected: 0, dailyConsumption: { labels: [], values: [], cumulative: [] }, projectedLine: [], budgetLine: [], status: 'on-track' as const, recommendation: '' },
   ] as const);
 
   const totalLoc = daily.loc.reduce((a, b) => a + b, 0);
@@ -236,9 +220,6 @@ export async function renderDashboard(container: HTMLElement, currentFilter: Dat
     .sort((a, b) => b.loc - a.loc)
     .slice(0, 8);
 
-  const burndownStatus = burndown.budget > 0 ? burndown.status : null;
-  const burndownLabel = burndownStatus === 'over-budget' ? 'Over' : burndownStatus === 'warning' ? 'Watch' : burndownStatus === 'on-track' ? 'OK' : '';
-  const burndownColor = burndownStatus === 'over-budget' ? COLORS.red : burndownStatus === 'warning' ? COLORS.yellow : COLORS.green;
   const skillCache = getSkillCache(currentFilter);
 
   renderDashboardMarkup(
@@ -251,10 +232,6 @@ export async function renderDashboard(container: HTMLElement, currentFilter: Dat
     totalReqs,
     totalSessions,
     totalLoc,
-    burndown,
-    burndownStatus,
-    burndownLabel,
-    burndownColor,
     skillCache,
   );
 

--- a/src/webview/page-output.ts
+++ b/src/webview/page-output.ts
@@ -315,7 +315,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     const topWsNames = allWsNames.slice(0, 15);
     const otherWsNames = allWsNames.slice(15);
     const otherWsData = aggLabels.map((_, i) => otherWsNames.reduce((sum, ws) => sum + (aggByWs[ws]?.[i] ?? 0), 0));
-    const dailyDatasets = topWsNames
+    const dailyDatasets: { label: string; data: number[]; backgroundColor: string; borderColor: string; borderWidth: number }[] = topWsNames
       .filter(ws => aggByWs[ws])
       .map((ws, i) => ({
         label: ws,

--- a/src/webview/page-output.ts
+++ b/src/webview/page-output.ts
@@ -8,7 +8,7 @@
 import { DateFilter } from '../core/types';
 import { TOKEN_DATA_AVAILABLE_FROM } from '../core/constants';
 import { isoWeek } from '../core/helpers';
-import { rpc, createChart, formatNum, formatMoney, $$, PALETTE, COLORS, HARNESS_COLORS } from './shared';
+import { rpc, createChart, formatNum, $$, PALETTE, COLORS, HARNESS_COLORS } from './shared';
 import { html, render, StatCard, CanvasEl, ComponentChildren } from './render';
 
 type AggLevel = 'daily' | 'weekly' | 'monthly';
@@ -63,16 +63,8 @@ interface ProdData {
   byLanguage: { labels: string[]; aiLoc: number[] };
   byWorkspace: { labels: string[]; aiLoc: number[] };
   dailyByWorkspace: Record<string, number[]>;
-}
-
-interface ConsData {
-  totalRequests: number;
-  avgPerDay: number;
-  avgPerWeek: number;
-  modelTotals: Record<string, number>;
-  defaultMultipliers: Record<string, number>;
-  daily: { labels: string[]; values: number[]; byModel: Record<string, number[]> };
-  weekly: { labels: string[]; values: number[]; byModel: Record<string, number[]> };
+  dailyByModel: Record<string, number[]>;
+  dailyByHarness: Record<string, number[]>;
 }
 
 interface AiCreditRpcData {
@@ -102,6 +94,7 @@ interface AiCreditRpcData {
   daily: { labels: string[]; credits: number[]; cumulative: number[]; byModel: Record<string, number[]> };
   weekly: { labels: string[]; credits: number[]; cumulative: number[]; byModel: Record<string, number[]> };
   dailyTokensByWorkspace: { labels: string[]; byWorkspace: Record<string, number[]> };
+  dailyTokensByHarness: { labels: string[]; byHarness: Record<string, number[]> };
   topRequests: Array<{
     timestamp: number; model: string;
     inputTokens: number; outputTokens: number;
@@ -117,35 +110,25 @@ interface AiCreditRpcData {
 
 // Module-level view state — survives filter/harness changes so the user's
 // tab and range selection is preserved when only the backing data changes.
-type OutputTab = 'production' | 'consumption' | 'ai-credits';
+type OutputTab = 'production' | 'token-usage';
 let activeRangeDays = 0;
 let activeTab: OutputTab = 'production';
 
 export async function renderOutput(container: HTMLElement, currentFilter: DateFilter): Promise<void> {
 
-  // Tabs whose answers depend on token data quality (and so honor the
-  // TOKEN_DATA_AVAILABLE_FROM cutoff). Other tabs are based on request
-  // counts / LOC and can safely look at all history.
-  const TOKEN_DATA_TABS = new Set<OutputTab>(['ai-credits']);
-
-  // Disclaimer banner shown above the AI Credit Usage and Premium Request
-  // Consumption tabs. Both views are computed from local session files only,
-  // so they cannot see activity from other devices, cloud-hosted agents, or
-  // harnesses we don't read. The link points users at the authoritative
-  // source for billing.
+  // Disclaimer banner shown above the Token Usage tab.
+  // Computed from local session files only, so cannot see activity from
+  // other devices, cloud-hosted agents, or harnesses we don't read.
   const APPROXIMATION_NOTICE = html`
     <div class="approximation-notice">
       <strong>Approximation only.</strong>${' '}
-      AI Credit Usage and Premium Request Consumption are estimated from the
-      session data this extension can read on your machine. They cannot reflect
-      activity on other devices, cloud-hosted agents, or harnesses this
-      extension doesn't ingest, so they will never be fully accurate.
-      Use them as a workflow optimization signal, not as a billing reference.
-      For authoritative consumption numbers, see your${' '}
-      <a href="https://github.com/settings/copilot/features" target="_blank" rel="noopener">GitHub Copilot usage settings</a>.
+      Token usage is estimated from the session data this extension can read
+      on your machine. It shows token consumption across all harnesses and
+      may not be fully accurate — it cannot reflect activity on other devices,
+      cloud-hosted agents, or harnesses this extension doesn't ingest.
+      Use it as a workflow optimization signal, not as a billing reference.
     </div>
   `;
-  const isTokenDataTab = (tab: OutputTab) => TOKEN_DATA_TABS.has(tab);
 
   // Range options shown in the bar. Order matters: longest range last so
   // "All time" (0) lives on the right. The 7/28-day buttons are short enough
@@ -167,7 +150,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
   }
 
   function isRangeDisabled(tab: OutputTab, days: number): boolean {
-    if (!isTokenDataTab(tab)) return false;
+    if (tab !== 'token-usage') return false;
     return rangeStartDate(days) < TOKEN_DATA_AVAILABLE_FROM;
   }
 
@@ -177,7 +160,8 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     if (days > 0) {
       f.fromDate = rangeStartDate(days);
     }
-    if (isTokenDataTab(activeTab)) {
+    // Only clamp to TOKEN_DATA_AVAILABLE_FROM on the token-usage tab
+    if (activeTab === 'token-usage') {
       const fromDate = (f.fromDate as string | undefined) ?? '';
       if (!fromDate || fromDate < TOKEN_DATA_AVAILABLE_FROM) {
         f.fromDate = TOKEN_DATA_AVAILABLE_FROM;
@@ -189,26 +173,21 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
   function creditChartTitle(): string {
     const rangeLabel = RANGES.find(r => r.days === activeRangeDays)?.label ?? 'All time';
     const granularity = activeRangeDays > 0 && activeRangeDays <= 28 ? 'Daily' : 'Weekly';
-    return `${granularity} AI Credit Consumption \u2014 ${rangeLabel}`;
+    return `${granularity} Token Consumption — ${rangeLabel}`;
   }
 
   function tokenByWsChartTitle(): string {
     const rangeLabel = RANGES.find(r => r.days === activeRangeDays)?.label ?? 'All time';
     const level = aggregationLevel(activeRangeDays);
     const granularity = level === 'daily' ? 'Daily' : level === 'weekly' ? 'Weekly' : 'Monthly';
-    return `${granularity} Token Consumption by Workspace \u2014 ${rangeLabel}`;
+    return `${granularity} Token Consumption by Workspace — ${rangeLabel}`;
   }
 
-  function consChartTitle(): string {
+  function tokenByHarnessChartTitle(): string {
     const rangeLabel = RANGES.find(r => r.days === activeRangeDays)?.label ?? 'All time';
-    const granularity = activeRangeDays > 0 && activeRangeDays <= 28 ? 'Daily' : 'Weekly';
-    return `${granularity} Premium Request Consumption \u2014 ${rangeLabel}`;
-  }
-
-  function overlayChartTitle(): string {
-    const rangeLabel = RANGES.find(r => r.days === activeRangeDays)?.label ?? 'All time';
-    const granularity = activeRangeDays > 0 && activeRangeDays <= 28 ? 'Daily' : 'Weekly';
-    return `${granularity} AI Credits vs Premium Requests \u2014 ${rangeLabel}`;
+    const level = aggregationLevel(activeRangeDays);
+    const granularity = level === 'daily' ? 'Daily' : level === 'weekly' ? 'Weekly' : 'Monthly';
+    return `${granularity} Token Consumption by Harness — ${rangeLabel}`;
   }
 
   function renderRangeBar(): ComponentChildren {
@@ -253,8 +232,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     <div class="cons-range-bar" id="outputRange"></div>
     <div class="tab-bar" id="output-tabs">
       <button class=${`tab${activeTab === 'production' ? ' active' : ''}`} data-tab="production">Code Output</button>
-      <button class=${`tab${activeTab === 'consumption' ? ' active' : ''}`} data-tab="consumption">Premium Request Consumption</button>
-      <button class=${`tab${activeTab === 'ai-credits' ? ' active' : ''}`} data-tab="ai-credits">AI Credit Usage</button>
+      <button class=${`tab${activeTab === 'token-usage' ? ' active' : ''}`} data-tab="token-usage">Token Usage</button>
     </div>
     <div id="output-tab-content"></div>
   `, container);
@@ -272,30 +250,72 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     const s = prod.summary;
     const level = aggregationLevel(activeRangeDays);
     const chartTitle = level === 'weekly' ? 'Weekly Production' : level === 'monthly' ? 'Monthly Production' : 'Daily Production';
+    const yLabel = level === 'weekly' ? 'LoC/week' : level === 'monthly' ? 'LoC/month' : 'LoC/day';
 
     render(html`
       <div class="stat-grid">
         <${StatCard} label="AI-Generated LoC" value=${formatNum(s.totalAiLoc)} accent="var(--accent-blue)" />
-        <${StatCard} label="Est. 2010s Value" value=${formatMoney(s.locCost2010)} accent="var(--accent-purple)" />
       </div>
-      <${CanvasEl} id="prodDailyChart" height=${250} title=${chartTitle} />
+      <div class="chart-tabs" style="margin-top:18px">
+        <button class="chart-tab active" data-prod-tab="model">Code Output</button>
+        <button class="chart-tab" data-prod-tab="workspace">Output by Workspace</button>
+        <button class="chart-tab" data-prod-tab="harness">Output by Harness</button>
+      </div>
+      <div id="prodTabModel" class="chart-tab-panel active"><${CanvasEl} id="prodModelChart" height=${300} title=${chartTitle} /></div>
+      <div id="prodTabWorkspace" class="chart-tab-panel"><${CanvasEl} id="prodDailyChart" height=${300} title=${chartTitle} /></div>
+      <div id="prodTabHarness" class="chart-tab-panel"><${CanvasEl} id="prodHarnessChart" height=${300} title=${chartTitle} /></div>
       <div class="two-col">
         <${CanvasEl} id="prodLangChart" height=${300} title="By Language" />
         <${CanvasEl} id="prodWsChart" height=${300} title="By Workspace" />
       </div>
     `, target);
 
-    const wsNames = prod.byWorkspace.labels;
     const wsColor = (i: number) => PALETTE[i % PALETTE.length];
 
+    // --- By Model chart (default) ---
+    const { labels: modelLabels, byWs: modelBuckets } = aggregateByWorkspace(
+      prod.dailyTimeline.labels, prod.dailyByModel, level,
+    );
+    const modelNames = Object.keys(modelBuckets).sort((a, b) => {
+      const sumA = modelBuckets[a].reduce((sum, v) => sum + v, 0);
+      const sumB = modelBuckets[b].reduce((sum, v) => sum + v, 0);
+      return sumB - sumA;
+    });
+    const topModels = modelNames.slice(0, 8);
+    const otherModels = modelNames.slice(8);
+    const otherModelData = modelLabels.map((_, i) => otherModels.reduce((sum, m) => sum + (modelBuckets[m]?.[i] ?? 0), 0));
+    const modelDatasets: Record<string, unknown>[] = topModels.map((m, i) => ({
+      label: m, data: modelBuckets[m], backgroundColor: PALETTE[i % PALETTE.length] + '99',
+      borderColor: PALETTE[i % PALETTE.length], borderWidth: 1, stack: 'models',
+    }));
+    if (otherModels.length > 0) {
+      modelDatasets.push({ label: `Other (${otherModels.length})`, data: otherModelData, backgroundColor: COLORS.muted + '60', borderColor: COLORS.muted, borderWidth: 1, stack: 'models' });
+    }
+    if (modelDatasets.length === 0) {
+      const { values: aggTotals } = aggregateTimeline(prod.dailyTimeline.labels, prod.dailyTimeline.aiLoc, level);
+      modelDatasets.push({ label: 'AI LoC', data: aggTotals, backgroundColor: PALETTE[0] + '99', borderColor: PALETTE[0], borderWidth: 1, stack: 'models' });
+    }
+    createChart('prodModelChart', 'bar', { labels: modelLabels, datasets: modelDatasets }, {
+      plugins: { legend: { position: 'top' } },
+      scales: { x: { stacked: true, ticks: { maxTicksLimit: 15 } }, y: { stacked: true, beginAtZero: true, title: { display: true, text: yLabel } } },
+    });
+
+    // --- By Workspace chart ---
     const { labels: aggLabels, byWs: aggByWs } = aggregateByWorkspace(
       prod.dailyTimeline.labels, prod.dailyByWorkspace, level,
     );
     const { values: aggTotals } = aggregateTimeline(
       prod.dailyTimeline.labels, prod.dailyTimeline.aiLoc, level,
     );
-
-    const dailyDatasets = wsNames
+    const allWsNames = Object.keys(aggByWs).sort((a, b) => {
+      const sumA = aggByWs[a].reduce((s, v) => s + v, 0);
+      const sumB = aggByWs[b].reduce((s, v) => s + v, 0);
+      return sumB - sumA;
+    });
+    const topWsNames = allWsNames.slice(0, 15);
+    const otherWsNames = allWsNames.slice(15);
+    const otherWsData = aggLabels.map((_, i) => otherWsNames.reduce((sum, ws) => sum + (aggByWs[ws]?.[i] ?? 0), 0));
+    const dailyDatasets = topWsNames
       .filter(ws => aggByWs[ws])
       .map((ws, i) => ({
         label: ws,
@@ -304,6 +324,15 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
         borderColor: wsColor(i),
         borderWidth: 1,
       }));
+    if (otherWsNames.length > 0) {
+      dailyDatasets.push({
+        label: `Other (${otherWsNames.length})`,
+        data: otherWsData,
+        backgroundColor: COLORS.muted + '60',
+        borderColor: COLORS.muted,
+        borderWidth: 1,
+      });
+    }
     if (dailyDatasets.length === 0) {
       dailyDatasets.push({
         label: 'AI LoC',
@@ -313,15 +342,36 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
         borderWidth: 1,
       });
     }
-
     createChart('prodDailyChart', 'bar', {
       labels: aggLabels,
       datasets: dailyDatasets,
     }, {
       plugins: { legend: { display: dailyDatasets.length > 1, position: 'bottom', labels: { boxWidth: 12, padding: 8 } } },
-      scales: { x: { stacked: true, ticks: { maxTicksLimit: 15 } }, y: { stacked: true, beginAtZero: true } },
+      scales: { x: { stacked: true, ticks: { maxTicksLimit: 15 } }, y: { stacked: true, beginAtZero: true, title: { display: true, text: yLabel } } },
     });
 
+    // --- By Harness chart ---
+    const { labels: hLabels, byWs: hBuckets } = aggregateByWorkspace(
+      prod.dailyTimeline.labels, prod.dailyByHarness, level,
+    );
+    const hNames = Object.keys(hBuckets).sort((a, b) => {
+      const sumA = hBuckets[a].reduce((sum, v) => sum + v, 0);
+      const sumB = hBuckets[b].reduce((sum, v) => sum + v, 0);
+      return sumB - sumA;
+    });
+    const hDatasets: Record<string, unknown>[] = hNames.map((h) => ({
+      label: h, data: hBuckets[h],
+      backgroundColor: (harnessColor(h)) + '99',
+      borderColor: harnessColor(h), borderWidth: 1, stack: 'harness',
+    }));
+    if (hDatasets.length > 0) {
+      createChart('prodHarnessChart', 'bar', { labels: hLabels, datasets: hDatasets }, {
+        plugins: { legend: { position: 'top' } },
+        scales: { x: { stacked: true, ticks: { maxTicksLimit: 15 } }, y: { stacked: true, beginAtZero: true, title: { display: true, text: yLabel } } },
+      });
+    }
+
+    // --- Sidebar charts ---
     createChart('prodLangChart', 'bar', {
       labels: prod.byLanguage.labels,
       datasets: [{ label: 'AI LoC', data: prod.byLanguage.aiLoc, backgroundColor: PALETTE[0] }],
@@ -331,7 +381,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
       scales: { x: { beginAtZero: true } },
     });
 
-    const wsBarColors = wsNames.map((_, i) => wsColor(i));
+    const wsBarColors = prod.byWorkspace.labels.map((_, i) => wsColor(i));
     createChart('prodWsChart', 'bar', {
       labels: prod.byWorkspace.labels,
       datasets: [{ label: 'AI LoC', data: prod.byWorkspace.aiLoc, backgroundColor: wsBarColors }],
@@ -340,110 +390,30 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
       plugins: { legend: { display: false } },
       scales: { x: { beginAtZero: true } },
     });
-  }
 
-  async function renderConsumptionTab(): Promise<void> {
-    const target = document.getElementById('output-tab-content')!;
-    render(html`<div class="loading-spinner"></div>`, target);
-
-    const cons = await rpc<ConsData>('getConsumption', buildRangeFilter());
-
-    render(html`
-      ${APPROXIMATION_NOTICE}
-      <div class="stat-grid" id="consStats">
-        <${StatCard} label="Total Requests" value=${formatNum(cons.totalRequests)} accent="var(--accent-blue)" />
-        <${StatCard} label="Avg/Day" value=${formatNum(Math.round(cons.avgPerDay))} accent="var(--accent-green)" />
-        <${StatCard} label="Avg/Week" value=${formatNum(Math.round(cons.avgPerWeek))} accent="var(--accent-purple)" />
-      </div>
-      <${CanvasEl} id="consChart" height=${300} title=${consChartTitle()} />
-      <h2>Model Breakdown</h2>
-      <div id="modelTable"></div>
-    `, target);
-
-    const useDaily = activeRangeDays > 0 && activeRangeDays <= 28;
-    const series = useDaily ? cons.daily : cons.weekly;
-    const cumulative = series.values.reduce((acc: number[], v: number) => {
-      acc.push((acc.length > 0 ? acc[acc.length - 1] : 0) + v);
-      return acc;
-    }, []);
-
-    const modelColors = PALETTE;
-    const byModel = series.byModel;
-    const modelNames = Object.keys(byModel).sort((a, b) => {
-      const sumA = byModel[a].reduce((s: number, v: number) => s + v, 0);
-      const sumB = byModel[b].reduce((s: number, v: number) => s + v, 0);
-      return sumB - sumA;
-    });
-
-    const TOP_N = 8;
-    const topModels = modelNames.slice(0, TOP_N);
-    const otherModels = modelNames.slice(TOP_N);
-
-    const otherData = series.labels.map((_: string, i: number) =>
-      otherModels.reduce((sum: number, m: string) => sum + (byModel[m]?.[i] ?? 0), 0)
-    );
-
-    const modelDatasets: Record<string, unknown>[] = topModels.map((model, i) => ({
-      label: model,
-      data: byModel[model],
-      backgroundColor: modelColors[i % modelColors.length] + '99',
-      borderColor: modelColors[i % modelColors.length],
-      borderWidth: 1,
-      order: 2,
-      stack: 'models',
-    }));
-
-    if (otherModels.length > 0) {
-      modelDatasets.push({
-        label: `Other (${otherModels.length})`,
-        data: otherData,
-        backgroundColor: COLORS.muted + '60',
-        borderColor: COLORS.muted,
-        borderWidth: 1,
-        order: 2,
-        stack: 'models',
+    // Wire production chart tab switching
+    for (const btn of target.querySelectorAll<HTMLButtonElement>('.chart-tab[data-prod-tab]')) {
+      btn.addEventListener('click', () => {
+        for (const b of target.querySelectorAll<HTMLButtonElement>('.chart-tab[data-prod-tab]')) b.classList.remove('active');
+        btn.classList.add('active');
+        const tab = btn.dataset.prodTab;
+        const panelMap: Record<string, string> = { model: 'prodTabModel', workspace: 'prodTabWorkspace', harness: 'prodTabHarness' };
+        for (const p of target.querySelectorAll<HTMLElement>('.chart-tab-panel')) p.classList.remove('active');
+        document.getElementById(panelMap[tab || 'model'])!.classList.add('active');
       });
     }
-
-    const yLabel = useDaily ? 'Requests/day' : 'Requests/week';
-
-    createChart('consChart', 'bar', {
-      labels: series.labels,
-      datasets: [
-        ...modelDatasets as { label: string; data: number[]; backgroundColor: string; borderColor: string; borderWidth: number; order: number; stack: string }[],
-        { label: 'Cumulative', data: cumulative, type: 'line' as const, borderColor: COLORS.yellow, backgroundColor: 'transparent', borderWidth: 2, pointRadius: 0, order: 1, yAxisID: 'y1' },
-      ],
-    }, {
-      plugins: { legend: { position: 'top' } },
-      scales: {
-        x: { stacked: true, ticks: { maxTicksLimit: 15 } },
-        y: { stacked: true, beginAtZero: true, position: 'left', title: { display: true, text: yLabel } },
-        y1: { beginAtZero: true, position: 'right', grid: { drawOnChartArea: false }, title: { display: true, text: 'Cumulative' } },
-      },
-    });
-
-    const models = Object.entries(cons.modelTotals).sort((a, b) => b[1] - a[1]);
-    const totalReqs = cons.totalRequests || 1;
-    const modelTableEl = document.getElementById('modelTable')!;
-    render(html`<table class="data-table"><thead><tr><th>Model</th><th>Requests</th><th>Share</th><th>Multiplier</th><th>Premium Reqs</th></tr></thead><tbody>
-      ${models.map(([model, count]) => {
-        const mult = cons.defaultMultipliers[model] ?? 1;
-        const premium = Math.round(count * mult);
-        return html`<tr><td>${model}</td><td>${formatNum(count)}</td><td>${((count / totalReqs) * 100).toFixed(1)}%</td><td>${mult}x</td><td>${formatNum(premium)}</td></tr>`;
-      })}
-    </tbody></table>`, modelTableEl);
   }
 
   function buildCreditCoverageSummary(data: AiCreditRpcData): { missingLabel: ComponentChildren; partialLabel: ComponentChildren; pendingLabel: ComponentChildren; noDataLabel: ComponentChildren } {
     const trulyMissing = data.finalizableRequests - data.countedRequests - data.partialRequests;
     return {
       missingLabel: data.finalizableRequests > 0 && data.missingPct > 0
-        ? html`<span class="missing-badge badge-popup-trigger" tabindex="0">missing ${data.missingPct}%<span class="badge-popup"><strong>Missing (${data.missingPct}%)</strong><br/>${formatNum(trulyMissing)} of ${formatNum(data.finalizableRequests)} finalizable requests have no token data (neither input nor output tokens recorded). These requests could not be billed and are excluded from credit totals.</span></span>`
+        ? html`<span class="missing-badge badge-popup-trigger" tabindex="0">missing ${data.missingPct}%<span class="badge-popup"><strong>Missing (${data.missingPct}%)</strong><br/>${formatNum(trulyMissing)} of ${formatNum(data.finalizableRequests)} finalizable requests have no token data (neither input nor output tokens recorded). These requests are excluded from totals.</span></span>`
         : data.finalizableRequests === 0 && data.totalRequests > 0
-          ? html`<span class="missing-badge badge-popup-trigger" tabindex="0">no finalizable requests<span class="badge-popup"><strong>No finalizable requests</strong><br/>All requests in this period are either still pending (active/aborted sessions) or from sources that don\u2019t record token usage. No credit totals can be computed yet.</span></span>`
+          ? html`<span class="missing-badge badge-popup-trigger" tabindex="0">no finalizable requests<span class="badge-popup"><strong>No finalizable requests</strong><br/>All requests in this period are either still pending (active/aborted sessions) or from sources that don\u2019t record token usage. No token totals can be computed yet.</span></span>`
           : '',
       partialLabel: data.partialRequests > 0
-        ? html` <span class="pending-badge badge-popup-trigger" tabindex="0">+${formatNum(data.partialRequests)} partial<span class="badge-popup"><strong>Partial (${formatNum(data.partialRequests)} requests)</strong><br/>These requests captured output tokens but not input tokens \u2014 credits cannot be billed exactly. The output token cost is still included in totals, but input cost is unknown. This is common with VS Code Copilot auto-completions and inline suggestions.</span></span>`
+        ? html` <span class="pending-badge badge-popup-trigger" tabindex="0">+${formatNum(data.partialRequests)} partial<span class="badge-popup"><strong>Partial (${formatNum(data.partialRequests)} requests)</strong><br/>These requests captured output tokens but not input tokens \u2014 cost cannot be estimated exactly. The output token cost is still included in totals, but input cost is unknown. This is common with VS Code Copilot auto-completions and inline suggestions.</span></span>`
         : '',
       pendingLabel: data.pendingRequests > 0
         ? html` <span class="pending-badge badge-popup-trigger" tabindex="0">+${formatNum(data.pendingRequests)} pending<span class="badge-popup"><strong>Pending (${formatNum(data.pendingRequests)} requests)</strong><br/>Requests in active or aborted sessions where token data was never finalized. These are excluded from the missing % calculation because they may still receive data when sessions close. Common with long-running or interrupted agentic sessions.</span></span>`
@@ -464,10 +434,14 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     const body = data.pendingRequests > 0
       ? `All ${formatNum(data.totalRequests)} request${data.totalRequests === 1 ? '' : 's'} in this period are still pending or were aborted before any model output. Token data may yet arrive once sessions finalize.`
       : data.noDataRequests === data.totalRequests
-        ? `All ${formatNum(data.totalRequests)} request${data.totalRequests === 1 ? '' : 's'} are from sources that don't record token usage (e.g. Xcode), so AI Credit usage cannot be computed.`
-        : `None of the ${formatNum(data.totalRequests)} request${data.totalRequests === 1 ? '' : 's'} in this period have both input and output token counts reported by the harness, so AI Credit usage cannot be computed.`;
+        ? `All ${formatNum(data.totalRequests)} request${data.totalRequests === 1 ? '' : 's'} are from sources that don't record token usage (e.g. Xcode), so token usage cannot be computed.`
+        : `None of the ${formatNum(data.totalRequests)} request${data.totalRequests === 1 ? '' : 's'} in this period have both input and output token counts reported by the harness, so token usage cannot be computed.`;
     render(html`${APPROXIMATION_NOTICE}<div class="empty-state"><h2>${heading}</h2><p>${body}</p></div>`, target);
     return true;
+  }
+
+  function harnessColor(h: string): string {
+    return HARNESS_COLORS[h] || '#6b7280';
   }
 
   function renderAiCreditsCharts(data: AiCreditRpcData): { modelEntries: [string, AiCreditRpcData['costByModel'][string]][] } {
@@ -484,20 +458,15 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
       }],
     }, { plugins: { legend: { display: false }, tooltip: { callbacks: { label: (ctx: { label: string; raw: number }) => `${ctx.label}: ${formatNum(ctx.raw)}` } } }, scales: { y: { beginAtZero: true, ticks: { callback: (v: number) => formatNum(v) } } } });
 
-    const modelEntries = Object.entries(data.costByModel).sort((a, b) => b[1].credits - a[1].credits);
-    const topN = modelEntries.slice(0, 10);
-    createChart('creditModelBar', 'bar', {
-      labels: topN.map(([m]) => m),
-      datasets: [{ label: 'AI Credits', data: topN.map(([, v]) => Math.round(v.credits * 100) / 100), backgroundColor: topN.map((_, i) => PALETTE[i % PALETTE.length]) }],
-    }, { indexAxis: 'y', plugins: { legend: { display: false } }, scales: { x: { beginAtZero: true } } });
+    const modelEntries = Object.entries(data.costByModel).sort((a, b) => (b[1].inputTokens + b[1].outputTokens) - (a[1].inputTokens + a[1].outputTokens));
 
     const useDaily = activeRangeDays > 0 && activeRangeDays <= 28;
     const series = useDaily ? data.daily : data.weekly;
-    const yLabel = useDaily ? 'Credits/day' : 'Credits/week';
+    const yLabel = useDaily ? 'Tokens/day' : 'Tokens/week';
     const byModel = series.byModel;
     const modelNames = Object.keys(byModel).sort((a, b) => byModel[b].reduce((s: number, v: number) => s + v, 0) - byModel[a].reduce((s: number, v: number) => s + v, 0));
-    const topCreditModels = modelNames.slice(0, 8);
-    const otherCreditModels = modelNames.slice(8);
+    const topCreditModels = modelNames.slice(0, 12);
+    const otherCreditModels = modelNames.slice(12);
     const otherCreditData = series.labels.map((_: string, i: number) => otherCreditModels.reduce((sum: number, m: string) => sum + (byModel[m]?.[i] ?? 0), 0));
     const creditDatasets: Record<string, unknown>[] = topCreditModels.map((model, i) => ({ label: model, data: byModel[model], backgroundColor: PALETTE[i % PALETTE.length] + '99', borderColor: PALETTE[i % PALETTE.length], borderWidth: 1, order: 2, stack: 'models' }));
     if (otherCreditModels.length > 0) {
@@ -521,8 +490,8 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
       const sumB = wsBuckets[b].reduce((s, v) => s + v, 0);
       return sumB - sumA;
     });
-    const topWs = wsNames.slice(0, 8);
-    const otherWs = wsNames.slice(8);
+    const topWs = wsNames.slice(0, 20);
+    const otherWs = wsNames.slice(20);
     const otherWsData = wsLabels.map((_, i) => otherWs.reduce((sum, ws) => sum + (wsBuckets[ws]?.[i] ?? 0), 0));
     const wsDatasets: Record<string, unknown>[] = topWs.map((ws, i) => ({
       label: ws, data: wsBuckets[ws], backgroundColor: PALETTE[i % PALETTE.length] + '99',
@@ -539,11 +508,29 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
       }, { plugins: { legend: { position: 'top' }, tooltip: { callbacks: { label: (ctx: { dataset: { label: string }; raw: number }) => `${ctx.dataset.label}: ${formatNum(ctx.raw)} tokens` } } }, scales: { x: { stacked: true, ticks: { maxTicksLimit: 15 } }, y: { stacked: true, beginAtZero: true, title: { display: true, text: wsYLabel }, ticks: { callback: (v: number) => formatNum(v) } } } });
     }
 
-    return { modelEntries };
-  }
+    // Token Consumption by Harness chart
+    const { labels: hLabels, byWs: hBuckets } = aggregateByWorkspace(
+      data.dailyTokensByHarness.labels, data.dailyTokensByHarness.byHarness, level,
+    );
+    const hNames = Object.keys(hBuckets).sort((a, b) => {
+      const sumA = hBuckets[a].reduce((s, v) => s + v, 0);
+      const sumB = hBuckets[b].reduce((s, v) => s + v, 0);
+      return sumB - sumA;
+    });
+    const hDatasets: Record<string, unknown>[] = hNames.map((h) => ({
+      label: h, data: hBuckets[h],
+      backgroundColor: (harnessColor(h)) + '99',
+      borderColor: harnessColor(h), borderWidth: 1, stack: 'harness',
+    }));
+    if (hDatasets.length > 0) {
+      const hYLabel = level === 'daily' ? 'Tokens/day' : level === 'weekly' ? 'Tokens/week' : 'Tokens/month';
+      createChart('creditTokenByHarnessChart', 'bar', {
+        labels: hLabels,
+        datasets: hDatasets,
+      }, { plugins: { legend: { position: 'top' }, tooltip: { callbacks: { label: (ctx: { dataset: { label: string }; raw: number }) => `${ctx.dataset.label}: ${formatNum(ctx.raw)} tokens` } } }, scales: { x: { stacked: true, ticks: { maxTicksLimit: 15 } }, y: { stacked: true, beginAtZero: true, title: { display: true, text: hYLabel }, ticks: { callback: (v: number) => formatNum(v) } } } });
+    }
 
-  function harnessColor(h: string): string {
-    return HARNESS_COLORS[h] || '#6b7280';
+    return { modelEntries };
   }
 
   function renderCreditModelTable(target: HTMLElement, modelEntries: [string, AiCreditRpcData['costByModel'][string]][]): void {
@@ -551,7 +538,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     const hiddenModelCount = modelEntries.length - visibleModelEntries.length;
     const anyCached = visibleModelEntries.some(([, info]) => (info.cacheReadTokens + info.cacheWriteTokens) > 0);
     render(html`
-      <table class="data-table"><thead><tr><th>Model</th><th>Source</th><th>Requests</th><th>Input Tokens</th>${anyCached && html`<th title="Cached input tokens (read + write). Billed at the cached rate (~10% of input rate).">Cached</th>`}<th>Output Tokens</th><th>AI Credits</th><th>Est. Cost</th><th>Data</th></tr></thead><tbody>
+      <table class="data-table"><thead><tr><th>Model</th><th>Source</th><th>Requests</th><th>Input Tokens</th>${anyCached && html`<th title="Cached input tokens (read + write).">Cached</th>`}<th>Output Tokens</th><th>Data</th></tr></thead><tbody>
         ${visibleModelEntries.map(([model, info]) => {
           const dataTag = info.finalizableRequests === 0 && info.requests > 0
             ? html`<span class="missing-badge-inline" title="No finalizable requests for this model \u2014 all are pending or from a source that doesn't record tokens.">N/A</span>`
@@ -566,8 +553,6 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
             <td>${formatNum(info.inputTokens)}</td>
             ${anyCached && html`<td>${cachedTotal > 0 ? formatNum(cachedTotal) : html`<span class="missing-badge-inline">\u2014</span>`}</td>`}
             <td>${formatNum(info.outputTokens)}</td>
-            <td>${info.credits.toFixed(1)}</td>
-            <td>${formatMoney(info.credits / 100)}</td>
             <td>${dataTag}${info.partialRequests > 0 && html` <span class="pending-badge" title=${formatNum(info.partialRequests) + ' output-only requests (input not captured) \u2014 output tokens shown but credits cannot be billed.'}>+${formatNum(info.partialRequests)} partial</span>`}${info.pendingRequests > 0 && html` <span class="pending-badge" title=${formatNum(info.pendingRequests) + ' requests in active/aborted sessions (excluded from missing %)'}>+${formatNum(info.pendingRequests)} pending</span>`}${info.noDataRequests > 0 && html` <span class="pending-badge" title=${formatNum(info.noDataRequests) + " requests where the harness/source did not record token data (excluded from missing %)"}>+${formatNum(info.noDataRequests)} no-data</span>`}</td>
           </tr>`;
         })}
@@ -621,7 +606,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
 
   function renderTopRequestsTable(target: HTMLElement, data: AiCreditRpcData): void {
     render(html`
-      <table class="data-table"><thead><tr><th>Date</th><th>Workspace</th><th>Source</th><th>Model</th><th>Total Tokens</th><th>Credits</th><th>Prompt</th></tr></thead><tbody>
+      <table class="data-table"><thead><tr><th>Date</th><th>Workspace</th><th>Source</th><th>Model</th><th>Total Tokens</th><th>Prompt</th></tr></thead><tbody>
         ${data.topRequests.map(req => {
           const d = new Date(req.timestamp).toLocaleDateString();
           const aggregated = req.aggregationKind === 'session-aggregated';
@@ -633,22 +618,16 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
             : req.status === 'no-data' ? html`<span class="missing-badge" title="Source structurally does not record token counts.">no-data</span>`
             : req.status === 'partial' ? html`<span class="missing-badge" title="Only output captured \u2014 total incomplete.">partial</span>`
             : html`<span class="missing-badge" title="No native token count.">missing</span>`;
-          const creditsCell = req.status === 'complete'
-            ? (aggregated ? html`<span class="aggregated-badge" title=${aggTitle}>~${req.credits.toFixed(2)}</span>` : req.credits.toFixed(2))
-            : req.status === 'pending' ? html`<span class="missing-badge" title="Cannot compute credits \u2014 token data not yet finalized.">pending</span>`
-            : req.status === 'no-data' ? html`<span class="missing-badge" title="Cannot compute credits \u2014 source does not record token usage.">no-data</span>`
-            : req.status === 'partial' ? html`<span class="missing-badge" title="Cannot compute credits exactly \u2014 input tokens not captured.">partial</span>`
-            : html`<span class="missing-badge" title="Cannot compute credits \u2014 no billing data">missing</span>`;
           const wsCell = req.workspace || html`<span class="missing-badge">unknown</span>`;
           const harnessCell = req.harness ? html`<span class="harness-badge" style="--harness-color:${harnessColor(req.harness)}" title=${req.harness}>${req.harness}</span>` : '';
-          return html`<tr><td>${d}</td><td>${wsCell}</td><td>${harnessCell}</td><td>${req.model}</td><td>${tokensCell}</td><td>${creditsCell}</td><td><span class="prompt-preview-trigger" onclick=${(e: MouseEvent) => showPromptPopup(e, req.fullPrompt)}>${req.preview.slice(0, 50)}\u2026</span></td></tr>`;
+          return html`<tr><td>${d}</td><td>${wsCell}</td><td>${harnessCell}</td><td>${req.model}</td><td>${tokensCell}</td><td><span class="prompt-preview-trigger" onclick=${(e: MouseEvent) => showPromptPopup(e, req.fullPrompt)}>${req.preview.slice(0, 50)}\u2026</span></td></tr>`;
         })}
       </tbody></table>
       ${data.topRequests.some(r => r.aggregationKind === 'session-aggregated') && html`<p class="credits-note"><span class="aggregated-badge">~value</span> = derived share of session-level totals (per-request data not reported by harness).</p>`}
     `, target);
   }
 
-  async function renderAiCreditsTab(): Promise<void> {
+  async function renderTokenUsageTab(): Promise<void> {
     const target = document.getElementById('output-tab-content')!;
     render(html`<div class="loading-spinner"></div>`, target);
 
@@ -657,64 +636,34 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     const { missingLabel, partialLabel, pendingLabel, noDataLabel } = buildCreditCoverageSummary(data);
     if (renderAiCreditsEmptyState(target, data)) return;
 
+    const totalTokens = data.totalInputTokens + data.totalOutputTokens;
+
     render(html`
       ${APPROXIMATION_NOTICE}
       <div class="stat-grid" id="creditStats">
-        <${StatCard} label="Total AI Credits" value=${formatNum(Math.round(data.totalCredits))} accent="var(--accent-blue)" />
-        <${StatCard} label="Est. Cost" value=${formatMoney(data.totalCredits / 100)} accent="var(--accent-purple)" />
-        <${StatCard} label="Avg Credits/Request" value=${data.avgCreditsPerRequest.toFixed(2)} accent="var(--accent-green)" />
-        <${StatCard} label="Avg Credits/Day" value=${data.avgCreditsPerDay.toFixed(1)} accent="var(--accent-yellow)" />
+        <${StatCard} label="Total Tokens" value=${formatNum(totalTokens)} accent="var(--accent-blue)" />
+        <${StatCard} label="Input Tokens" value=${formatNum(data.totalInputTokens)} accent="var(--accent-green)" />
+        <${StatCard} label="Output Tokens" value=${formatNum(data.totalOutputTokens)} accent="var(--accent-purple)" />
       </div>
-      <p class="credits-note">1 AI Credit = $0.01 USD. Code completions are free and not counted. Totals reflect ${formatNum(data.countedRequests)} of ${formatNum(data.finalizableRequests)} finalizable requests with billing data (per-request native tokens or session-level totals from the harness). ${missingLabel}${partialLabel}${pendingLabel}${noDataLabel}</p>
+      <p class="credits-note">Totals reflect ${formatNum(data.countedRequests)} of ${formatNum(data.finalizableRequests)} finalizable requests with token data. Code completions are free and not counted. ${missingLabel}${partialLabel}${pendingLabel}${noDataLabel}</p>
       <div class="chart-tabs" style="margin-top:18px">
-        <button class="chart-tab active" data-chart-tab="credits">AI Credits</button>
+        <button class="chart-tab active" data-chart-tab="tokens">Token Consumption</button>
         <button class="chart-tab" data-chart-tab="tokens-ws">Tokens by Workspace</button>
-        <button class="chart-tab" data-chart-tab="overlay">Credits vs Requests</button>
+        <button class="chart-tab" data-chart-tab="tokens-harness">Tokens by Harness</button>
       </div>
       <div id="chartTabCredits" class="chart-tab-panel active"><${CanvasEl} id="creditWeeklyChart" height=${300} title=${creditChartTitle()} /></div>
       <div id="chartTabTokensWs" class="chart-tab-panel"><${CanvasEl} id="creditTokenByWsChart" height=${350} title=${tokenByWsChartTitle()} /></div>
-      <div id="chartTabOverlay" class="chart-tab-panel"><${CanvasEl} id="creditVsRequestsChart" height=${300} title=${overlayChartTitle()} /></div>
-      <div class="two-col"><div class="chart-wrap"><div class="chart-title">Token Breakdown <span class="info-icon" tabindex="0" role="button" aria-label="Token breakdown info">${'\u24d8'}<span class="info-popup">Cache token breakdown (cache read / cache write) is only available for harnesses that report it natively, such as Claude Code and Copilot CLI. VS Code Copilot chat sessions report a single aggregated input token count and do not break out cached vs. uncached tokens — this is a limitation of the upstream data format, not a bug.</span></span></div><canvas id="creditTokenPie" height=${250}></canvas></div><${CanvasEl} id="creditModelBar" height=${250} title="Credit Cost by Model" /></div>
-      <h2>Model Cost Breakdown</h2>
+      <div id="chartTabTokensHarness" class="chart-tab-panel"><${CanvasEl} id="creditTokenByHarnessChart" height=${350} title=${tokenByHarnessChartTitle()} /></div>
+      <div class="chart-wrap"><div class="chart-title">Token Breakdown <span class="info-icon" tabindex="0" role="button" aria-label="Token breakdown info">${'\u24d8'}<span class="info-popup">Cache token breakdown (cache read / cache write) is only available for harnesses that report it natively, such as Claude Code and Copilot CLI. VS Code Copilot chat sessions report a single aggregated input token count and do not break out cached vs. uncached tokens — this is a limitation of the upstream data format, not a bug.</span></span></div><canvas id="creditTokenPie" height=${250}></canvas></div>
+      <h2>Model Token Breakdown</h2>
       <div id="creditModelTable"></div>
-      <h2>Most Expensive Requests</h2>
+      <h2>Top Requests by Token Usage</h2>
       <div id="topRequestsTable"></div>
     `, target);
 
     const { modelEntries } = renderAiCreditsCharts(data);
     renderCreditModelTable(document.getElementById('creditModelTable')!, modelEntries);
     renderTopRequestsTable(document.getElementById('topRequestsTable')!, data);
-
-    // Overlay chart: normalized AI Credits vs Premium Requests (both 0-100% of peak)
-    const cons = await rpc<ConsData>('getConsumption', buildRangeFilter());
-    const useOverlayDaily = activeRangeDays > 0 && activeRangeDays <= 28;
-    const creditSeries = useOverlayDaily ? data.daily : data.weekly;
-    const reqSeries = useOverlayDaily ? cons.daily : cons.weekly;
-    // Align on credit series labels
-    const overlayLabels = creditSeries.labels;
-    const reqValues = overlayLabels.map((label, i) => {
-      const idx = reqSeries.labels.indexOf(label);
-      return idx >= 0 ? reqSeries.values[idx] : (i < reqSeries.values.length ? reqSeries.values[i] : 0);
-    });
-    // Normalize both to percentage of their max
-    const creditMax = Math.max(...creditSeries.credits, 1);
-    const reqMax = Math.max(...reqValues, 1);
-    const creditNorm = creditSeries.credits.map((v: number) => Math.round((v / creditMax) * 1000) / 10);
-    const reqNorm = reqValues.map(v => Math.round((v / reqMax) * 1000) / 10);
-    const granLabel = useOverlayDaily ? 'day' : 'week';
-    createChart('creditVsRequestsChart', 'line', {
-      labels: overlayLabels,
-      datasets: [
-        { label: `AI Credits (peak: ${formatNum(Math.round(creditMax))}/${granLabel})`, data: creditNorm, borderColor: PALETTE[0], backgroundColor: PALETTE[0] + '20', borderWidth: 2, pointRadius: 1, fill: true, tension: 0.3 },
-        { label: `Premium Requests (peak: ${formatNum(Math.round(reqMax))}/${granLabel})`, data: reqNorm, borderColor: PALETTE[3], backgroundColor: PALETTE[3] + '20', borderWidth: 2, pointRadius: 1, fill: true, tension: 0.3 },
-      ],
-    }, {
-      plugins: { legend: { position: 'top' }, tooltip: { callbacks: { label: (ctx: { dataset: { label: string }; raw: number }) => `${ctx.dataset.label}: ${ctx.raw}% of peak` } } },
-      scales: {
-        x: { ticks: { maxTicksLimit: 15 } },
-        y: { beginAtZero: true, max: 100, title: { display: true, text: '% of peak' }, ticks: { callback: (v: number) => v + '%' } },
-      },
-    });
 
     // Wire chart tab switching
     for (const btn of target.querySelectorAll<HTMLButtonElement>('.chart-tab')) {
@@ -724,8 +673,8 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
         const tab = btn.dataset.chartTab;
         const panels = target.querySelectorAll<HTMLElement>('.chart-tab-panel');
         for (const p of panels) p.classList.remove('active');
-        const panelMap: Record<string, string> = { credits: 'chartTabCredits', 'tokens-ws': 'chartTabTokensWs', overlay: 'chartTabOverlay' };
-        document.getElementById(panelMap[tab || 'credits'])!.classList.add('active');
+        const panelMap: Record<string, string> = { tokens: 'chartTabCredits', 'tokens-ws': 'chartTabTokensWs', 'tokens-harness': 'chartTabTokensHarness' };
+        document.getElementById(panelMap[tab || 'tokens'])!.classList.add('active');
       });
     }
   }
@@ -733,8 +682,7 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
 
   async function renderActiveTab(): Promise<void> {
     if (activeTab === 'production') await renderProductionTab();
-    else if (activeTab === 'ai-credits') await renderAiCreditsTab();
-    else await renderConsumptionTab();
+    else await renderTokenUsageTab();
   }
 
   // Initial render — honour the persisted active tab

--- a/src/webview/panel-rpc.ts
+++ b/src/webview/panel-rpc.ts
@@ -63,10 +63,20 @@ export function validateDateFilter(p: Record<string, unknown>): DateFilter | und
 function validateBurndownConfig(raw: unknown): BurndownConfig {
   if (!isRecord(raw)) return { sku: 'pro' };
   const obj = raw;
+  // Validate modelBudgets: must be Record<string, number> with positive values
+  let modelBudgets: Record<string, number> | undefined;
+  if (isRecord(obj.modelBudgets)) {
+    modelBudgets = {};
+    for (const [k, v] of Object.entries(obj.modelBudgets)) {
+      if (isString(k) && isNumber(v) && v > 0) modelBudgets[k] = v;
+    }
+    if (Object.keys(modelBudgets).length === 0) modelBudgets = undefined;
+  }
   return {
     sku: isString(obj.sku) ? obj.sku : 'pro',
     ...(isNumber(obj.customBudget) && { customBudget: obj.customBudget }),
     ...(isString(obj.month) && { month: obj.month }),
+    ...(modelBudgets && { modelBudgets }),
   };
 }
 

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -28,6 +28,7 @@ export class DashboardPanel {
   private readonly panel: vscode.WebviewPanel;
   private readonly extensionUri: vscode.Uri;
   private readonly requestService: PanelRequestService;
+  private readonly globalState: vscode.Memento;
   private readonly disposables: vscode.Disposable[] = [];
 
   private analyzer: Analyzer | undefined;
@@ -38,9 +39,10 @@ export class DashboardPanel {
   private loading = false;
   private loadCompletedAt = 0;
 
-  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, _context: vscode.ExtensionContext) {
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri, context: vscode.ExtensionContext) {
     this.panel = panel;
     this.extensionUri = extensionUri;
+    this.globalState = context.globalState;
     this.requestService = new PanelRequestService(
       this.panel.webview,
       () => this.analyzer,
@@ -262,6 +264,13 @@ export class DashboardPanel {
   private handleMessage(msg: unknown): void {
     if (this.disposed) return;
     if (!isRequestMessage(msg)) return;
+
+    // Budget persistence — handled before data readiness check
+    if (msg.method === 'saveModelBudgets' || msg.method === 'loadModelBudgets') {
+      this.handleBudgetMessage(msg);
+      return;
+    }
+
     if (this.requestService.tryHandle(msg)) return;
 
     if (!this.dataReady || !this.analyzer || !this.parseResult) {
@@ -303,6 +312,21 @@ export class DashboardPanel {
       if (!this.disposed) {
         try { postResponse(this.panel.webview, msg.id, data); } catch { /* disposed */ }
       }
+    }
+  }
+
+  private static readonly BUDGET_STATE_KEY = 'modelBudgets';
+
+  private handleBudgetMessage(msg: Extract<WebviewMessage, { type: 'request' }>): void {
+    if (msg.method === 'saveModelBudgets') {
+      const budgets = (msg.params as Record<string, unknown>)?.budgets;
+      this.globalState.update(DashboardPanel.BUDGET_STATE_KEY, budgets).then(
+        () => { if (!this.disposed) try { postResponse(this.panel.webview, msg.id, { ok: true }); } catch { /* disposed */ } },
+        () => { if (!this.disposed) try { postResponse(this.panel.webview, msg.id, errorResult('Failed to save budgets')); } catch { /* disposed */ } },
+      );
+    } else {
+      const budgets = this.globalState.get<Record<string, number>>(DashboardPanel.BUDGET_STATE_KEY, {});
+      if (!this.disposed) try { postResponse(this.panel.webview, msg.id, budgets); } catch { /* disposed */ }
     }
   }
 

--- a/src/webview/shared.ts
+++ b/src/webview/shared.ts
@@ -322,7 +322,7 @@ export const HARNESS_COLORS: Record<string, string> = {
   'Xcode': '#147EFB',
   'GitHub Copilot CLI': '#6e40c9',
   'Claude': '#d97706',
-  'Claude (via GHCP)': '#fb923c',
+
   'Codex': '#10b981',
   'OpenCode': '#8b5cf6',
 };

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -1704,6 +1704,11 @@ h2 {
   outline-offset: -1px;
 }
 
+.burndown-model-select {
+  min-width: 160px;
+  cursor: pointer;
+}
+
 .month-nav {
   display: flex;
   align-items: center;
@@ -1750,6 +1755,126 @@ h2 {
 .burndown-info.status-bad { border-left: 4px solid var(--accent-red); }
 .burndown-info.status-nodata { border-left: 4px solid var(--text-muted); opacity: 0.85; }
 .burndown-info p { margin-bottom: 6px; }
+
+.model-budget-status { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0; }
+.model-budget-pill { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.8em; font-weight: 500; }
+.model-budget-pill.status-good { background: rgba(63, 185, 80, 0.15); color: #3fb950; }
+.model-budget-pill.status-warn { background: rgba(210, 153, 34, 0.15); color: #d29922; }
+.model-budget-pill.status-bad { background: rgba(248, 81, 73, 0.15); color: #f85149; }
+
+/* ---- Token Budget tab ---- */
+.budget-header { margin-bottom: 16px; }
+
+.budget-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 14px;
+}
+
+.budget-autofill-btn {
+  background: color-mix(in srgb, var(--accent-blue) 15%, var(--surface)) !important;
+  border-color: color-mix(in srgb, var(--accent-blue) 50%, transparent) !important;
+  color: var(--accent-blue) !important;
+}
+.budget-autofill-btn:hover {
+  background: color-mix(in srgb, var(--accent-blue) 25%, var(--surface)) !important;
+}
+
+.budget-clear-btn {
+  background: transparent !important;
+  border-color: color-mix(in srgb, var(--text-muted) 40%, transparent) !important;
+  color: var(--text-muted) !important;
+}
+.budget-clear-btn:hover {
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent) !important;
+  color: var(--text) !important;
+}
+
+.budget-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin: 0 0 14px 0;
+}
+.budget-hint strong { color: var(--text); }
+
+.budget-table .rate-col { text-align: center; }
+.budget-col { text-align: right; }
+.budget-usage-col { text-align: right; width: 180px; }
+
+.budget-model-name {
+  font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
+  font-size: 12px;
+}
+
+.budget-usage-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+.budget-usage-value {
+  font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.budget-usage-bar {
+  width: 100%;
+  height: 3px;
+  background: color-mix(in srgb, var(--text-muted) 12%, transparent);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.budget-usage-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.budget-loading {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.rate-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+  border-radius: 4px;
+}
+
+.budget-input {
+  width: 100px;
+  padding: 4px 8px;
+  font-size: 13px;
+  font-family: var(--font-mono, 'Consolas', 'Courier New', monospace);
+  color: var(--text);
+  background: var(--input-bg, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--text-muted) 30%, transparent);
+  border-radius: 4px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  text-align: right;
+}
+.budget-input:focus {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 20%, transparent);
+}
+.budget-input::placeholder { color: var(--text-muted); opacity: 0.5; }
+
+.budget-row-active {
+  background: color-mix(in srgb, var(--accent-blue) 5%, transparent) !important;
+}
+.budget-row-active .budget-model-name {
+  color: var(--accent-blue);
+  font-weight: 600;
+}
 
 /* ---- Missing-data badge (replaces deprecated .est-badge) ---- */
 .missing-badge {


### PR DESCRIPTION
This pull request simplifies and unifies the handling of Claude harnesses in AI credit and consumption analytics. It removes the special-casing for "Claude (via GHCP)" and the concept of "delegated" requests, treating all Claude sessions under the single "Claude" harness. The codebase is streamlined by removing related constants, logic, and fields, and by updating tests for this new convention. Additionally, the analytics now provide a new per-harness daily token breakdown.