### PR TITLE
Add configurable Claude profile discovery

### DIFF
--- a/README.extension.md
+++ b/README.extension.md
@@ -61,6 +61,8 @@ The extension is organized into three sections: **Observe**, **Measure**, and **
 | **OpenCode** | macOS/Linux: `~/.local/share/opencode/`<br>Windows: `%USERPROFILE%\.local\share\opencode\` |
 | **GitHub Copilot CLI** | `~/.copilot/session-state/` and `~/.copilot/history-session-state/` |
 
+Claude auto-detects `CLAUDE_CONFIG_DIR` and `~/.claude` by default. To scan only specific Claude profiles, set `aiEngineerCoach.claudeConfigDirs` in VS Code settings, for example `["~/.claude-home", "~/.claude-work"]`.
+
 ## Getting Started
 
 1. Open the command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`).

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -46,3 +46,13 @@ You can also click the AI Engineer Coach icon in the Activity Bar (sidebar) if i
 ## Configuration
 
 AI Engineer Coach works out of the box with sensible defaults. Optional settings are available under `aiEngineerCoach.*` in VS Code settings to control cache behavior, date ranges, and workspace filtering.
+
+By default, Claude session discovery scans `CLAUDE_CONFIG_DIR` and `~/.claude`. To scan only specific Claude profiles, add config roots to `aiEngineerCoach.claudeConfigDirs`:
+
+```json
+{
+  "aiEngineerCoach.claudeConfigDirs": ["~/.claude-home", "~/.claude-work"]
+}
+```
+
+When this setting is non-empty, it replaces automatic Claude discovery.

--- a/package.json
+++ b/package.json
@@ -81,6 +81,19 @@
           "type": "webview"
         }
       ]
