### PR TITLE
docs: add AGENTS.md worker and trust flow notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,31 @@
 ## Local Rule Trust Flow
 
 Rules move pending→review→approve→reload; edits revoke trust. See [anti-patterns](docs/content/improve/anti-patterns.md) and [rule editor](docs/content/improve/rule-editor.md).
+
+## Documentation Index
+
+This is a quick map of the docs tree so readers and agents can see the available pages at a glance.
+
+- [Features](/features/)
+- [Getting Started](/getting-started/)
+  - [Installation](/getting-started/installation/)
+  - [Supported Tools](/getting-started/supported-tools/)
+- [Improve](/improve/)
+  - [Anti-Patterns](/improve/anti-patterns/)
+  - [Context Health](/improve/context-health/)
+  - [Data Explorer](/improve/data-explorer/)
+  - [Rule Editor](/improve/rule-editor/)
+  - [Rule Playground](/improve/rule-playground/)
+  - [Skill Finder](/improve/skill-finder/)
+- [Level Up](/level-up/)
+  - [Achievements](/level-up/achievements/)
+  - [Learning Center](/level-up/learning/)
+  - [Agentic SDLC](/level-up/sdlc/)
+  - [Share](/level-up/share/)
+- [Measure](/measure/)
+  - [Burndown](/measure/burndown/)
+  - [Output](/measure/output/)
+  - [Activity Patterns](/measure/patterns/)
+- [Observe](/observe/)
+  - [Dashboard](/observe/dashboard/)
+  - [Timeline](/observe/timeline/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Workers
+
+- [warm-up-worker.ts](src/core/warm-up-worker.ts): `sessions` -> `antiPatterns` + `configHealth`.
+- [parse-worker.ts](src/core/parse-worker.ts): `logsDirs` -> `progress` + `result`/`error`.
+- [cache-write-worker.ts](src/core/cache-write-worker.ts): writes cache payload.
+
+## Local Rule Trust Flow
+
+Rules move pending→review→approve→reload; edits revoke trust. See [anti-patterns](docs/content/improve/anti-patterns.md) and [rule editor](docs/content/improve/rule-editor.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Workers
+## Workers
 
 - [warm-up-worker.ts](src/core/warm-up-worker.ts): `sessions` -> `antiPatterns` + `configHealth`.
 - [parse-worker.ts](src/core/parse-worker.ts): `logsDirs` -> `progress` + `result`/`error`.

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -26,31 +26,3 @@ AI Engineer Coach runs as a VS Code extension. On activation, it scans your loca
 ## Editable Rule Engine
 
 Anti-pattern detection is driven by an editable rule engine. Each detector is a markdown file with YAML frontmatter and a small DSL that you can inspect, tune, and extend. The [Rule Editor](/improve/rule-editor/) lets you live-test changes against your own data, and an AI builder can scaffold new rules from a natural-language description. The [Rule Playground](/improve/rule-playground/) is an interactive REPL for the DSL, and the [Data Explorer](/improve/data-explorer/) shows every field and distribution the rules can key off.
-
-## Documentation Index
-
-This is a quick map of the docs tree so readers and agents can see the available pages at a glance.
-
-- [Features](/features/)
-- [Getting Started](/getting-started/)
-  - [Installation](/getting-started/installation/)
-  - [Supported Tools](/getting-started/supported-tools/)
-- [Improve](/improve/)
-  - [Anti-Patterns](/improve/anti-patterns/)
-  - [Context Health](/improve/context-health/)
-  - [Data Explorer](/improve/data-explorer/)
-  - [Rule Editor](/improve/rule-editor/)
-  - [Rule Playground](/improve/rule-playground/)
-  - [Skill Finder](/improve/skill-finder/)
-- [Level Up](/level-up/)
-  - [Achievements](/level-up/achievements/)
-  - [Learning Center](/level-up/learning/)
-  - [Agentic SDLC](/level-up/sdlc/)
-  - [Share](/level-up/share/)
-- [Measure](/measure/)
-  - [Burndown](/measure/burndown/)
-  - [Output](/measure/output/)
-  - [Activity Patterns](/measure/patterns/)
-- [Observe](/observe/)
-  - [Dashboard](/observe/dashboard/)
-  - [Timeline](/observe/timeline/)

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -26,3 +26,31 @@ AI Engineer Coach runs as a VS Code extension. On activation, it scans your loca
 ## Editable Rule Engine
 
 Anti-pattern detection is driven by an editable rule engine. Each detector is a markdown file with YAML frontmatter and a small DSL that you can inspect, tune, and extend. The [Rule Editor](/improve/rule-editor/) lets you live-test changes against your own data, and an AI builder can scaffold new rules from a natural-language description. The [Rule Playground](/improve/rule-playground/) is an interactive REPL for the DSL, and the [Data Explorer](/improve/data-explorer/) shows every field and distribution the rules can key off.
+
+## Documentation Index
+
+This is a quick map of the docs tree so readers and agents can see the available pages at a glance.
+
+- [Features](/features/)
+- [Getting Started](/getting-started/)
+  - [Installation](/getting-started/installation/)
+  - [Supported Tools](/getting-started/supported-tools/)
+- [Improve](/improve/)
+  - [Anti-Patterns](/improve/anti-patterns/)
+  - [Context Health](/improve/context-health/)
+  - [Data Explorer](/improve/data-explorer/)
+  - [Rule Editor](/improve/rule-editor/)
+  - [Rule Playground](/improve/rule-playground/)
+  - [Skill Finder](/improve/skill-finder/)
+- [Level Up](/level-up/)
+  - [Achievements](/level-up/achievements/)
+  - [Learning Center](/level-up/learning/)
+  - [Agentic SDLC](/level-up/sdlc/)
+  - [Share](/level-up/share/)
+- [Measure](/measure/)
+  - [Burndown](/measure/burndown/)
+  - [Output](/measure/output/)
+  - [Activity Patterns](/measure/patterns/)
+- [Observe](/observe/)
+  - [Dashboard](/observe/dashboard/)
+  - [Timeline](/observe/timeline/)


### PR DESCRIPTION
Adds the canonical AGENTS.md notes for the three worker subsystems and the local rule trust lifecycle. Includes links to the existing anti-patterns and rule editor docs so agents can follow the source material.