### PR TITLE
Fix install instructions repository directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ AI Engineer Coach reads your local AI session logs and turns them into actionabl
 
 ```bash
 git clone https://github.com/microsoft/ai-engineering-coach.git
-cd ai-engineer-coach
+cd ai-engineering-coach
 npm install
 npm run package
 ```

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -11,8 +11,8 @@ The extension is not yet published on the VS Code Marketplace. Install it by bui
 ## Package from Source
 
 ```bash
-git clone https://github.com/microsoft/ai-engineer-coach.git
-cd ai-engineer-coach
+git clone https://github.com/microsoft/ai-engineering-coach.git
+cd ai-engineering-coach
 npm install
 npm run package
 ```


### PR DESCRIPTION
## Summary
- Fixed the Quick Start install path so the `cd` command matches the directory created by `git clone`.
- Updated the installation docs to use the same repository URL and checkout directory.

## Files changed
- `README.md`
- `docs/content/getting-started/installation.md`

## Validation
- Ran `git diff --check`.
- Confirmed the clone URL and `cd` commands are consistent.
- Left `ai-engineer-coach-*.vsix` unchanged because it is the package artifact pattern.

Documentation-only change.