+    },
+    "configuration": {
+      "title": "AI Engineer Coach",
+      "properties": {
+        "aiEngineerCoach.claudeConfigDirs": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Claude configuration directories to scan for session logs. Leave empty to auto-detect `CLAUDE_CONFIG_DIR` and the default `~/.claude`; set one or more entries to explicitly choose Claude profiles such as `~/.claude-home` and `~/.claude-work`. Each entry should point to a Claude config directory; `projects/` is appended automatically unless the entry already ends with `projects`."
+        }
+      }
     }
   },
   "scripts": {

--- a/src/core/harness-config-roots.ts
+++ b/src/core/harness-config-roots.ts
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Harness-specific configuration root discovery. */
+
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const CLAUDE_CONFIG_DIRS_ENV = 'AI_ENGINEER_COACH_CLAUDE_CONFIG_DIRS';
+
+function expandHomeDir(dir: string, home: string): string {
+  if (dir === '~') return home || dir;
+  if (dir.startsWith(`~${path.sep}`) || dir.startsWith('~/') || dir.startsWith('~\\')) {
+    return home ? path.join(home, dir.slice(2)) : dir;
+  }
+  return dir;
+}
+
+function parseDirList(raw: string | undefined): string[] {
+  if (!raw || raw.trim().length === 0) return [];
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+  return trimmed.split(path.delimiter).map(part => part.trim()).filter(Boolean);
+}
+
+function uniqueResolvedDirs(dirs: string[], home: string): string[] {
+  const seen = new Set<string>();
+  const roots: string[] = [];
+
+  for (const dir of dirs) {
+    if (!dir || dir.trim().length === 0) continue;
+    const resolved = path.resolve(expandHomeDir(dir.trim(), home));
+    let canonical = resolved;
+    try {
+      canonical = fs.realpathSync(resolved);
+    } catch {
+      /* Keep the unresolved path so future dirs can still be configured. */
+    }
+    const key = process.platform === 'win32' ? canonical.toLowerCase() : canonical;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    roots.push(resolved);
+  }
+
+  return roots;
+}
+
+export function getClaudeConfigRoots(): string[] {
+  const home = os.homedir() || process.env.HOME || process.env.USERPROFILE || '';
+  const configuredDirs = parseDirList(process.env[CLAUDE_CONFIG_DIRS_ENV]);
+  if (configuredDirs.length > 0) return uniqueResolvedDirs(configuredDirs, home);
+
+  const dirs = [
+    process.env.CLAUDE_CONFIG_DIR || '',
+  ];
+  if (home) dirs.push(path.join(home, '.claude'));
+  return uniqueResolvedDirs(dirs, home);
+}

--- a/src/core/parser-claude.test.ts
+++ b/src/core/parser-claude.test.ts
@@ -12,7 +12,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { describe, it, expect } from 'vitest';
-import { parseClaudeSessions } from './parser-claude';
+import { CLAUDE_CONFIG_DIRS_ENV } from './harness-config-roots';
+import { findClaudeDirs, parseClaudeSessions } from './parser-claude';
 
 /** os.tmpdir() on Windows often returns 8.3 short names (e.g. TAMASB~1)
  *  that don't match readdirSync output. Resolve to the long form so
@@ -74,7 +75,109 @@ function withProjectsDir(filename: string, lines: object[], run: (projectsDir: s
   try { run(projectsDir); } finally { fs.rmSync(root, { recursive: true, force: true }); }
 }
 
+function withClaudeEnv(run: () => void): void {
+  const original = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+    [CLAUDE_CONFIG_DIRS_ENV]: process.env[CLAUDE_CONFIG_DIRS_ENV],
+  };
+  try {
+    run();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
 describe('parseClaudeSessions', () => {
+  it('uses configured Claude config directories as an explicit override', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-dirs-test-'));
+    const home = path.join(root, 'home');
+    const work = path.join(root, '.claude-work');
+    const active = path.join(root, '.claude-active');
+    const directProjects = path.join(root, '.claude-home', 'projects');
+
+    try {
+      withClaudeEnv(() => {
+        for (const dir of [
+          path.join(home, '.claude', 'projects'),
+          path.join(work, 'projects'),
+          path.join(active, 'projects'),
+          directProjects,
+        ]) {
+          fs.mkdirSync(dir, { recursive: true });
+        }
+
+        process.env.HOME = home;
+        delete process.env.USERPROFILE;
+        process.env.CLAUDE_CONFIG_DIR = active;
+        process.env[CLAUDE_CONFIG_DIRS_ENV] = JSON.stringify([work, directProjects]);
+
+        expect(findClaudeDirs()).toEqual([
+          path.join(work, 'projects'),
+          directProjects,
+        ]);
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to CLAUDE_CONFIG_DIR and default home when no Claude dirs are configured', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-auto-dirs-test-'));
+    const home = path.join(root, 'home');
+    const active = path.join(root, '.claude-active');
+
+    try {
+      withClaudeEnv(() => {
+        fs.mkdirSync(path.join(home, '.claude', 'projects'), { recursive: true });
+        fs.mkdirSync(path.join(active, 'projects'), { recursive: true });
+
+        process.env.HOME = home;
+        delete process.env.USERPROFILE;
+        process.env.CLAUDE_CONFIG_DIR = active;
+        delete process.env[CLAUDE_CONFIG_DIRS_ENV];
+
+        expect(findClaudeDirs()).toEqual([
+          path.join(active, 'projects'),
+          path.join(home, '.claude', 'projects'),
+        ]);
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('deduplicates Claude config directories that resolve to the same symlink target', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-symlink-dirs-test-'));
+    const home = path.join(root, 'home');
+    const target = path.join(root, '.claude-home');
+
+    try {
+      withClaudeEnv(() => {
+        fs.mkdirSync(path.join(home), { recursive: true });
+        fs.mkdirSync(path.join(target, 'projects'), { recursive: true });
+        try {
+          fs.symlinkSync(target, path.join(home, '.claude'), 'dir');
+        } catch {
+          return;
+        }
+
+        process.env.HOME = home;
+        delete process.env.USERPROFILE;
+        delete process.env.CLAUDE_CONFIG_DIR;
+        process.env[CLAUDE_CONFIG_DIRS_ENV] = JSON.stringify([target]);
+
+        expect(findClaudeDirs()).toEqual([path.join(target, 'projects')]);
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('skips tool_result-only user records and merges following assistant into prior real user request', () => {
     withProjectsDir('s.jsonl', [
       makeUser('write a file please'),

--- a/src/core/parser-claude.ts
+++ b/src/core/parser-claude.ts
@@ -18,6 +18,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Session, SessionRequest } from './types';
+import { getClaudeConfigRoots } from './harness-config-roots';
 import { assertTrustedPath, readFileSafe, createRequest, createSession, detectDevcontainerFromRequests, extractSkillNameFromPath } from './parser-shared';
 import { extractReasoningEffortFromModelId } from './helpers';
 import { warnCore } from './log';
@@ -311,10 +312,25 @@ function collectClaudeAssistantData(lines: ClaudeLine[], startIndex: number, las
 }
 
 export function findClaudeDirs(): string[] {
-  const home = process.env.HOME || process.env.USERPROFILE || '';
   const dirs: string[] = [];
-  const projectsDir = path.join(home, '.claude', 'projects');
-  if (fs.existsSync(projectsDir)) dirs.push(projectsDir);
+  const seen = new Set<string>();
+
+  for (const root of getClaudeConfigRoots()) {
+    const projectsDir = path.basename(root) === 'projects' ? root : path.join(root, 'projects');
+    const resolved = path.resolve(projectsDir);
+    let canonical = resolved;
+    try {
+      canonical = fs.realpathSync(resolved);
+    } catch {
+      /* Keep the unresolved path so future dirs can still be configured. */
+    }
+    const key = process.platform === 'win32' ? canonical.toLowerCase() : canonical;
+    if (seen.has(key)) continue;
+    if (fs.existsSync(resolved)) {
+      seen.add(key);
+      dirs.push(resolved);
+    }
+  }
   return dirs;
 }
 

