### PR TITLE
feat: viral share card with social buttons and streak fix

### DIFF
--- a/src/core/types/rpc-types.ts
+++ b/src/core/types/rpc-types.ts
@@ -116,6 +116,7 @@ export interface RpcMethodMap {
 export type RpcMethodName = keyof RpcMethodMap;
 
 export interface ExtensionMethodMap extends RpcMethodMap {
+  openExternal: { params: { url: string }; result: { ok: boolean } };
   createSkill: { params: { prompt: string }; result: { ok: boolean } };
   generateSkillContent: { params: Record<string, unknown>; result: { content: string; filename: string } };
   generateLearningQuiz: { params: Record<string, unknown>; result: { questions: unknown[] } };

--- a/src/webview/page-peers.ts
+++ b/src/webview/page-peers.ts
@@ -10,9 +10,50 @@ import { rpc, formatNum } from './shared';
 import { html, render, LoadingScreen } from './render';
 import { SVG } from './svg-icons';
 
+const REPO_URL = 'https://github.com/microsoft/AI-Engineering-Coach';
+
+/* ── Share Context ─────────────────────────────────────────────────── */
+
+interface ShareContext {
+  totalSessions: number;
+  totalRequests: number;
+  currentStreak: number;
+  bestStreak: number;
+  flowScore: number;
+  antiPatternCount: number;
+  topLanguages: string[];
+  activeDays: number;
+  totalLoc: number;
+}
+
+/* ── Social Share URLs ────────────────────────────────────────────── */
+
+function getShareText(data: ShareContext): string {
+  return `My AI coding stats: ${formatNum(data.totalLoc)} lines of code, ${data.currentStreak}-day streak, Flow Score ${data.flowScore}. Track yours with AI Engineer Coach 👇\n\n${REPO_URL}`;
+}
+
+function getTwitterShareUrl(data: ShareContext): string {
+  const text = getShareText(data);
+  return `https://x.com/intent/tweet?text=${encodeURIComponent(text)}`;
+}
+
+function getLinkedInShareUrl(data: ShareContext): string {
+  const text = `My AI coding stats:\n🔥 ${data.currentStreak}-day streak\n💻 ${formatNum(data.totalLoc)} AI lines of code\n⚡ Flow Score ${data.flowScore}\n\nTrack yours → ${REPO_URL}\n\n#AI #CodingStats #GitHub #Copilot`;
+  return `https://www.linkedin.com/feed/?shareActive=true&text=${encodeURIComponent(text)}`;
+}
+
+function getRedditShareUrl(data: ShareContext): string {
+  const title = `My AI coding stats: ${formatNum(data.totalLoc)} lines, ${data.currentStreak}-day streak (AI Engineer Coach)`;
+  return `https://www.reddit.com/submit?url=${encodeURIComponent(REPO_URL)}&title=${encodeURIComponent(title)}`;
+}
+
+function getHNShareUrl(): string {
+  return `https://news.ycombinator.com/submitlink?u=${encodeURIComponent(REPO_URL)}&t=${encodeURIComponent('AI Engineer Coach - Local analytics for AI coding sessions')}`;
+}
+
 /* ── Canvas Card Renderer ─────────────────────────────────────────── */
 
-function drawShareCard(canvas: HTMLCanvasElement, data: {
+interface CardData {
   totalLoc: number;
   totalSessions: number;
   totalRequests: number;
@@ -22,17 +63,21 @@ function drawShareCard(canvas: HTMLCanvasElement, data: {
   topLanguages: string[];
   activeDays: number;
   firstDay: string;
-}): void {
+  antiPatternCount: number;
+  dailyQuality: { labels: string[]; values: number[] };
+}
+
+function drawShareCard(canvas: HTMLCanvasElement, data: CardData): void {
   const W = 600;
-  const H = 340;
-  canvas.width = W * 2;  // 2x for retina
+  const H = 280;
+  canvas.width = W * 2;
   canvas.height = H * 2;
   canvas.style.width = `${W}px`;
   canvas.style.height = `${H}px`;
   const ctx = canvas.getContext('2d')!;
   ctx.scale(2, 2);
 
-  // Background gradient
+  // Background
   const bg = ctx.createLinearGradient(0, 0, W, H);
   bg.addColorStop(0, '#0d1117');
   bg.addColorStop(1, '#161b22');
@@ -46,45 +91,51 @@ function drawShareCard(canvas: HTMLCanvasElement, data: {
   roundRect(ctx, 0.5, 0.5, W - 1, H - 1, 16);
   ctx.stroke();
 
-  // Accent bar at top
+  // Accent bar
   const accent = ctx.createLinearGradient(0, 0, W, 0);
   accent.addColorStop(0, '#58a6ff');
   accent.addColorStop(0.5, '#3fb950');
   accent.addColorStop(1, '#bc8cff');
   ctx.fillStyle = accent;
-  ctx.fillRect(24, 0, W - 48, 3);
+  ctx.fillRect(24, 0, W - 48, 4);
 
   // Title
   ctx.fillStyle = '#e6edf3';
-  ctx.font = 'bold 18px -apple-system, BlinkMacSystemFont, sans-serif';
-  ctx.fillText('GitHub Copilot Stats', 28, 36);
+  ctx.font = 'bold 20px -apple-system, BlinkMacSystemFont, sans-serif';
+  ctx.fillText('Agentic Engineering Stats', 28, 36);
+
+  // Streak badge (if >= 7 days)
+  if (data.currentStreak >= 7) {
+    const titleW = ctx.measureText('Agentic Engineering Stats').width;
+    const streakText = `\u{1F525} ${data.currentStreak}d`;
+    const streakColor = data.currentStreak >= 100 ? '#ff4500' : data.currentStreak >= 30 ? '#f85149' : '#d29922';
+    ctx.fillStyle = streakColor + '20';
+    const stw = ctx.measureText(streakText).width + 12;
+    roundRect(ctx, 28 + titleW + 10, 22, stw, 20, 10);
+    ctx.fill();
+    ctx.fillStyle = streakColor;
+    ctx.font = 'bold 12px -apple-system, BlinkMacSystemFont, sans-serif';
+    ctx.fillText(streakText, 28 + titleW + 16, 36);
+  }
 
   // Subtitle
   ctx.fillStyle = '#8b949e';
   ctx.font = '12px -apple-system, BlinkMacSystemFont, sans-serif';
   ctx.fillText(`Since ${data.firstDay} \u00b7 ${data.activeDays} active days`, 28, 56);
 
-  // Divider
-  ctx.strokeStyle = '#21262d';
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(28, 68);
-  ctx.lineTo(W - 28, 68);
-  ctx.stroke();
-
-  // Stats grid (2 rows x 3 cols)
+  // Stats grid — 2 rows x 3 cols (no duplicate streak)
   const stats = [
     { label: 'AI Lines of Code', value: formatNum(data.totalLoc), color: '#3fb950' },
-    { label: 'Current Streak', value: `${data.currentStreak}d`, color: '#d29922' },
-    { label: 'Flow Score', value: String(data.flowScore), color: '#58a6ff' },
     { label: 'Sessions', value: formatNum(data.totalSessions), color: '#e6edf3' },
-    { label: 'Best Streak', value: `${data.bestStreak}d`, color: '#d29922' },
+    { label: 'Flow Score', value: String(data.flowScore), color: '#58a6ff' },
     { label: 'Requests', value: formatNum(data.totalRequests), color: '#bc8cff' },
+    { label: 'Best Streak', value: `${data.bestStreak}d`, color: '#d29922' },
+    { label: 'Active Days', value: String(data.activeDays), color: '#8b949e' },
   ];
 
   const colW = (W - 56) / 3;
-  const rowH = 64;
-  const startY = 88;
+  const rowH = 56;
+  const startY = 72;
 
   for (const [i, s] of stats.entries()) {
     const col = i % 3;
@@ -94,47 +145,47 @@ function drawShareCard(canvas: HTMLCanvasElement, data: {
 
     ctx.fillStyle = s.color;
     ctx.font = 'bold 26px -apple-system, BlinkMacSystemFont, sans-serif';
-    ctx.fillText(s.value, x, y + 24);
+    ctx.fillText(s.value, x, y + 22);
 
     ctx.fillStyle = '#8b949e';
     ctx.font = '11px -apple-system, BlinkMacSystemFont, sans-serif';
-    ctx.fillText(s.label, x, y + 42);
+    ctx.fillText(s.label, x, y + 38);
   }
 
-  // Divider before languages
-  const langY = startY + 2 * rowH + 10;
-  ctx.strokeStyle = '#21262d';
-  ctx.beginPath();
-  ctx.moveTo(28, langY);
-  ctx.lineTo(W - 28, langY);
-  ctx.stroke();
-
-  // Top languages as pills
+  // Languages
+  const langY = startY + 2 * rowH + 8;
   ctx.fillStyle = '#8b949e';
   ctx.font = '11px -apple-system, BlinkMacSystemFont, sans-serif';
-  ctx.fillText('Top Languages', 28, langY + 22);
+  ctx.fillText('Top Languages', 28, langY + 14);
 
-  let pillX = 130;
+  let pillX = 126;
   const langColors = ['#58a6ff', '#3fb950', '#d29922', '#bc8cff', '#f85149'];
   for (const [i, lang] of data.topLanguages.slice(0, 5).entries()) {
-    const tw = ctx.measureText(lang).width + 16;
-    ctx.fillStyle = langColors[i % langColors.length] + '20';
-    roundRect(ctx, pillX, langY + 8, tw, 22, 11);
+    const tw = ctx.measureText(lang).width + 14;
+    ctx.fillStyle = langColors[i % langColors.length] + '22';
+    roundRect(ctx, pillX, langY + 2, tw, 20, 10);
     ctx.fill();
     ctx.fillStyle = langColors[i % langColors.length];
-    ctx.font = '11px -apple-system, BlinkMacSystemFont, sans-serif';
-    ctx.fillText(lang, pillX + 8, langY + 23);
-    pillX += tw + 6;
+    ctx.font = 'bold 10px -apple-system, BlinkMacSystemFont, sans-serif';
+    ctx.fillText(lang, pillX + 7, langY + 15);
+    pillX += tw + 5;
   }
 
   // Footer
   ctx.fillStyle = '#484f58';
   ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
-  ctx.fillText('ai-engineer-coach', 28, H - 16);
+  ctx.fillText('ai-engineer-coach', 28, H - 14);
 
   const dateStr = new Date().toISOString().slice(0, 10);
   const dateW = ctx.measureText(dateStr).width;
-  ctx.fillText(dateStr, W - 28 - dateW, H - 16);
+  ctx.fillText(dateStr, W - 28 - dateW, H - 14);
+
+  // Repo URL centered
+  ctx.fillStyle = '#58a6ff';
+  ctx.font = '10px -apple-system, BlinkMacSystemFont, sans-serif';
+  const repoShort = 'github.com/microsoft/AI-Engineering-Coach';
+  const repoW = ctx.measureText(repoShort).width;
+  ctx.fillText(repoShort, (W - repoW) / 2, H - 14);
 }
 
 function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
@@ -151,60 +202,86 @@ function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: numbe
   ctx.closePath();
 }
 
+/* ── Current Streak (Fixed) ───────────────────────────────────────── */
+
+function computeCurrentStreak(labels: string[], values: number[]): number {
+  // Walk backwards from today, only count consecutive CALENDAR days with activity
+  let streak = 0;
+  for (let i = labels.length - 1; i >= 0; i--) {
+    if (values[i] <= 0) break;
+    // Check calendar day consecutiveness
+    if (i < labels.length - 1) {
+      const curr = new Date(labels[i] + 'T00:00:00');
+      const next = new Date(labels[i + 1] + 'T00:00:00');
+      const gap = Math.round((next.getTime() - curr.getTime()) / 86400000);
+      if (gap !== 1) break;
+    }
+    streak++;
+  }
+  return streak;
+}
+
 /* ── Main Render ──────────────────────────────────────────────────── */
 
 export async function renderShareCard(container: HTMLElement, filter: DateFilter): Promise<void> {
   render(html`<${LoadingScreen} message="Generating share card..." />`, container);
 
-  const [stats, production, balance, flowState, codeByLang, dailyActivity] = await Promise.all([
+  const [stats, production, balance, flowState, codeByLang, dailyActivity, antiPatterns] = await Promise.all([
     rpc<{ totalSessions: number; totalRequests: number }>('getStats', filter as Record<string, unknown>),
     rpc<{ summary: { totalAiLoc: number } }>('getCodeProduction', filter as Record<string, unknown>),
     rpc<{ maxStreak: number } | null>('getWorkLifeBalance', filter as Record<string, unknown>),
     rpc<{ overallFlowScore: number }>('getFlowState', filter as Record<string, unknown>),
     rpc<{ byLanguage: { labels: string[] } }>('getCodeProduction', filter as Record<string, unknown>),
     rpc<{ labels: string[]; values: number[] }>('getDailyActivity', filter as Record<string, unknown>),
+    rpc<{ patterns: { id: string }[] }>('getAntiPatterns', filter as Record<string, unknown>),
   ]);
 
-  // Current streak
-  let currentStreak = 0;
-  for (let i = dailyActivity.labels.length - 1; i >= 0; i--) {
-    if (dailyActivity.values[i] > 0) currentStreak++;
-    else break;
-  }
+  // Fixed: compute current streak using calendar-day consecutiveness
+  const currentStreak = computeCurrentStreak(dailyActivity.labels, dailyActivity.values);
+  const bestStreak = balance?.maxStreak ?? 0;
 
   const activeDays = dailyActivity.values.filter(v => v > 0).length;
   const firstDay = dailyActivity.labels[0] ?? 'Unknown';
+  const antiPatternCount = antiPatterns?.patterns?.length ?? 0;
 
-  const cardData = {
+  // Deduplicate languages (e.g., "py" and "python")
+  const langDedup = deduplicateLanguages(codeByLang.byLanguage.labels);
+
+  const cardData: CardData = {
     totalLoc: production.summary.totalAiLoc,
     totalSessions: stats.totalSessions,
     totalRequests: stats.totalRequests,
     currentStreak,
-    bestStreak: balance?.maxStreak ?? 0,
+    bestStreak: Math.max(bestStreak, currentStreak),
     flowScore: flowState.overallFlowScore,
-    topLanguages: codeByLang.byLanguage.labels.slice(0, 5),
+    topLanguages: langDedup.slice(0, 5),
     activeDays,
     firstDay,
+    antiPatternCount,
+    dailyQuality: { labels: [], values: [] },
+  };
+
+  const shareCtx: ShareContext = {
+    ...cardData,
+    antiPatternCount,
   };
 
   render(html`
     <div class="share-page">
-      <div class="share-hero">
-        <div class="share-hero-icon">${SVG.share}</div>
-        <div>
-          <h2 class="share-hero-title">Share Your Stats</h2>
-          <p class="share-hero-sub">Generate a card with your AI coding stats to share with your team.</p>
-        </div>
-      </div>
-
       <div class="share-card-wrap">
         <canvas id="share-card-canvas"></canvas>
       </div>
 
       <div class="share-actions">
         <button class="btn btn-primary" id="share-download-btn">${SVG.share} Download PNG</button>
-        <button class="btn btn-secondary" id="share-copy-btn">${SVG.clipboard} Copy to Clipboard</button>
-        <button class="btn btn-secondary" id="share-refresh-btn">${SVG.refresh} Refresh</button>
+        <button class="btn btn-secondary" id="share-copy-btn">${SVG.clipboard} Copy</button>
+      </div>
+
+      <div class="share-social">
+        <button class="btn-social btn-social-x" id="share-x">𝕏 Post</button>
+        <button class="btn-social btn-social-linkedin" id="share-linkedin">in LinkedIn</button>
+        <button class="btn-social btn-social-reddit" id="share-reddit">Reddit</button>
+        <button class="btn-social btn-social-hn" id="share-hn">Y Hacker News</button>
       </div>
 
       <div class="share-hint" id="share-toast" style="display:none"></div>
@@ -213,9 +290,7 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
 
   // Draw the card
   const canvas = document.getElementById('share-card-canvas') as HTMLCanvasElement;
-  if (canvas) {
-    drawShareCard(canvas, cardData);
-  }
+  drawShareCard(canvas, cardData);
 
   // Download handler
   document.getElementById('share-download-btn')?.addEventListener('click', () => {
@@ -224,7 +299,7 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
     link.download = `copilot-stats-${new Date().toISOString().slice(0, 10)}.png`;
     link.href = canvas.toDataURL('image/png');
     link.click();
-    showToast('Image downloaded');
+    showToast('Downloaded! Now share it.');
   });
 
   // Copy to clipboard handler
@@ -236,17 +311,58 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
           canvas.toBlob(b => resolve(b!), 'image/png');
         });
         await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-        showToast('Copied to clipboard');
+        showToast('Copied! Paste it anywhere.');
       } catch {
-        showToast('Copy failed \u2014 try downloading instead');
+        showToast('Copy failed — try downloading instead');
       }
     })();
   });
 
-  // Refresh handler
-  document.getElementById('share-refresh-btn')?.addEventListener('click', () => {
-    void renderShareCard(container, filter);
+  // Social share handlers — use rpc to open externally (window.open doesn't work in webviews)
+  const openUrl = (url: string) => { void rpc('openExternal', { url }); };
+  document.getElementById('share-x')?.addEventListener('click', () => openUrl(getTwitterShareUrl(shareCtx)));
+  document.getElementById('share-linkedin')?.addEventListener('click', () => {
+    // Copy image to clipboard first so user can paste it in LinkedIn
+    void (async () => {
+      try {
+        const blob = await new Promise<Blob>((resolve) => {
+          canvas.toBlob(b => resolve(b!), 'image/png');
+        });
+        await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+        showToast('Image copied! Paste it in your LinkedIn post.');
+      } catch { /* ignore clipboard errors */ }
+      openUrl(getLinkedInShareUrl(shareCtx));
+    })();
   });
+  document.getElementById('share-reddit')?.addEventListener('click', () => openUrl(getRedditShareUrl(shareCtx)));
+  document.getElementById('share-hn')?.addEventListener('click', () => openUrl(getHNShareUrl()));
+}
+
+/* ── Language Deduplication ────────────────────────────────────────── */
+
+function deduplicateLanguages(langs: string[]): string[] {
+  const aliases: Record<string, string> = {
+    py: 'python',
+    ts: 'typescript',
+    js: 'javascript',
+    rb: 'ruby',
+    rs: 'rust',
+    cs: 'csharp',
+    sh: 'shell',
+    bash: 'shell',
+    zsh: 'shell',
+    yml: 'yaml',
+  };
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const lang of langs) {
+    const normalized = aliases[lang.toLowerCase()] ?? lang.toLowerCase();
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(lang);
+    }
+  }
+  return result;
 }
 
 function showToast(msg: string): void {

--- a/src/webview/page-peers.ts
+++ b/src/webview/page-peers.ts
@@ -205,15 +205,28 @@ function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: numbe
 /* ── Current Streak (Fixed) ───────────────────────────────────────── */
 
 function computeCurrentStreak(labels: string[], values: number[]): number {
+  if (labels.length === 0 || values.length === 0) return 0;
+
+  const toUtcDay = (label: string): number => {
+    const [year, month, day] = label.split('-').map(Number);
+    return Date.UTC(year, month - 1, day);
+  };
+
+  const today = new Date();
+  const todayUtcDay = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  const lastActivityUtcDay = toUtcDay(labels[labels.length - 1]);
+  const gapFromToday = Math.round((todayUtcDay - lastActivityUtcDay) / 86400000);
+  if (gapFromToday > 1) return 0;
+
   // Walk backwards from today, only count consecutive CALENDAR days with activity
   let streak = 0;
   for (let i = labels.length - 1; i >= 0; i--) {
     if (values[i] <= 0) break;
     // Check calendar day consecutiveness
     if (i < labels.length - 1) {
-      const curr = new Date(labels[i] + 'T00:00:00');
-      const next = new Date(labels[i + 1] + 'T00:00:00');
-      const gap = Math.round((next.getTime() - curr.getTime()) / 86400000);
+      const curr = toUtcDay(labels[i]);
+      const next = toUtcDay(labels[i + 1]);
+      const gap = Math.round((next - curr) / 86400000);
       if (gap !== 1) break;
     }
     streak++;

--- a/src/webview/page-peers.ts
+++ b/src/webview/page-peers.ts
@@ -309,7 +309,7 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
   document.getElementById('share-download-btn')?.addEventListener('click', () => {
     if (!canvas) return;
     const link = document.createElement('a');
-    link.download = `copilot-stats-${new Date().toISOString().slice(0, 10)}.png`;
+    link.download = `agentic-engineering-stats-${new Date().toISOString().slice(0, 10)}.png`;
     link.href = canvas.toDataURL('image/png');
     link.click();
     showToast('Downloaded! Now share it.');

--- a/src/webview/page-peers.ts
+++ b/src/webview/page-peers.ts
@@ -332,7 +332,11 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
   });
 
   // Social share handlers — use rpc to open externally (window.open doesn't work in webviews)
-  const openUrl = (url: string) => { void rpc('openExternal', { url }); };
+  const openUrl = (url: string) => {
+    void rpc('openExternal', { url }).catch(() => {
+      showToast('Unable to open link right now.');
+    });
+  };
   document.getElementById('share-x')?.addEventListener('click', () => openUrl(getTwitterShareUrl(shareCtx)));
   document.getElementById('share-linkedin')?.addEventListener('click', () => {
     // Copy image to clipboard first so user can paste it in LinkedIn

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -265,6 +265,16 @@ export class DashboardPanel {
     if (this.disposed) return;
     if (!isRequestMessage(msg)) return;
 
+    // Open external URLs from webview
+    if (msg.method === 'openExternal') {
+      const url = (msg.params as Record<string, unknown> | undefined)?.url;
+      if (typeof url === 'string') {
+        void vscode.env.openExternal(vscode.Uri.parse(url));
+        postResponse(this.panel.webview, msg.id, { ok: true });
+      }
+      return;
+    }
+
     // Budget persistence — handled before data readiness check
     if (msg.method === 'saveModelBudgets' || msg.method === 'loadModelBudgets') {
       this.handleBudgetMessage(msg);

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -266,7 +266,7 @@ export class DashboardPanel {
     if (!isRequestMessage(msg)) return;
 
     // Open external URLs from webview
-    if ((msg.method as string) === 'openExternal') {
+    if (msg.method === 'openExternal') {
       const url = (msg.params as Record<string, unknown> | undefined)?.url;
       if (typeof url === 'string') {
         void vscode.env.openExternal(vscode.Uri.parse(url));

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -266,7 +266,7 @@ export class DashboardPanel {
     if (!isRequestMessage(msg)) return;
 
     // Open external URLs from webview
-    if (msg.method === 'openExternal') {
+    if ((msg.method as string) === 'openExternal') {
       const url = (msg.params as Record<string, unknown> | undefined)?.url;
       if (typeof url === 'string') {
         void vscode.env.openExternal(vscode.Uri.parse(url));

--- a/src/webview/styles-pages.css
+++ b/src/webview/styles-pages.css
@@ -331,6 +331,48 @@
   margin-bottom: 16px;
 }
 
+
+.share-social {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.share-social-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.btn-social {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--card-bg);
+  color: var(--text-primary);
+  transition: all 0.15s ease;
+}
+
+.btn-social:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.btn-social-x { border-color: #536471; }
+.btn-social-x:hover { background: #1d9bf0; color: #fff; border-color: #1d9bf0; }
+.btn-social-linkedin { border-color: #0a66c2; }
+.btn-social-linkedin:hover { background: #0a66c2; color: #fff; }
+.btn-social-reddit { border-color: #ff4500; }
+.btn-social-reddit:hover { background: #ff4500; color: #fff; }
+.btn-social-hn { border-color: #ff6600; }
+.btn-social-hn:hover { background: #ff6600; color: #fff; }
+
 .share-hint {
   text-align: center;
   font-size: 12px;


### PR DESCRIPTION
## Summary

Redesigns the Share Card page into a clean, viral-optimized PNG card with social sharing buttons.

## Changes

### Share Card (page-peers.ts)
- **Renamed** card title from "GitHub Copilot Stats" to "Agentic Engineering Stats"
- **Fixed streak calculation** — `computeCurrentStreak()` now walks backwards checking calendar-day gaps instead of counting all trailing non-zero days
- **Fixed language dedup** — "py"/"python", "ts"/"typescript" etc. no longer show as separate entries
- **Added streak badge** — fire emoji pill next to title when streak >= 7 days (color scales with streak length)
- **Added social share buttons** — X, LinkedIn, Reddit, Hacker News with `vscode.env.openExternal`
- **LinkedIn flow** — auto-copies PNG to clipboard before opening LinkedIn composer with pre-filled text
- **Removed** roast feature, milestones, activity sparkline, hero header — stripped to essentials for max virality
- **Guard** for bestStreak < currentStreak edge case

### Webview Panel (panel.ts)
- Added `openExternal` RPC handler since `window.open()` is blocked in VS Code webviews

### Styles (styles-pages.css)
- Added social button styles (platform-specific colors and hover states)
- Removed unused `.btn-roast` styles