### PR TITLE
Extract skillsUsed from Codex session transcripts

### DIFF
--- a/src/core/parser-codex.test.ts
+++ b/src/core/parser-codex.test.ts
@@ -102,6 +102,92 @@ describe('parseCodexSessions', () => {
   });
 });
 
+describe('parseCodexSessions skillsUsed extraction', () => {
+  it('extracts skillsUsed from a function_call event whose cmd argument references SKILL.md', () => {
+    withCodexFile([
+      { type: 'session_meta', payload: { id: 'sess-skill-1', cwd: '/Users/me/proj' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.3-codex' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:00Z', payload: { type: 'user_message', message: 'run investigate' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:01Z',
+        payload: { type: 'function_call', name: 'shell',
+          arguments: { cmd: ['bash', '-c', 'cat ~/.codex/skills/investigate/SKILL.md'] } } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:02Z', payload: { type: 'assistant_message', content: 'done' } },
+    ], (sessionsDir) => {
+      const sessions = parseCodexSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      const req = sessions[0].requests[0];
+      expect(req.skillsUsed).toEqual(['investigate']);
+      expect(req.referencedFiles).toContain('/skills/investigate/SKILL.md');
+    });
+  });
+
+  it('extracts skillsUsed from a response_item function_call with stringified arguments', () => {
+    withCodexFile([
+      { type: 'session_meta', payload: { id: 'sess-skill-2', cwd: '/Users/me/proj' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.3-codex' } },
+      { type: 'response_item', timestamp: '2025-06-15T10:00:00Z',
+        payload: { role: 'user', content: [{ type: 'input_text', text: 'use money skill' }] } },
+      { type: 'response_item', timestamp: '2025-06-15T10:00:01Z',
+        payload: { type: 'function_call', name: 'shell',
+          arguments: JSON.stringify({ command: 'cat ~/.codex/skills/money/SKILL.md' }) } },
+      { type: 'response_item', timestamp: '2025-06-15T10:00:02Z',
+        payload: { role: 'assistant', type: 'message', content: [{ type: 'output_text', text: 'ok' }] } },
+    ], (sessionsDir) => {
+      const sessions = parseCodexSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].requests[0].skillsUsed).toEqual(['money']);
+    });
+  });
+
+  it('leaves skillsUsed empty when no function_call references SKILL.md', () => {
+    withCodexFile([
+      { type: 'session_meta', payload: { id: 'sess-skill-3', cwd: '/Users/me/proj' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.3-codex' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:00Z', payload: { type: 'user_message', message: 'list files' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:01Z',
+        payload: { type: 'function_call', name: 'shell', arguments: { cmd: 'ls README.md' } } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:02Z', payload: { type: 'assistant_message', content: 'done' } },
+    ], (sessionsDir) => {
+      const sessions = parseCodexSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].requests[0].skillsUsed).toEqual([]);
+    });
+  });
+
+  it('excludes the ai_toolkit pseudo-skill', () => {
+    withCodexFile([
+      { type: 'session_meta', payload: { id: 'sess-skill-4', cwd: '/Users/me/proj' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.3-codex' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:00Z', payload: { type: 'user_message', message: 'noop' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:01Z',
+        payload: { type: 'function_call', name: 'shell',
+          arguments: { cmd: 'cat ~/.codex/skills/ai_toolkit/SKILL.md' } } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:02Z', payload: { type: 'assistant_message', content: 'done' } },
+    ], (sessionsDir) => {
+      const sessions = parseCodexSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].requests[0].skillsUsed).toEqual([]);
+    });
+  });
+
+  it('deduplicates a skill referenced multiple times in the same turn', () => {
+    withCodexFile([
+      { type: 'session_meta', payload: { id: 'sess-skill-5', cwd: '/Users/me/proj' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.3-codex' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:00Z', payload: { type: 'user_message', message: 'run twice' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:01Z',
+        payload: { type: 'function_call', name: 'shell', arguments: { cmd: 'cat /a/skills/pdf/SKILL.md' } } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:02Z',
+        payload: { type: 'function_call', name: 'shell', arguments: { cmd: 'cat /b/skills/pdf/SKILL.md' } } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:03Z', payload: { type: 'assistant_message', content: 'done' } },
+    ], (sessionsDir) => {
+      const sessions = parseCodexSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].requests[0].skillsUsed).toEqual(['pdf']);
+    });
+  });
+});
+
 describe('findCodexDirs', () => {
   it('discovers active and archived Codex session directories', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-dirs-test-'));

--- a/src/core/parser-codex.ts
+++ b/src/core/parser-codex.ts
@@ -21,7 +21,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { StringDecoder } from 'string_decoder';
 import { ModelUsage, Session, SessionRequest } from './types';
-import { assertTrustedPath, createRequest, createSession, detectDevcontainerFromRequests } from './parser-shared';
+import { assertTrustedPath, createRequest, createSession, detectDevcontainerFromRequests, extractSkillNameFromPath, extractSkillPathsFromText } from './parser-shared';
 import { canonicalizeReasoningEffort, extractReasoningEffortFromModelId } from './helpers';
 
 interface CodexLine {
@@ -50,6 +50,8 @@ interface CodexParseState {
   currentAssistantTexts: string[];
   currentToolsUsed: string[];
   currentEditedFiles: string[];
+  currentReferencedFiles: string[];
+  currentSkillsUsed: string[];
   turnModel: string;
   turnEffort: 'max' | 'high' | 'medium' | 'low' | null;
   turnStartTs: number | null;
@@ -124,6 +126,8 @@ function createCodexState(initialModel: string): CodexParseState {
     currentAssistantTexts: [],
     currentToolsUsed: [],
     currentEditedFiles: [],
+    currentReferencedFiles: [],
+    currentSkillsUsed: [],
     turnModel: initialModel,
     turnEffort: null,
     turnStartTs: null,
@@ -201,6 +205,8 @@ function flushCodexTurn(state: CodexParseState, defaultModel: string): void {
     modelId: state.turnModel || defaultModel,
     toolsUsed: state.currentToolsUsed,
     editedFiles: [...new Set(state.currentEditedFiles)],
+    referencedFiles: [...new Set(state.currentReferencedFiles)],
+    skillsUsed: [...new Set(state.currentSkillsUsed)],
     totalElapsed: state.turnStartTs && state.lastTs ? state.lastTs - state.turnStartTs : null,
     promptTokens: reqPromptTokens,
     completionTokens: reqCompletionTokens,
@@ -211,6 +217,8 @@ function flushCodexTurn(state: CodexParseState, defaultModel: string): void {
   state.currentAssistantTexts = [];
   state.currentToolsUsed = [];
   state.currentEditedFiles = [];
+  state.currentReferencedFiles = [];
+  state.currentSkillsUsed = [];
   state.turnStartTs = null;
   state.turnCanceled = false;
 }
@@ -226,6 +234,28 @@ function extractContentItems(value: unknown): CodexContentItem[] {
     });
   }
   return items;
+}
+
+/** Pull SKILL.md path references out of Codex function-call arguments,
+ *  which are typically shell commands like `cat .../skills/<name>/SKILL.md`.
+ *  Updates state.currentReferencedFiles and state.currentSkillsUsed. */
+function collectSkillsFromArgs(args: Record<string, unknown> | null | undefined, state: CodexParseState): void {
+  if (!args) return;
+  const candidates: string[] = [];
+  for (const key of ['cmd', 'command', 'script', 'input']) {
+    const v = args[key];
+    if (typeof v === 'string') candidates.push(v);
+    else if (Array.isArray(v)) {
+      for (const part of v) if (typeof part === 'string') candidates.push(part);
+    }
+  }
+  for (const text of candidates) {
+    for (const skillPath of extractSkillPathsFromText(text)) {
+      state.currentReferencedFiles.push(skillPath);
+      const name = extractSkillNameFromPath(skillPath);
+      if (name) state.currentSkillsUsed.push(name);
+    }
+  }
 }
 
 function extractFilePath(args: Record<string, unknown> | null | undefined): string | null {
@@ -251,9 +281,11 @@ function handleUserMessageEvent(payload: Record<string, unknown>, state: CodexPa
 function handleFunctionCallEvent(payload: Record<string, unknown>, state: CodexParseState): void {
   const toolName = stringValue(payload.name) || 'unknown';
   state.currentToolsUsed.push(toolName);
-  if (!CODEX_WRITE_TOOLS.has(toolName.toLowerCase())) return;
 
   const args = recordValue(payload.arguments);
+  collectSkillsFromArgs(args, state);
+
+  if (!CODEX_WRITE_TOOLS.has(toolName.toLowerCase())) return;
   const filePath = extractFilePath(args);
   if (filePath) state.currentEditedFiles.push(filePath);
 }
@@ -330,11 +362,13 @@ function handleFunctionCallResponseItem(payload: Record<string, unknown>, state:
   if (!toolName) return;
 
   state.currentToolsUsed.push(toolName);
-  if (!CODEX_WRITE_TOOLS.has(toolName.toLowerCase())) return;
 
   const args = typeof payload.arguments === 'string'
     ? parseJsonRecord(payload.arguments)
     : recordValue(payload.arguments);
+  collectSkillsFromArgs(args, state);
+
+  if (!CODEX_WRITE_TOOLS.has(toolName.toLowerCase())) return;
   const filePath = extractFilePath(args);
   if (filePath) state.currentEditedFiles.push(filePath);
 }

--- a/src/core/parser-shared.test.ts
+++ b/src/core/parser-shared.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { describe, it, expect } from 'vitest';
-import { detectDevcontainerFromRequests } from './parser-shared';
+import { detectDevcontainerFromRequests, extractSkillPathsFromText } from './parser-shared';
 import { createRequest, createSession } from './parser-shared';
 import { SessionRequest } from './types';
 
@@ -103,6 +103,39 @@ describe('createRequest timestamp sanitization', () => {
   it('keeps null timestamp as null', () => {
     const req = createRequest({ messageText: 'hi', responseText: 'ok', timestamp: null });
     expect(req.timestamp).toBeNull();
+  });
+});
+
+describe('extractSkillPathsFromText', () => {
+  it('returns an empty array for empty, non-string, or non-matching input', () => {
+    expect(extractSkillPathsFromText('')).toEqual([]);
+    expect(extractSkillPathsFromText(undefined as unknown as string)).toEqual([]);
+    expect(extractSkillPathsFromText(null as unknown as string)).toEqual([]);
+    expect(extractSkillPathsFromText('cat README.md')).toEqual([]);
+    expect(extractSkillPathsFromText('echo /skills/foo')).toEqual([]);
+  });
+
+  it('extracts a single SKILL.md path from a shell-style command line', () => {
+    const out = extractSkillPathsFromText('cat ~/.codex/skills/investigate/SKILL.md');
+    expect(out).toEqual(['/skills/investigate/SKILL.md']);
+  });
+
+  it('extracts multiple SKILL.md paths from one string', () => {
+    const cmd = 'cat /a/skills/foo/SKILL.md /b/skills/bar/SKILL.md';
+    expect(extractSkillPathsFromText(cmd)).toEqual([
+      '/skills/foo/SKILL.md',
+      '/skills/bar/SKILL.md',
+    ]);
+  });
+
+  it('extracts paths embedded inside quoted JSON-style text', () => {
+    const text = '{"file":"/Users/me/.claude/skills/money/SKILL.md"}';
+    expect(extractSkillPathsFromText(text)).toEqual(['/skills/money/SKILL.md']);
+  });
+
+  it('does not match SKILL.md outside a skills/ directory', () => {
+    expect(extractSkillPathsFromText('cat /etc/SKILL.md')).toEqual([]);
+    expect(extractSkillPathsFromText('cat /home/me/notes/SKILL.md')).toEqual([]);
   });
 });
 

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -306,6 +306,22 @@ export function extractSkillNameFromPath(rawPath: string): string | null {
   return (name && !name.includes('ai_toolkit')) ? name : null;
 }
 
+/** Regex to find SKILL.md path references embedded inside a larger string
+ *  (e.g. a shell command line like `cat ~/.codex/skills/foo/SKILL.md`).
+ *  The skill segment forbids whitespace and shell quote chars so the match
+ *  cannot run past the path boundary. Slug-style names (the convention in
+ *  the wild) are not affected by these restrictions. */
+const SKILL_PATH_IN_TEXT_RE = /[/\\]skills[/\\][^\s/\\'"`]+[/\\]SKILL\.md/gi;
+
+/** Extract all SKILL.md path references embedded in a string. Use this for
+ *  harnesses whose tool calls expose shell commands or other free-form text
+ *  rather than structured `file_path` arguments (e.g. Codex). For structured
+ *  paths, prefer {@link extractSkillNameFromPath} directly. */
+export function extractSkillPathsFromText(text: string): string[] {
+  if (typeof text !== 'string' || !text) return [];
+  return text.match(SKILL_PATH_IN_TEXT_RE) || [];
+}
+
 /**
  * Optional validation gate that individual parsers can call before returning
  * sessions. Returns the session unchanged if valid, or null (with a warning)


### PR DESCRIPTION
## Description

The Codex parser does not extract `skillsUsed` from session transcripts, so the dashboard's Tool Mastery metric undercounts skill usage for any user running skills inside Codex.

**Asymmetry (measured against a local cache of 1,890 Codex sessions):**

| Harness | Sessions with `skillsUsed` populated | Coverage |
| --- | --- | --- |
| Claude (already works) | 422 / 2,129 | 19.8% |
| Codex (before this fix) | 0 / 1,890 | 0.0% |
| Codex (after this fix) | 767 / 1,890 | 40.6% |

Raw evidence that the data was there to begin with: 806 of 1,602 Codex session files (50.3%) contain a literal `SKILL.md` reference inside a tool-call argument.

**Root cause.** The Claude parser passes referenced file paths through `extractSkillNameFromPath` when assembling a request (see `parser-claude.ts` → `buildClaudeRequest`). The Codex parser collected tool calls but never inspected their arguments for `SKILL.md` references — and Codex skills are typically activated via shell commands like `cat ~/.codex/skills/<name>/SKILL.md` rather than structured `file_path` arguments, so the existing edited-file logic does not catch them.

**Fix.** Adds `extractSkillPathsFromText` to `parser-shared.ts` as a sibling to the existing `extractSkillNameFromPath` — the new helper scans free-form text (a shell command line, a JSON-encoded payload) for embedded `SKILL.md` paths, while the existing helper continues to validate a single clean path. Threads skill detection through both Codex function-call entry points (`event_msg` and `response_item`, the latter with stringified arguments), populating `referencedFiles` and `skillsUsed` on the request. Detection runs regardless of `CODEX_WRITE_TOOLS` membership, since skills are typically activated via read commands.

**Tests.** Five integration tests in `parser-codex.test.ts` cover the happy path (event_msg function_call), the response_item path with stringified arguments, a no-skill-reference clean case, the `ai_toolkit` exclusion, and per-turn deduplication. Five unit tests in `parser-shared.test.ts` cover the new extractor directly (empty/non-string input, single match, multiple matches, embedded-in-JSON case, and negative cases outside `skills/`).

## Related Issues

None.

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests — 1029 tests pass locally)
- [x] Changes are covered by tests (5 in `parser-codex.test.ts`, 5 in `parser-shared.test.ts`)
- [x] Documentation updated (no doc surface changed)