--- a/src/core/parser-harnesses.test.ts
+++ b/src/core/parser-harnesses.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+import { CLAUDE_CONFIG_DIRS_ENV } from './harness-config-roots';
+import { collectExternalHarnessesSync } from './parser-harnesses';
+import { Session, Workspace } from './types';
+
+function writeClaudeSession(projectsDir: string, sessionId: string): void {
+  const projectDir = path.join(projectsDir, '-Users-me-story-book');
+  fs.mkdirSync(projectDir, { recursive: true });
+  const lines = [
+    {
+      type: 'user',
+      timestamp: '2026-05-26T10:00:00Z',
+      sessionId,
+      cwd: '/Users/me/story-book',
+      entrypoint: 'cli',
+      message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    },
+    {
+      type: 'assistant',
+      timestamp: '2026-05-26T10:00:01Z',
+      sessionId,
+      message: {
+        role: 'assistant',
+        model: 'claude-sonnet-4',
+        content: [{ type: 'text', text: 'hi' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    },
+  ];
+  fs.writeFileSync(path.join(projectDir, `${sessionId}.jsonl`), lines.map(line => JSON.stringify(line)).join('\n'), 'utf-8');
+}
+
+function withClaudeEnv(run: () => void): void {
+  const original = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+    [CLAUDE_CONFIG_DIRS_ENV]: process.env[CLAUDE_CONFIG_DIRS_ENV],
+  };
+  try {
+    run();
+  } finally {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+describe('collectExternalHarnessesSync', () => {
+  it('deduplicates Claude sessions copied across multiple config roots', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-harness-dedupe-'));
+    const home = path.join(root, 'home');
+    const defaultProjects = path.join(home, '.claude', 'projects');
+    const workRoot = path.join(root, '.claude-work');
+    const workProjects = path.join(workRoot, 'projects');
+    const sessionId = '11111111-1111-4111-8111-111111111111';
+
+    try {
+      withClaudeEnv(() => {
+        writeClaudeSession(defaultProjects, sessionId);
+        writeClaudeSession(workProjects, sessionId);
+
+        process.env.HOME = home;
+        delete process.env.USERPROFILE;
+        delete process.env.CLAUDE_CONFIG_DIR;
+        process.env[CLAUDE_CONFIG_DIRS_ENV] = JSON.stringify([workRoot]);
+
+        const workspaces = new Map<string, Workspace>();
+        const sessions: Session[] = [];
+        collectExternalHarnessesSync(workspaces, sessions);
+
+        const claudeSessions = sessions.filter(session => session.harness === 'Claude');
+        expect(claudeSessions).toHaveLength(1);
+        expect(claudeSessions[0].sessionId).toBe(sessionId);
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -32,23 +32,37 @@ function addSession(workspaces: WorkspaceMap, sessions: Session[], session: Sess
   }
 }
 
+function addClaudeSession(
+  workspaces: WorkspaceMap,
+  sessions: Session[],
+  seenSessionIds: Set<string>,
+  session: Session,
+  rootPath: string,
+): void {
+  if (seenSessionIds.has(session.sessionId)) return;
+  seenSessionIds.add(session.sessionId);
+  addSession(workspaces, sessions, session, rootPath);
+}
+
 const EXTERNAL_HARNESSES: ExternalHarnessCollector[] = [
   {
     name: 'Claude Code',
     collectSync(ctx) {
+      const seenSessionIds = new Set<string>();
       for (const claudeDir of findClaudeDirs()) {
         for (const { sessions } of parseClaudeSessions(claudeDir)) {
-          for (const session of sessions) addSession(ctx.workspaces, ctx.sessions, session, claudeDir);
+          for (const session of sessions) addClaudeSession(ctx.workspaces, ctx.sessions, seenSessionIds, session, claudeDir);
         }
       }
     },
     async collectAsync(ctx, reportDetail) {
+      const seenSessionIds = new Set<string>();
       for (const claudeDir of findClaudeDirs()) {
         const results = await parseClaudeSessionsAsync(claudeDir, (idx, total, name) => {
           reportDetail?.(`${idx}/${total}: ${name}`);
         });
         for (const { sessions } of results) {
-          for (const session of sessions) addSession(ctx.workspaces, ctx.sessions, session, claudeDir);
+          for (const session of sessions) addClaudeSession(ctx.workspaces, ctx.sessions, seenSessionIds, session, claudeDir);
         }
       }
     },

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { CodeBlock, Session, SessionRequest, Workspace } from './types';
 import { SessionSource } from './cache';
 import { classifyWorkType } from './helpers';
+import { getClaudeConfigRoots } from './harness-config-roots';
 import { warnCore } from './log';
 import { SessionSchema } from './schemas';
 
@@ -59,11 +60,11 @@ function getTrustedRoots(): string[] {
   // Standard session log locations
   if (home) {
     roots.push(path.resolve(home, '.copilot'));
-    roots.push(path.resolve(home, '.claude'));
     roots.push(path.resolve(home, '.codex'));
     roots.push(path.resolve(home, '.local', 'share', 'opencode'));
     roots.push(path.resolve(home, '.config', 'github-copilot'));
   }
+  roots.push(...getClaudeConfigRoots());
 
   // OS temp directory (used by tests and VS Code temp storage)
   const tmpDir = os.tmpdir();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { Analyzer } from './core/analyzer';
+import { CLAUDE_CONFIG_DIRS_ENV } from './core/harness-config-roots';
 import { findLogsDirs, parseAllLogsViaWorker } from './core/parser';
 import { getRuntimeDebugLogPath, installRuntimeDebugHooks, runtimeDebug, setOutputHook } from './core/runtime-debug';
 import { loadAllRuleLayersAsync, loadAllMetricLayersAsync, setDefaultTrustGate } from './core/rule-loader';
@@ -31,12 +32,20 @@ function loadPanelModule(): Promise<PanelModule> {
   return panelModulePromise;
 }
 
-async function exportSummaryFromLogs(): Promise<void> {
-  const dirs = findLogsDirs();
-  if (dirs.length === 0) {
-    vscode.window.showErrorMessage('No AI coding session log directories found.');
-    return;
+function syncClaudeConfigDirsSetting(): void {
+  const value = vscode.workspace.getConfiguration('aiEngineerCoach').get<unknown>('claudeConfigDirs', []);
+  const dirs = Array.isArray(value) ? value.filter((dir): dir is string => typeof dir === 'string' && dir.trim().length > 0) : [];
+  if (dirs.length > 0) {
+    process.env[CLAUDE_CONFIG_DIRS_ENV] = JSON.stringify(dirs);
+  } else {
+    delete process.env[CLAUDE_CONFIG_DIRS_ENV];
   }
+  runtimeDebug('extension', 'claude-config-dirs-setting', `count=${dirs.length}`);
+}
+
+async function exportSummaryFromLogs(): Promise<void> {
+  syncClaudeConfigDirsSetting();
+  const dirs = findLogsDirs();
 
   await vscode.window.withProgress(
     {
@@ -48,6 +57,10 @@ async function exportSummaryFromLogs(): Promise<void> {
       const parsed = await parseAllLogsViaWorker(dirs, update => {
         progress.report({ message: update.detail ?? 'Reading session logs' });
       });
+      if (parsed.sessions.length === 0) {
+        vscode.window.showErrorMessage('No AI coding session logs found.');
+        return;
+      }
       const analyzer = new Analyzer(parsed.sessions, parsed.editLocIndex, parsed.workspaces);
       await exportSummaryFiles(analyzer);
     },
@@ -98,6 +111,7 @@ async function reviewPendingTrust(context: vscode.ExtensionContext): Promise<Set
 export function activate(context: vscode.ExtensionContext) {
   installRuntimeDebugHooks();
   runtimeDebug('extension', 'activate', `runtimeLog=${getRuntimeDebugLogPath()}`);
+  syncClaudeConfigDirsSetting();
 
   const outputChannel = vscode.window.createOutputChannel('AI Engineer Coach');
   context.subscriptions.push(outputChannel);
@@ -144,8 +158,14 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (!e.affectsConfiguration('aiEngineerCoach.claudeConfigDirs')) return;
+      syncClaudeConfigDirsSetting();
+      void loadPanelModule().then(({ DashboardPanel }) => DashboardPanel.current?.reload(true));
+    }),
     vscode.commands.registerCommand('aiEngineerCoach.open', async () => {
       runtimeDebug('extension', 'command-open');
+      syncClaudeConfigDirsSetting();
       await ready;
       // Gate dashboard creation behind the approval review.
       if (getPending().length > 0) await promptAndReload();
@@ -154,6 +174,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
     vscode.commands.registerCommand('aiEngineerCoach.reload', async () => {
       runtimeDebug('extension', 'command-reload');
+      syncClaudeConfigDirsSetting();
       await ready;
       if (getPending().length > 0) await promptAndReload();
       const { DashboardPanel } = await loadPanelModule();
@@ -165,6 +186,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
     vscode.commands.registerCommand('aiEngineerCoach.exportSummary', async () => {
       runtimeDebug('extension', 'command-export-summary');
+      syncClaudeConfigDirsSetting();
       await ready;
       if (getPending().length > 0) await promptAndReload();
       await exportSummaryFromLogs();

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -204,13 +204,6 @@ export class DashboardPanel {
 
       const dirs = findLogsDirs();
       runtimeDebug('panel', 'logs-dirs-found', `count=${dirs.length}`);
-      if (dirs.length === 0) {
-        runtimeDebug('panel', 'loadData-no-dirs');
-        if (!this.disposed) {
-          try { this.panel.webview.html = getErrorHtml('No Copilot chat log directories found.'); } catch { /* disposed */ }
-        }
-        return;
-      }
 
       this.parseResult = await parseAllLogsViaWorker(dirs, progress => sendProgress(progress));
       if (this.disposed) return;


### PR DESCRIPTION
## Summary
- add `aiEngineerCoach.claudeConfigDirs` for explicit Claude config root selection
- keep automatic discovery via `CLAUDE_CONFIG_DIR` and `~/.claude` when unset
- deduplicate Claude config roots via realpath and sessions by `sessionId`
- allow Claude-only parsing when no VS Code/Xcode log dirs exist

## Validation
- npm run typecheck
- npx vitest run src/core/parser-claude.test.ts src/core/parser-harnesses.test.ts
- npm run lint