### PR TITLE
fix(security): escape harness names to prevent XSS in sidebar

### DIFF
--- a/src/webview/panel-shared.test.ts
+++ b/src/webview/panel-shared.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, it, expect } from 'vitest';
+import { escapeHtmlAttr } from './panel-shared';
+
+describe('escapeHtmlAttr', () => {
+  it('escapes all HTML-special characters', () => {
+    expect(escapeHtmlAttr('<script>alert("xss")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;'
+    );
+  });
+
+  it('escapes ampersands', () => {
+    expect(escapeHtmlAttr('foo & bar')).toBe('foo &amp; bar');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapeHtmlAttr("it's")).toBe('it&#39;s');
+  });
+
+  it('leaves safe strings unchanged', () => {
+    expect(escapeHtmlAttr('VS Code')).toBe('VS Code');
+    expect(escapeHtmlAttr('Claude')).toBe('Claude');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeHtmlAttr('')).toBe('');
+  });
+});

--- a/src/webview/panel-shared.ts
+++ b/src/webview/panel-shared.ts
@@ -54,3 +54,13 @@ export function postEvent(webview: vscode.Webview, method: string, data: unknown
 export function getNonce(): string {
   return crypto.randomBytes(16).toString('base64url');
 }
+
+/** Escape HTML special characters to prevent XSS when interpolating into templates. */
+export function escapeHtmlAttr(s: string): string {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}

--- a/src/webview/panel-sidebar.ts
+++ b/src/webview/panel-sidebar.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { loadSidebarStats } from '../core/cache';
-import { getNonce } from './panel-shared';
+import { getNonce, escapeHtmlAttr } from './panel-shared';
 
 export class DashboardSidebarProvider implements vscode.WebviewViewProvider {
   public static instance: DashboardSidebarProvider | undefined;
@@ -45,7 +45,7 @@ export class DashboardSidebarProvider implements vscode.WebviewViewProvider {
       ? `
       <div class="sidebar-card">
         <p class="sidebar-label">Detected harnesses</p>
-        <p class="sidebar-harnesses">${stats.harnesses.join(' · ')}</p>
+        <p class="sidebar-harnesses">${stats.harnesses.map(h => escapeHtmlAttr(h)).join(' \u00b7 ')}</p>
         <p class="sidebar-note">Last synced ${new Date(stats.savedAt).toLocaleString()}</p>
       </div>`
       : `


### PR DESCRIPTION
## Summary

Fixes a stored XSS vulnerability in the sidebar webview where harness names from the on-disk cache were interpolated directly into HTML without escaping.

## Changes

- **`src/webview/panel-shared.ts`** — Added `escapeHtmlAttr()` helper that escapes `& < > " '`
- **`src/webview/panel-sidebar.ts`** — Applied escaping: `stats.harnesses.map(h => escapeHtmlAttr(h)).join(' · ')`
- **`src/webview/panel-shared.test.ts`** — 5 unit tests covering XSS payloads, safe strings, and edge cases

## Security

- **OWASP:** A03:2021 – Injection
- **Vector:** Tampered cache file could inject `<script>` tags via harness names
- **Breaking change:** No — legitimate harness names contain no HTML special characters

## Validation

- ✅ All 991 unit tests pass
- ✅ TypeScript compiles cleanly (`tsc --noEmit`)
- ✅ New tests specifically verify XSS payloads are escaped

## Linked Issues

Fixes #19
Closes #18 (duplicate)