### PR TITLE
fix(esbuild): rebuild CSS bundle on change in watch mode

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -100,10 +100,15 @@ const cssSources = [
   'src/webview/styles-skills.css',
   'src/webview/styles-learning.css',
 ];
-const bundledCss = cssSources
-  .map(source => fs.readFileSync(source, 'utf-8').trimEnd())
-  .join('\n\n');
-fs.writeFileSync(path.join(webviewDist, 'styles.css'), `${bundledCss}\n`);
+
+function bundleCss() {
+  const bundledCss = cssSources
+    .map(source => fs.readFileSync(source, 'utf-8').trimEnd())
+    .join('\n\n');
+  fs.writeFileSync(path.join(webviewDist, 'styles.css'), `${bundledCss}\n`);
+}
+
+bundleCss();
 
 console.log('Build complete.');
 
@@ -158,5 +163,15 @@ if (isWatch) {
     sourcemap: true,
   });
   await Promise.all([ctx1.watch(), ctx2.watch(), ctx3.watch(), ctx4.watch(), ctx5.watch()]);
+  for (const source of cssSources) {
+    fs.watch(source, () => {
+      try {
+        bundleCss();
+        console.log(`CSS rebuilt (${source} changed)`);
+      } catch (err) {
+        console.error('CSS rebuild failed:', err);
+      }
+    });
+  }
   console.log('Watching for changes...');
 }


### PR DESCRIPTION
## Summary
Fixes #20. `npm run watch` now rebuilds `dist/webview/styles.css` when any of the source CSS files change.

## Root cause
The CSS bundling block at `esbuild.mjs:97–106` ran once at module load — it was not covered by an `esbuild.context()` or `fs.watch` inside the `--watch` branch, so changes to source CSS were never observed.

## Change
- Extract the existing read-concat-write into a `bundleCss()` function. No behavioral change for `npm run build`.
- In `--watch` mode, register a `fs.watch` per CSS source. On change events the callback re-runs `bundleCss()` and logs which file triggered the rebuild.
- No new dependencies. JS esbuild contexts untouched.

## Verification (local, macOS)
1. `npm run watch`
2. Edit any of the 4 source CSS files
3. `dist/webview/styles.css` is rewritten (verified via mtime)
4. `npm run build` produces the same output as before (unchanged code path)