### PR TITLE
fix: load dashboard when only non-VS Code harness logs exist (Claude/Codex/OpenCode)

### DIFF
--- a/src/core/parser-harnesses.test.ts
+++ b/src/core/parser-harnesses.test.ts
@@ -1,0 +1,50 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Tests for external-harness source discovery used by the dashboard load gate,
+ * so a host with only non-VS Code logs (e.g. Claude Code on a headless
+ * Remote-SSH box, with no VS Code/Copilot directories) still loads. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, it, expect } from 'vitest';
+import { hasExternalHarnessSources } from './parser-harnesses';
+
+const ORIG_HOME = process.env.HOME;
+const ORIG_USERPROFILE = process.env.USERPROFILE;
+
+function withHome(setup: (home: string) => void, run: () => void): void {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-home-'));
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    setup(home);
+    run();
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  if (ORIG_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIG_HOME;
+  if (ORIG_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = ORIG_USERPROFILE;
+});
+
+describe('hasExternalHarnessSources', () => {
+  it('returns false when no external-harness directories exist', () => {
+    withHome(() => { /* empty home */ }, () => {
+      expect(hasExternalHarnessSources()).toBe(false);
+    });
+  });
+
+  it('returns true when a Claude Code projects directory exists', () => {
+    withHome(home => {
+      fs.mkdirSync(path.join(home, '.claude', 'projects'), { recursive: true });
+    }, () => {
+      expect(hasExternalHarnessSources()).toBe(true);
+    });
+  });
+});

--- a/src/core/parser-harnesses.test.ts
+++ b/src/core/parser-harnesses.test.ts
@@ -10,28 +10,31 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { hasExternalHarnessSources } from './parser-harnesses';
 
-const ORIG_HOME = process.env.HOME;
-const ORIG_USERPROFILE = process.env.USERPROFILE;
+function setEnv(key: 'HOME' | 'USERPROFILE', value: string | undefined): void {
+  if (value === undefined) delete process.env[key]; else process.env[key] = value;
+}
 
-function withHome(setup: (home: string) => void, run: () => void): void {
+/** Run `body` with HOME/USERPROFILE pointed at a fresh temp dir, restoring the
+ *  previous values (and removing the temp dir) afterwards. Self-contained so it
+ *  leaks no env state across tests. */
+function withHome(setup: (home: string) => void, body: () => void): void {
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-home-'));
   process.env.HOME = home;
   process.env.USERPROFILE = home;
   try {
     setup(home);
-    run();
+    body();
   } finally {
+    setEnv('HOME', prevHome);
+    setEnv('USERPROFILE', prevUserProfile);
     fs.rmSync(home, { recursive: true, force: true });
   }
 }
-
-afterEach(() => {
-  if (ORIG_HOME === undefined) delete process.env.HOME; else process.env.HOME = ORIG_HOME;
-  if (ORIG_USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = ORIG_USERPROFILE;
-});
 
 describe('hasExternalHarnessSources', () => {
   it('returns false when no external-harness directories exist', () => {
@@ -46,5 +49,18 @@ describe('hasExternalHarnessSources', () => {
     }, () => {
       expect(hasExternalHarnessSources()).toBe(true);
     });
+  });
+
+  it('returns false when no home directory is set (avoids relative-path probing)', () => {
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    setEnv('HOME', undefined);
+    setEnv('USERPROFILE', undefined);
+    try {
+      expect(hasExternalHarnessSources()).toBe(false);
+    } finally {
+      setEnv('HOME', prevHome);
+      setEnv('USERPROFILE', prevUserProfile);
+    }
   });
 });

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -78,6 +78,15 @@ export interface ExternalHarnessProgressHandlers {
   yieldToLoop?: () => Promise<void>;
 }
 
+/** Returns true if any external-harness (Claude Code, Codex, OpenCode) session
+ *  source exists on disk. The dashboard uses this so it does not abort when the
+ *  only available logs come from a non-VS Code harness — e.g. a headless
+ *  Remote-SSH host that has Claude Code sessions under `~/.claude/projects` but
+ *  no VS Code workspace storage or Copilot directories. */
+export function hasExternalHarnessSources(): boolean {
+  return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
+}
+
 export function collectExternalHarnessesSync(workspaces: WorkspaceMap, sessions: Session[]): void {
   const ctx: HarnessCollectionContext = { workspaces, sessions };
   for (const harness of EXTERNAL_HARNESSES) {

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -84,6 +84,10 @@ export interface ExternalHarnessProgressHandlers {
  *  Remote-SSH host that has Claude Code sessions under `~/.claude/projects` but
  *  no VS Code workspace storage or Copilot directories. */
 export function hasExternalHarnessSources(): boolean {
+  // Without a home directory the find* helpers would join against an empty
+  // string and probe relative paths (e.g. `.claude/projects`) under the current
+  // working directory, which could report false positives. Bail out instead.
+  if (!process.env.HOME && !process.env.USERPROFILE) return false;
   return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
 }
 

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -213,7 +213,7 @@ export class DashboardPanel {
       if (dirs.length === 0 && !hasExternal) {
         runtimeDebug('panel', 'loadData-no-dirs');
         if (!this.disposed) {
-          try { this.panel.webview.html = getErrorHtml('No AI coding session logs found. Looked for VS Code, GitHub Copilot, Claude Code, Codex, and OpenCode sessions.'); } catch { /* disposed */ }
+          try { this.panel.webview.html = getErrorHtml('No AI coding session logs found. Looked for VS Code, GitHub Copilot (CLI and Xcode), Claude Code, Codex, and OpenCode sessions.'); } catch { /* disposed */ }
         }
         return;
       }

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -9,6 +9,7 @@ import * as vscode from 'vscode';
 import { Analyzer } from '../core/analyzer';
 import { saveSidebarStats } from '../core/cache';
 import { clearCache, findLogsDirs, parseAllLogsViaWorker, ParseResult } from '../core/parser';
+import { hasExternalHarnessSources } from '../core/parser-harnesses';
 import { runtimeDebug } from '../core/runtime-debug';
 import { WebviewMessage } from '../core/types';
 import { panelCache } from './panel-cache';
@@ -203,11 +204,16 @@ export class DashboardPanel {
       if (this.disposed) return;
 
       const dirs = findLogsDirs();
-      runtimeDebug('panel', 'logs-dirs-found', `count=${dirs.length}`);
-      if (dirs.length === 0) {
+      const hasExternal = hasExternalHarnessSources();
+      runtimeDebug('panel', 'logs-dirs-found', `count=${dirs.length} external=${hasExternal}`);
+      // External harnesses (Claude Code, Codex, OpenCode) are collected by the
+      // parse worker independently of `dirs`, so only abort when no source of
+      // any kind is present. Otherwise a host with e.g. only Claude Code logs
+      // (and no VS Code/Copilot directories) would never load.
+      if (dirs.length === 0 && !hasExternal) {
         runtimeDebug('panel', 'loadData-no-dirs');
         if (!this.disposed) {
-          try { this.panel.webview.html = getErrorHtml('No Copilot chat log directories found.'); } catch { /* disposed */ }
+          try { this.panel.webview.html = getErrorHtml('No AI coding session logs found. Looked for VS Code, GitHub Copilot, Claude Code, Codex, and OpenCode sessions.'); } catch { /* disposed */ }
         }
         return;
       }


### PR DESCRIPTION
The dashboard's load gate aborts with "No Copilot chat log directories found" when `findLogsDirs()` is empty, but that only scans VS Code workspace storage and Copilot paths. The Claude Code / Codex / OpenCode collectors run in the parse worker independently of that list, so a host with only `~/.claude/projects` (e.g. a headless Remote-SSH machine, Claude Code used from the terminal, no VS Code workspace storage) never loads despite valid sessions.

Adds `hasExternalHarnessSources()`, gates on it so the panel aborts only when no source of any kind is present, and updates the Copilot-specific empty-state message to reflect all supported sources. Validated against 133 real Claude Code sessions discovered with zero VS Code directories present.

Fixes #52

## Checklist
- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [x] Changes are covered by tests (new `parser-harnesses.test.ts`)
- [x] Documentation updated (n/a)