### PR TITLE
[codex] Add Markdown and JSON summary export

### DIFF
--- a/README.extension.md
+++ b/README.extension.md
@@ -47,7 +47,7 @@ The extension is organized into three sections: **Observe**, **Measure**, and **
 | **Learning Center** | Personalized quizzes and code-comparison rounds generated from your actual usage |
 | **Achievements** | XP-based progression with Bronze, Silver, Gold, and Diamond tiers |
 | **Agentic SDLC** | Track how you use AI across the full software-development lifecycle |
-| **Share** | Generate a shareable stat card |
+| **Share** | Generate a shareable stat card and export Markdown/JSON summaries |
 
 ## Supported Harnesses
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ code --install-extension (Get-ChildItem . -Filter 'ai-engineer-coach-*.vsix' | S
 | **Learning Center** | Personalized quizzes and code-comparison rounds generated from your actual usage |
 | **Achievements** | XP-based progression with Bronze → Silver → Gold → Diamond tiers |
 | **Agentic SDLC** | How you use AI across the full software-development lifecycle |
-| **Share** | Generate a shareable stat card |
+| **Share** | Generate a shareable stat card and export Markdown/JSON summaries |
 
 ---
 

--- a/docs/content/level-up/share.md
+++ b/docs/content/level-up/share.md
@@ -29,4 +29,5 @@ Three actions are available:
 
 - **Download PNG** -- Save the card as an image file
 - **Copy to Clipboard** -- Copy the card image to your clipboard for pasting
+- **Export Summary** -- Save a Markdown report and matching JSON data file for archiving or sharing
 - **Refresh** -- Regenerate the card with current data

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "activationEvents": [
     "onCommand:aiEngineerCoach.open",
     "onCommand:aiEngineerCoach.reload",
+    "onCommand:aiEngineerCoach.exportSummary",
     "onCommand:aiEngineerCoach.reviewLocalRules",
     "onView:aiEngineerCoach.welcome"
   ],
@@ -51,6 +52,11 @@
         "command": "aiEngineerCoach.reload",
         "title": "AI Engineer Coach: Reload Data",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "aiEngineerCoach.exportSummary",
+        "title": "AI Engineer Coach: Export Summary",
+        "icon": "$(export)"
       },
       {
         "command": "aiEngineerCoach.reviewLocalRules",

--- a/src/core/summary-export.test.ts
+++ b/src/core/summary-export.test.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, expect, it } from 'vitest';
+import { buildSummaryExport, renderSummaryMarkdown, renderSummaryJson, getSummaryExportFilenames } from './summary-export';
+import type {
+  AntiPatternData,
+  CodeProductionData,
+  DailyActivity,
+  StatsResult,
+  WorkLifeBalanceResult,
+} from './types/analytics-types';
+import type { FlowStateData } from './types/context-types';
+
+const stats: StatsResult = {
+  totalSessions: 7,
+  totalRequests: 42,
+  totalWorkspaces: 3,
+};
+
+const codeProduction: CodeProductionData = {
+  summary: {
+    totalAiLoc: 1200,
+    totalUserLoc: 300,
+    totalLoc: 1500,
+    aiBlocks: 12,
+    userBlocks: 4,
+    aiRatio: 0.8,
+    locCost2010: 0,
+    costPerLoc: 0,
+  },
+  byLanguage: {
+    labels: ['typescript', 'python', 'markdown'],
+    aiLoc: [900, 250, 50],
+    userLoc: [100, 150, 50],
+  },
+  dailyTimeline: { labels: [], aiLoc: [], userLoc: [] },
+  byWorkspace: { labels: [], aiLoc: [], userLoc: [] },
+  dailyByWorkspace: {},
+  dailyByModel: {},
+  dailyByHarness: {},
+};
+
+const dailyActivity: DailyActivity = {
+  labels: ['2026-05-20', '2026-05-21', '2026-05-22'],
+  values: [2, 0, 5],
+  loc: [100, 0, 400],
+  sessions: [1, 0, 2],
+  workspaces: [1, 0, 2],
+  byHarness: [],
+};
+
+const workLifeBalance: WorkLifeBalanceResult = {
+  score: 76,
+  totalRequests: 42,
+  weekdayReqs: 40,
+  weekendReqs: 2,
+  weekendRatio: 0.05,
+  timeDistribution: { lateNight: 1, earlyMorning: 2, workHours: 30, evening: 9 },
+  hours: [],
+  weekdayHours: [],
+  weekendHours: [],
+  avgStartHour: 9,
+  avgEndHour: 18,
+  avgSpanHours: 7.5,
+  maxStreak: 5,
+  maxBreak: 2,
+  activeDays: 12,
+  weeklyTrend: { labels: [], weekday: [], weekend: [] },
+};
+
+const flowState: FlowStateData = {
+  days: [],
+  overallFlowScore: 84,
+  avgFollowUpSec: 45,
+  avgBlockMin: 55,
+  deepFlowDays: 4,
+  totalDays: 10,
+  weeklyTrend: { labels: [], scores: [] },
+  hourlyFlow: [],
+  suggestions: ['Batch related prompts before starting an agent session.'],
+};
+
+const antiPatterns: AntiPatternData = {
+  totalOccurrences: 22,
+  weeklyTrend: { labels: [], counts: [] },
+  groupScores: [],
+  weeklyScores: { labels: [], series: [] },
+  patterns: [
+    {
+      id: 'low-context',
+      name: 'Low Context Prompts',
+      severity: 'medium',
+      group: 'prompt-quality',
+      occurrences: 8,
+      description: 'Prompts often miss project context.',
+      suggestion: 'Reference the relevant files and constraints.',
+      examples: ['fix this'],
+      details: [],
+      weeklyHist: { labels: [], counts: [] },
+    },
+    {
+      id: 'mega-session',
+      name: 'Mega Sessions',
+      severity: 'high',
+      group: 'session-hygiene',
+      occurrences: 14,
+      description: 'Long sessions can lose decision context.',
+      suggestion: 'Start a fresh session after major milestones.',
+      examples: [],
+      details: [],
+      weeklyHist: { labels: [], counts: [] },
+    },
+  ],
+};
+
+describe('summary export', () => {
+  it('builds a stable report object with totals, filters, languages, and top anti-patterns', () => {
+    const report = buildSummaryExport({
+      generatedAt: '2026-05-25T10:00:00.000Z',
+      filter: { workspaceId: 'directus', harness: 'Codex' },
+      stats,
+      codeProduction,
+      dailyActivity,
+      workLifeBalance,
+      flowState,
+      antiPatterns,
+    });
+
+    expect(report.schemaVersion).toBe(1);
+    expect(report.filter).toEqual({ workspaceId: 'directus', harness: 'Codex' });
+    expect(report.totals).toEqual({ sessions: 7, requests: 42, workspaces: 3 });
+    expect(report.production.totalAiLoc).toBe(1200);
+    expect(report.production.topLanguages).toEqual([
+      { language: 'typescript', aiLoc: 900, userLoc: 100 },
+      { language: 'python', aiLoc: 250, userLoc: 150 },
+      { language: 'markdown', aiLoc: 50, userLoc: 50 },
+    ]);
+    expect(report.activity).toEqual({ activeDays: 2, firstActivityDate: '2026-05-20', lastActivityDate: '2026-05-22', maxStreak: 5 });
+    expect(report.antiPatterns.topPatterns.map(pattern => pattern.id)).toEqual(['mega-session', 'low-context']);
+  });
+
+  it('renders readable markdown and deterministic json', () => {
+    const report = buildSummaryExport({
+      generatedAt: '2026-05-25T10:00:00.000Z',
+      filter: {},
+      stats,
+      codeProduction,
+      dailyActivity,
+      workLifeBalance: null,
+      flowState,
+      antiPatterns,
+    });
+
+    const markdown = renderSummaryMarkdown(report);
+    expect(markdown).toContain('# AI Engineer Coach Summary');
+    expect(markdown).toContain('- Sessions: 7');
+    expect(markdown).toContain('- AI-generated LoC: 1,200');
+    expect(markdown).toContain('## Top Anti-Patterns');
+    expect(markdown).toContain('Mega Sessions');
+
+    const json = renderSummaryJson(report);
+    expect(JSON.parse(json)).toEqual(report);
+    expect(json).toContain('  "schemaVersion": 1');
+  });
+
+  it('uses date-stamped markdown and json filenames', () => {
+    expect(getSummaryExportFilenames('2026-05-25T10:00:00.000Z')).toEqual({
+      markdown: 'ai-engineer-coach-summary-2026-05-25.md',
+      json: 'ai-engineer-coach-summary-2026-05-25.json',
+    });
+  });
+});

--- a/src/core/summary-export.ts
+++ b/src/core/summary-export.ts
@@ -1,0 +1,269 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Summary export helpers for machine-readable and human-readable reports. */
+
+import type {
+  AntiPatternData,
+  CodeProductionData,
+  DailyActivity,
+  StatsResult,
+  WorkLifeBalanceResult,
+} from './types/analytics-types';
+import type { FlowStateData } from './types/context-types';
+import type { DateFilter } from './types/session-types';
+
+export interface SummaryExportInput {
+  generatedAt?: string | Date;
+  filter?: DateFilter;
+  stats: StatsResult;
+  codeProduction: CodeProductionData;
+  dailyActivity: DailyActivity;
+  workLifeBalance: WorkLifeBalanceResult | null;
+  flowState: FlowStateData;
+  antiPatterns: AntiPatternData;
+}
+
+export interface SummaryExportAnalyzer {
+  getStats(filter?: DateFilter): StatsResult;
+  getCodeProduction(filter?: DateFilter): CodeProductionData;
+  getDailyActivity(filter?: DateFilter): DailyActivity;
+  getWorkLifeBalance(filter?: DateFilter): WorkLifeBalanceResult | null;
+  getFlowState(filter?: DateFilter): FlowStateData;
+  getAntiPatterns(filter?: DateFilter): AntiPatternData;
+}
+
+export interface SummaryExportReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  filter: DateFilter;
+  totals: {
+    sessions: number;
+    requests: number;
+    workspaces: number;
+  };
+  production: {
+    totalAiLoc: number;
+    totalUserLoc: number;
+    totalLoc: number;
+    aiRatio: number;
+    topLanguages: Array<{ language: string; aiLoc: number; userLoc: number }>;
+  };
+  activity: {
+    activeDays: number;
+    firstActivityDate: string | null;
+    lastActivityDate: string | null;
+    maxStreak: number | null;
+  };
+  flow: {
+    overallScore: number;
+    deepFlowDays: number;
+    totalDays: number;
+    avgBlockMin: number;
+    suggestions: string[];
+  };
+  antiPatterns: {
+    totalOccurrences: number;
+    topPatterns: Array<{
+      id: string;
+      name: string;
+      severity: string;
+      group: string;
+      occurrences: number;
+      description: string;
+      suggestion: string;
+    }>;
+  };
+}
+
+const TOP_LANGUAGE_LIMIT = 10;
+const TOP_ANTI_PATTERN_LIMIT = 10;
+
+function toIsoString(value: string | Date | undefined): string {
+  if (!value) return new Date().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(Math.round(value));
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return '0%';
+  return `${Math.round(value * 100)}%`;
+}
+
+function summarizeFilter(filter: DateFilter): string {
+  const parts: string[] = [];
+  if (filter.workspaceId) parts.push(`workspace=${filter.workspaceId}`);
+  if (filter.harness) parts.push(`harness=${filter.harness}`);
+  if (filter.fromDate) parts.push(`from=${filter.fromDate}`);
+  if (filter.toDate) parts.push(`to=${filter.toDate}`);
+  return parts.length > 0 ? parts.join(', ') : 'All data';
+}
+
+function buildTopLanguages(data: CodeProductionData): SummaryExportReport['production']['topLanguages'] {
+  return data.byLanguage.labels
+    .map((language, index) => ({
+      language,
+      aiLoc: data.byLanguage.aiLoc[index] ?? 0,
+      userLoc: data.byLanguage.userLoc[index] ?? 0,
+    }))
+    .filter(item => item.aiLoc > 0 || item.userLoc > 0)
+    .sort((a, b) => b.aiLoc - a.aiLoc || b.userLoc - a.userLoc || a.language.localeCompare(b.language))
+    .slice(0, TOP_LANGUAGE_LIMIT);
+}
+
+function activeDates(data: DailyActivity): { activeDays: number; firstActivityDate: string | null; lastActivityDate: string | null } {
+  const active = data.labels.filter((_, index) => (data.values[index] ?? 0) > 0);
+  return {
+    activeDays: active.length,
+    firstActivityDate: data.labels[0] ?? null,
+    lastActivityDate: data.labels[data.labels.length - 1] ?? null,
+  };
+}
+
+function buildTopAntiPatterns(data: AntiPatternData): SummaryExportReport['antiPatterns']['topPatterns'] {
+  const severityRank: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  return data.patterns
+    .map(pattern => ({
+      id: pattern.id,
+      name: pattern.name,
+      severity: pattern.severity,
+      group: pattern.group,
+      occurrences: pattern.occurrences,
+      description: pattern.description,
+      suggestion: pattern.suggestion,
+    }))
+    .sort((a, b) =>
+      b.occurrences - a.occurrences ||
+      (severityRank[a.severity] ?? 99) - (severityRank[b.severity] ?? 99) ||
+      a.name.localeCompare(b.name)
+    )
+    .slice(0, TOP_ANTI_PATTERN_LIMIT);
+}
+
+export function buildSummaryExport(input: SummaryExportInput): SummaryExportReport {
+  const filter = input.filter ?? {};
+  const activity = activeDates(input.dailyActivity);
+
+  return {
+    schemaVersion: 1,
+    generatedAt: toIsoString(input.generatedAt),
+    filter,
+    totals: {
+      sessions: input.stats.totalSessions,
+      requests: input.stats.totalRequests,
+      workspaces: input.stats.totalWorkspaces,
+    },
+    production: {
+      totalAiLoc: input.codeProduction.summary.totalAiLoc,
+      totalUserLoc: input.codeProduction.summary.totalUserLoc,
+      totalLoc: input.codeProduction.summary.totalLoc,
+      aiRatio: input.codeProduction.summary.aiRatio,
+      topLanguages: buildTopLanguages(input.codeProduction),
+    },
+    activity: {
+      ...activity,
+      maxStreak: input.workLifeBalance?.maxStreak ?? null,
+    },
+    flow: {
+      overallScore: input.flowState.overallFlowScore,
+      deepFlowDays: input.flowState.deepFlowDays,
+      totalDays: input.flowState.totalDays,
+      avgBlockMin: input.flowState.avgBlockMin,
+      suggestions: input.flowState.suggestions.slice(0, 5),
+    },
+    antiPatterns: {
+      totalOccurrences: input.antiPatterns.totalOccurrences,
+      topPatterns: buildTopAntiPatterns(input.antiPatterns),
+    },
+  };
+}
+
+export function buildSummaryExportFromAnalyzer(
+  analyzer: SummaryExportAnalyzer,
+  filter?: DateFilter,
+  generatedAt?: string | Date,
+): SummaryExportReport {
+  return buildSummaryExport({
+    generatedAt,
+    filter,
+    stats: analyzer.getStats(filter),
+    codeProduction: analyzer.getCodeProduction(filter),
+    dailyActivity: analyzer.getDailyActivity(filter),
+    workLifeBalance: analyzer.getWorkLifeBalance(filter),
+    flowState: analyzer.getFlowState(filter),
+    antiPatterns: analyzer.getAntiPatterns(filter),
+  });
+}
+
+export function renderSummaryJson(report: SummaryExportReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function renderSummaryMarkdown(report: SummaryExportReport): string {
+  const lines: string[] = [
+    '# AI Engineer Coach Summary',
+    '',
+    `Generated: ${report.generatedAt}`,
+    `Filter: ${summarizeFilter(report.filter)}`,
+    '',
+    '## Totals',
+    `- Sessions: ${formatNumber(report.totals.sessions)}`,
+    `- Requests: ${formatNumber(report.totals.requests)}`,
+    `- Workspaces: ${formatNumber(report.totals.workspaces)}`,
+    `- AI-generated LoC: ${formatNumber(report.production.totalAiLoc)}`,
+    `- User LoC observed: ${formatNumber(report.production.totalUserLoc)}`,
+    `- AI ratio: ${formatPercent(report.production.aiRatio)}`,
+    '',
+    '## Activity',
+    `- Active days: ${formatNumber(report.activity.activeDays)}`,
+    `- First activity date: ${report.activity.firstActivityDate ?? 'n/a'}`,
+    `- Last activity date: ${report.activity.lastActivityDate ?? 'n/a'}`,
+    `- Max streak: ${report.activity.maxStreak === null ? 'n/a' : formatNumber(report.activity.maxStreak)}`,
+    '',
+    '## Flow',
+    `- Overall flow score: ${formatNumber(report.flow.overallScore)}`,
+    `- Deep-flow days: ${formatNumber(report.flow.deepFlowDays)} of ${formatNumber(report.flow.totalDays)}`,
+    `- Average block length: ${formatNumber(report.flow.avgBlockMin)} min`,
+  ];
+
+  if (report.flow.suggestions.length > 0) {
+    lines.push('', '### Flow Suggestions');
+    for (const suggestion of report.flow.suggestions) lines.push(`- ${suggestion}`);
+  }
+
+  lines.push('', '## Top Languages');
+  if (report.production.topLanguages.length === 0) {
+    lines.push('- No language data available.');
+  } else {
+    for (const item of report.production.topLanguages) {
+      lines.push(`- ${item.language}: ${formatNumber(item.aiLoc)} AI LoC, ${formatNumber(item.userLoc)} user LoC`);
+    }
+  }
+
+  lines.push('', '## Top Anti-Patterns');
+  if (report.antiPatterns.topPatterns.length === 0) {
+    lines.push('- No anti-patterns detected.');
+  } else {
+    for (const pattern of report.antiPatterns.topPatterns) {
+      lines.push(
+        `- ${pattern.name} (${pattern.severity}, ${formatNumber(pattern.occurrences)} occurrence${pattern.occurrences === 1 ? '' : 's'}): ${pattern.suggestion}`,
+      );
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function getSummaryExportFilenames(generatedAt: string | Date = new Date()): { markdown: string; json: string } {
+  const date = toIsoString(generatedAt).slice(0, 10);
+  return {
+    markdown: `ai-engineer-coach-summary-${date}.md`,
+    json: `ai-engineer-coach-summary-${date}.json`,
+  };
+}

--- a/src/core/types/rpc-types.ts
+++ b/src/core/types/rpc-types.ts
@@ -123,6 +123,7 @@ export interface ExtensionMethodMap extends RpcMethodMap {
   generateLearningResources: { params: Record<string, unknown>; result: { resources: unknown[]; error?: string } };
   generateCodeComparison: { params: Record<string, unknown>; result: { rounds: unknown[] } };
   generateDidYouKnow: { params: Record<string, unknown>; result: { facts: unknown[] } };
+  exportSummary: { params: { filter?: DateFilter } | DateFilter | undefined; result: { ok: boolean; cancelled?: boolean; folder?: string; markdownPath?: string; jsonPath?: string } };
   installSkill: { params: { filename: string; content: string }; result: { ok: boolean; path?: string; error?: string } };
   installCatalogItem: { params: { path: string; kind?: string; title?: string }; result: { content: string; filename: string; error?: string } };
   triageSkills: { params: Record<string, unknown>; result: { triaged: unknown[] } };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,8 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { Analyzer } from './core/analyzer';
+import { findLogsDirs, parseAllLogsViaWorker } from './core/parser';
 import { getRuntimeDebugLogPath, installRuntimeDebugHooks, runtimeDebug, setOutputHook } from './core/runtime-debug';
 import { loadAllRuleLayersAsync, loadAllMetricLayersAsync, setDefaultTrustGate } from './core/rule-loader';
 import {
@@ -19,6 +21,7 @@ import {
   setDefaultTrustStore,
   type PendingEntry,
 } from './core/rule-trust';
+import { exportSummaryFiles } from './summary-export-vscode';
 
 
 type PanelModule = typeof import('./webview/panel');
@@ -26,6 +29,29 @@ let panelModulePromise: Promise<PanelModule> | null = null;
 function loadPanelModule(): Promise<PanelModule> {
   if (!panelModulePromise) panelModulePromise = import('./webview/panel');
   return panelModulePromise;
+}
+
+async function exportSummaryFromLogs(): Promise<void> {
+  const dirs = findLogsDirs();
+  if (dirs.length === 0) {
+    vscode.window.showErrorMessage('No AI coding session log directories found.');
+    return;
+  }
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: 'Exporting AI Engineer Coach summary',
+      cancellable: false,
+    },
+    async progress => {
+      const parsed = await parseAllLogsViaWorker(dirs, update => {
+        progress.report({ message: update.detail ?? 'Reading session logs' });
+      });
+      const analyzer = new Analyzer(parsed.sessions, parsed.editLocIndex, parsed.workspaces);
+      await exportSummaryFiles(analyzer);
+    },
+  );
 }
 
 async function reviewPendingTrust(context: vscode.ExtensionContext): Promise<Set<string>> {
@@ -136,6 +162,12 @@ export function activate(context: vscode.ExtensionContext) {
       } else {
         DashboardPanel.createOrShow(context.extensionUri, context);
       }
+    }),
+    vscode.commands.registerCommand('aiEngineerCoach.exportSummary', async () => {
+      runtimeDebug('extension', 'command-export-summary');
+      await ready;
+      if (getPending().length > 0) await promptAndReload();
+      await exportSummaryFromLogs();
     }),
     vscode.commands.registerCommand('aiEngineerCoach.reviewLocalRules', async () => {
       runtimeDebug('extension', 'command-review-trust');

--- a/src/summary-export-vscode.ts
+++ b/src/summary-export-vscode.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* VS Code integration for summary export file writes. */
+
+import * as vscode from 'vscode';
+import {
+  buildSummaryExportFromAnalyzer,
+  getSummaryExportFilenames,
+  renderSummaryJson,
+  renderSummaryMarkdown,
+  type SummaryExportAnalyzer,
+} from './core/summary-export';
+import type { DateFilter } from './core/types/session-types';
+
+export interface SummaryExportWriteResult {
+  ok: boolean;
+  cancelled?: boolean;
+  folder?: string;
+  markdownPath?: string;
+  jsonPath?: string;
+}
+
+export async function exportSummaryFiles(
+  analyzer: SummaryExportAnalyzer,
+  filter?: DateFilter,
+): Promise<SummaryExportWriteResult> {
+  const generatedAt = new Date();
+  const report = buildSummaryExportFromAnalyzer(analyzer, filter, generatedAt);
+  const filenames = getSummaryExportFilenames(generatedAt);
+  const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+
+  const folders = await vscode.window.showOpenDialog({
+    canSelectFiles: false,
+    canSelectFolders: true,
+    canSelectMany: false,
+    defaultUri,
+    openLabel: 'Export Summary',
+    title: 'Choose a folder for the AI Engineer Coach summary',
+  });
+
+  const folder = folders?.[0];
+  if (!folder) return { ok: false, cancelled: true };
+
+  const markdownUri = vscode.Uri.joinPath(folder, filenames.markdown);
+  const jsonUri = vscode.Uri.joinPath(folder, filenames.json);
+
+  await vscode.workspace.fs.writeFile(markdownUri, Buffer.from(renderSummaryMarkdown(report), 'utf8'));
+  await vscode.workspace.fs.writeFile(jsonUri, Buffer.from(renderSummaryJson(report), 'utf8'));
+
+  const result = {
+    ok: true,
+    folder: folder.fsPath,
+    markdownPath: markdownUri.fsPath,
+    jsonPath: jsonUri.fsPath,
+  };
+
+  const action = await vscode.window.showInformationMessage(
+    `Exported AI Engineer Coach summary to ${folder.fsPath}`,
+    'Open Folder',
+  );
+  if (action === 'Open Folder') {
+    await vscode.env.openExternal(folder);
+  }
+
+  return result;
+}

--- a/src/webview/page-peers.ts
+++ b/src/webview/page-peers.ts
@@ -288,6 +288,7 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
       <div class="share-actions">
         <button class="btn btn-primary" id="share-download-btn">${SVG.share} Download PNG</button>
         <button class="btn btn-secondary" id="share-copy-btn">${SVG.clipboard} Copy</button>
+        <button class="btn btn-secondary" id="share-export-summary-btn">${SVG.share} Export Summary</button>
       </div>
 
       <div class="share-social">
@@ -327,6 +328,18 @@ export async function renderShareCard(container: HTMLElement, filter: DateFilter
         showToast('Copied! Paste it anywhere.');
       } catch {
         showToast('Copy failed — try downloading instead');
+      }
+    })();
+  });
+
+  document.getElementById('share-export-summary-btn')?.addEventListener('click', () => {
+    void (async () => {
+      try {
+        const result = await rpc<{ ok: boolean; cancelled?: boolean }>('exportSummary', { filter });
+        if (result.cancelled) return;
+        showToast(result.ok ? 'Summary exported.' : 'Export cancelled.');
+      } catch {
+        showToast('Export failed.');
       }
     })();
   });

--- a/src/webview/panel-request-service.ts
+++ b/src/webview/panel-request-service.ts
@@ -11,6 +11,7 @@ import { Analyzer } from '../core/analyzer';
 import { ParseResult } from '../core/parser';
 import { readFileSafe } from '../core/parser-shared';
 import { Workspace } from '../core/types';
+import { exportSummaryFiles } from '../summary-export-vscode';
 import {
   callLlm,
   callLlmJson,
@@ -33,6 +34,7 @@ type CustomPanelMethodName =
   | 'generateLearningResources'
   | 'generateCodeComparison'
   | 'generateDidYouKnow'
+  | 'exportSummary'
   | 'installSkill'
   | 'installCatalogItem'
   | 'triageSkills'
@@ -105,6 +107,7 @@ export class PanelRequestService {
     generateLearningResources: this.handleGenerateLearningResources.bind(this),
     generateCodeComparison: this.handleGenerateCodeComparison.bind(this),
     generateDidYouKnow: this.handleGenerateDidYouKnow.bind(this),
+    exportSummary: this.handleExportSummary.bind(this),
     installSkill: this.handleInstallSkill.bind(this),
     installCatalogItem: this.handleInstallCatalogItem.bind(this),
     triageSkills: this.handleTriageSkills.bind(this),
@@ -229,6 +232,23 @@ ${context.packageDeps.length > 0 ? `- Key dependencies: ${context.packageDeps.sl
 ${context.focusSkills.length > 0 ? `- Skill focus areas: ${context.focusSkills.join(', ')}` : ''}
 
 Generate 3 ${context.difficulty} interview-style questions tailored to this developer's actual stack.`;
+  }
+
+  private async handleExportSummary(msg: RequestMessage): Promise<void> {
+    if (!this.analyzer) {
+      postError(this.webview, msg.id, 'Dashboard data is still loading. Try again once the dashboard is ready.');
+      return;
+    }
+
+    const params = (msg.params ?? {}) as Record<string, unknown>;
+    const filter = isRecord(params.filter) ? validateDateFilter(params.filter) : validateDateFilter(params);
+
+    try {
+      const result = await exportSummaryFiles(this.analyzer, filter);
+      postResponse(this.webview, msg.id, result);
+    } catch (error: unknown) {
+      postError(this.webview, msg.id, error instanceof Error ? error.message : 'Failed to export summary');
+    }
   }
 
   private normalizeQuizQuestions(response: { items: QuizQuestion[] } | QuizQuestion[], fallbackDifficulty: QuizDifficulty): Array<{


### PR DESCRIPTION
## Summary

Adds a first-class summary export path for AI Engineer Coach so users can save dashboard insights outside the webview.

- adds `AI Engineer Coach: Export Summary` command palette action
- adds `Export Summary` to the Share page using the current dashboard filter
- writes both Markdown and JSON files with totals, activity, flow, top languages, and top anti-patterns
- keeps report generation local and deterministic with a tested core formatter
- documents the export option in README and Share docs

## Validation

- `npm run typecheck`
- `vitest run src/core/summary-export.test.ts`
- `npm test`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run check`
- `npm run package`

## Notes

The export uses existing local analyzer data. It does not call LLM APIs, make network requests, or modify session logs.