### PR TITLE
feat: add VS Code Remote SSH / vscode-server Copilot session support

### DIFF
--- a/src/core/parser-debug-logs.ts
+++ b/src/core/parser-debug-logs.ts
@@ -1,0 +1,200 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* VS Code Copilot debug-logs parser for remote SSH / newer VS Code versions.
+ *
+ * Data layout:
+ *   <workspaceStorage>/<wsId>/GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl
+ *
+ * Each line is a span: { ts, dur, sid, type, name, spanId, status, attrs }
+ *
+ * Event flow per user turn:
+ *   session_start → (turn_start → user_message → llm_request → tool_call* → agent_response → turn_end)*
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Session, SessionRequest } from './types';
+import { createRequest, createSession, detectDevcontainerFromRequests } from './parser-shared';
+import { readFile } from './parser-vscode-files';
+import { normalizeModel } from './helpers';
+
+interface DebugSpan {
+  ts: number;
+  dur?: number;
+  sid: string;
+  type: string;
+  name?: string;
+  spanId?: string;
+  status?: string;
+  attrs?: Record<string, unknown>;
+}
+
+interface TurnAccumulator {
+  userMsg: string;
+  userTs: number | null;
+  responseChunks: string[];
+  toolNames: string[];
+  modelId: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+function freshTurn(): TurnAccumulator {
+  return {
+    userMsg: '',
+    userTs: null,
+    responseChunks: [],
+    toolNames: [],
+    modelId: '',
+    inputTokens: 0,
+    outputTokens: 0,
+  };
+}
+
+function parseSpan(line: string): DebugSpan | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.type !== 'string') return null;
+    return {
+      ts: typeof obj.ts === 'number' ? obj.ts : 0,
+      dur: typeof obj.dur === 'number' ? obj.dur : undefined,
+      sid: typeof obj.sid === 'string' ? obj.sid : '',
+      type: obj.type,
+      name: typeof obj.name === 'string' ? obj.name : undefined,
+      spanId: typeof obj.spanId === 'string' ? obj.spanId : undefined,
+      status: typeof obj.status === 'string' ? obj.status : undefined,
+      attrs: typeof obj.attrs === 'object' && obj.attrs !== null ? obj.attrs as Record<string, unknown> : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function flushTurn(turn: TurnAccumulator, requests: SessionRequest[]): void {
+  if (!turn.userMsg && turn.responseChunks.length === 0) return;
+
+  const responseText = turn.responseChunks.join('\n');
+  requests.push(createRequest({
+    messageText: turn.userMsg,
+    responseText,
+    timestamp: turn.userTs,
+    modelId: turn.modelId ? normalizeModel(turn.modelId) : '',
+    toolsUsed: turn.toolNames,
+    promptTokens: turn.inputTokens > 0 ? turn.inputTokens : null,
+    completionTokens: turn.outputTokens > 0 ? turn.outputTokens : null,
+  }));
+}
+
+export function parseDebugLogSession(mainJsonlPath: string, wsId: string, wsName: string, harness: string, customInstructionsBytes?: number): Session | null {
+  let raw: string;
+  try {
+    raw = readFile(mainJsonlPath);
+  } catch {
+    return null;
+  }
+
+  const lines = raw.split('\n');
+  const requests: SessionRequest[] = [];
+  let sessionId = '';
+  let startTime: number | null = null;
+  let turn = freshTurn();
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const span = parseSpan(line);
+    if (!span) continue;
+
+    switch (span.type) {
+      case 'session_start':
+        sessionId = span.sid || wsId;
+        startTime = span.ts || null;
+        break;
+
+      case 'user_message': {
+        // Flush previous turn if it had content
+        if (turn.userMsg || turn.responseChunks.length > 0) {
+          flushTurn(turn, requests);
+        }
+        turn = freshTurn();
+        turn.userTs = span.ts || null;
+        const content = span.attrs?.content;
+        if (typeof content === 'string') {
+          turn.userMsg = content;
+        }
+        break;
+      }
+
+      case 'llm_request': {
+        const attrs = span.attrs;
+        if (!attrs) break;
+        const model = attrs.model;
+        if (typeof model === 'string' && model) {
+          turn.modelId = model;
+        }
+        const inp = attrs.inputTokens;
+        const out = attrs.outputTokens;
+        if (typeof inp === 'number') turn.inputTokens += inp;
+        if (typeof out === 'number') turn.outputTokens += out;
+        break;
+      }
+
+      case 'tool_call': {
+        const toolName = span.name;
+        if (typeof toolName === 'string' && toolName) {
+          turn.toolNames.push(toolName);
+        }
+        break;
+      }
+
+      case 'agent_response': {
+        const attrs = span.attrs;
+        if (!attrs) break;
+        const response = attrs.response;
+        if (typeof response === 'string' && response) {
+          turn.responseChunks.push(response);
+        }
+        break;
+      }
+
+      case 'turn_end':
+        // Turn boundary — flush accumulated turn
+        flushTurn(turn, requests);
+        turn = freshTurn();
+        break;
+    }
+  }
+
+  // Flush any remaining turn
+  flushTurn(turn, requests);
+
+  if (requests.length === 0) return null;
+
+  return createSession({
+    sessionId: sessionId || wsId,
+    workspaceId: wsId,
+    workspaceName: wsName,
+    location: 'panel',
+    harness,
+    creationDate: startTime ?? undefined,
+    requests,
+    customInstructionsBytes,
+    hasDevcontainer: detectDevcontainerFromRequests(requests),
+  });
+}
+
+export function listDebugLogSessions(wsEntryPath: string): string[] {
+  const debugLogsDir = path.join(wsEntryPath, 'GitHub.copilot-chat', 'debug-logs');
+  try {
+    return fs.readdirSync(debugLogsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => path.join(debugLogsDir, d.name, 'main.jsonl'))
+      .filter(p => fs.existsSync(p));
+  } catch {
+    return [];
+  }
+}

--- a/src/core/parser-vscode.ts
+++ b/src/core/parser-vscode.ts
@@ -12,6 +12,7 @@ import { createRequest, createSession, detectDevcontainerFromRequests, extractSk
 import { debugCore, warnCore } from './log';
 import { canonicalizeReasoningEffort, extractReasoningEffortFromModelId } from './helpers';
 import { parseCLIEventsFile } from './parser-vscode-cli';
+import { parseDebugLogSession, listDebugLogSessions } from './parser-debug-logs';
 import { parseCLIWorkspaceName, parseWorkspaceName, parseWorkspaceFolderPath, parseCLIWorkspaceFolderPath, readFile, reconstructFromJsonl, stripImageData } from './parser-vscode-files';
 
 function isObj(v: unknown): v is Record<string, unknown> {
@@ -19,8 +20,9 @@ function isObj(v: unknown): v is Record<string, unknown> {
 }
 
 export function harnessFromPath(logsDir: string): string {
-  if (logsDir.includes('Code - Insiders')) return 'Local Agent (Insiders)';
+  if (logsDir.includes('Code - Insiders') || logsDir.includes('.vscode-server-insiders')) return 'Local Agent (Insiders)';
   if (logsDir.includes('.copilot')) return 'GitHub Copilot CLI';
+  if (logsDir.includes('.vscode-server')) return 'Copilot';
   return 'Local Agent';
 }
 
@@ -40,6 +42,13 @@ export function findVsCodeDirs(): string[] {
       vsPath = path.join(home, '.config', edition, 'User', 'workspaceStorage');
     }
     if (vsPath && fs.existsSync(vsPath) && !dirs.includes(vsPath)) dirs.push(vsPath);
+  }
+
+  // VS Code Remote SSH / Dev Containers — логи на remote-сервері
+  const remoteServerFolders = ['.vscode-server', '.vscode-server-insiders'];
+  for (const serverFolder of remoteServerFolders) {
+    const remotePath = path.join(home, serverFolder, 'data', 'User', 'workspaceStorage');
+    if (fs.existsSync(remotePath) && !dirs.includes(remotePath)) dirs.push(remotePath);
   }
 
   // Copilot CLI paths
@@ -128,6 +137,16 @@ function listChatSessionFiles(chatDir: string): string[] {
     return fs.readdirSync(chatDir, { withFileTypes: true })
       .filter(cf => cf.isFile() && (cf.name.endsWith('.json') || cf.name.endsWith('.jsonl')))
       .map(cf => path.join(chatDir, cf.name));
+  } catch {
+    return [];
+  }
+}
+
+function listTranscriptFiles(transcriptsDir: string): string[] {
+  try {
+    return fs.readdirSync(transcriptsDir, { withFileTypes: true })
+      .filter(cf => cf.isFile() && cf.name.endsWith('.jsonl'))
+      .map(cf => path.join(transcriptsDir, cf.name));
   } catch {
     return [];
   }
@@ -257,6 +276,45 @@ export function processWorkspaceEntry(
     }
   }
 
+  // VS Code Remote SSH: transcripts у GitHub.copilot-chat/transcripts/ (events.jsonl формат)
+  const transcriptsDir = path.join(entryPath, 'GitHub.copilot-chat', 'transcripts');
+  for (const transcriptFile of listTranscriptFiles(transcriptsDir)) {
+    const session = parseCLIEventsFile(transcriptFile, wsId, wsName, customInstructionsBytes);
+    if (session) {
+      session.harness = harness;
+      // Не дублювати якщо debug-log вже покрив цю сесію
+      if (!sessionSourceIndex.has(session.sessionId)) {
+        sessions.push(session);
+        sessionSourceIndex.set(session.sessionId, {
+          kind: 'cli-events',
+          filePath: transcriptFile,
+          workspaceId: wsId,
+          workspaceName: wsName,
+          harness,
+        });
+      }
+    }
+  }
+
+  // VS Code Remote SSH: debug-logs у GitHub.copilot-chat/debug-logs/*/main.jsonl (span формат)
+  const debugLogFiles = listDebugLogSessions(entryPath);
+  for (const debugLogFile of debugLogFiles) {
+    const session = parseDebugLogSession(debugLogFile, wsId, wsName, harness, customInstructionsBytes);
+    if (session) {
+      // Не дублювати якщо transcript вже покрив цю сесію
+      if (!sessionSourceIndex.has(session.sessionId)) {
+        sessions.push(session);
+        sessionSourceIndex.set(session.sessionId, {
+          kind: 'debug-log',
+          filePath: debugLogFile,
+          workspaceId: wsId,
+          workspaceName: wsName,
+          harness,
+        });
+      }
+    }
+  }
+
   const eventsFile = path.join(entryPath, 'events.jsonl');
   const cliSession = parseCLIEventsFile(eventsFile, wsId, wsName, customInstructionsBytes);
   if (cliSession) {
@@ -305,9 +363,12 @@ export async function processWorkspaceEntryAsync(
   }
 
   const chatFiles = listChatSessionFiles(path.join(entryPath, 'chatSessions'));
+  const transcriptFiles = listTranscriptFiles(path.join(entryPath, 'GitHub.copilot-chat', 'transcripts'));
+  const debugLogFilesForCount = listDebugLogSessions(entryPath);
   const editStateFiles = listEditStateFiles(path.join(entryPath, 'chatEditingSessions'));
-  const totalUnits = Math.max(1, chatFiles.length + editStateFiles.length);
+  const totalUnits = Math.max(1, chatFiles.length + transcriptFiles.length + debugLogFilesForCount.length + editStateFiles.length);
   const chatEvery = chunkInterval(chatFiles.length);
+  const transcriptEvery = chunkInterval(transcriptFiles.length);
   const editEvery = chunkInterval(editStateFiles.length);
   let completed = 0;
 
@@ -334,6 +395,63 @@ export async function processWorkspaceEntryAsync(
     }
     // Always yield after each file to keep the event loop responsive,
     // especially for workspaces with many large session files.
+    await yieldToLoop();
+  }
+
+  // VS Code Remote SSH: transcripts у GitHub.copilot-chat/transcripts/ (events.jsonl формат)
+  for (let i = 0; i < transcriptFiles.length; i++) {
+    const session = parseCLIEventsFile(transcriptFiles[i], wsId, wsName, customInstructionsBytes);
+    if (session) {
+      session.harness = harness;
+      if (!sessionSourceIndex.has(session.sessionId)) {
+        sessions.push(session);
+        sessionSourceIndex.set(session.sessionId, {
+          kind: 'cli-events',
+          filePath: transcriptFiles[i],
+          workspaceId: wsId,
+          workspaceName: wsName,
+          harness,
+        });
+      }
+    }
+    completed++;
+    if (shouldReportChunk(i, transcriptFiles.length, transcriptEvery)) {
+      onProgress?.({
+        wsName,
+        detail: `transcripts ${i + 1}/${transcriptFiles.length}`,
+        completed,
+        total: totalUnits,
+      });
+    }
+    await yieldToLoop();
+  }
+
+  // VS Code Remote SSH: debug-logs у GitHub.copilot-chat/debug-logs/*/main.jsonl (span формат)
+  const debugLogFiles = listDebugLogSessions(entryPath);
+  const debugEvery = chunkInterval(debugLogFiles.length);
+  for (let i = 0; i < debugLogFiles.length; i++) {
+    const session = parseDebugLogSession(debugLogFiles[i], wsId, wsName, harness, customInstructionsBytes);
+    if (session) {
+      if (!sessionSourceIndex.has(session.sessionId)) {
+        sessions.push(session);
+        sessionSourceIndex.set(session.sessionId, {
+          kind: 'debug-log',
+          filePath: debugLogFiles[i],
+          workspaceId: wsId,
+          workspaceName: wsName,
+          harness,
+        });
+      }
+    }
+    completed++;
+    if (shouldReportChunk(i, debugLogFiles.length, debugEvery)) {
+      onProgress?.({
+        wsName,
+        detail: `debug-logs ${i + 1}/${debugLogFiles.length}`,
+        completed,
+        total: totalUnits,
+      });
+    }
     await yieldToLoop();
   }
 

--- a/src/webview/panel-llm.ts
+++ b/src/webview/panel-llm.ts
@@ -311,7 +311,7 @@ const LLM_REQUEST_TIMEOUT_MS = 90_000;
  * nothing is available so callers can surface a useful message.
  */
 async function selectModel(): Promise<vscode.LanguageModelChat> {
-  const families = [LLM_FAMILY, 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4'];
+  const families = [LLM_FAMILY, 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4', 'claude-sonnet', 'claude-3.5-sonnet', 'o4-mini', 'o3-mini'];
   for (const family of families) {
     const models = await vscode.lm.selectChatModels({ family });
     if (models.length > 0) return models[0];
@@ -389,6 +389,8 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
       // On parse failures, nudge the model to return valid JSON on the next attempt
       if (lastError instanceof Error && /JSON|parse/i.test(lastError.message)) {
         parseFailures++;
+        // Після першого parse failure, скидаємо structured output і додаємо explicit JSON instruction
+        options.modelOptions = undefined;
         if (retryMessages.length === messages.length) {
           retryMessages.push(vscode.LanguageModelChatMessage.User(
             'Your previous response was not valid JSON. Please respond ONLY with a valid JSON object or array, no markdown fences, no commentary.'


### PR DESCRIPTION
## Problem

When using **VS Code Remote SSH**, Copilot Chat session data lives on the *remote server* at `~/.vscode-server/data/User/workspaceStorage/`. The extension only searched `~/.config/Code/User/workspaceStorage/` (local path), so **all Copilot sessions were invisible** on Remote SSH setups.

Additionally, newer VS Code versions (April 2026+) write sessions in two new formats not previously parsed:
- **Transcripts**: `GitHub.copilot-chat/transcripts/<sessionId>.jsonl` (events format)
- **Debug-logs**: `GitHub.copilot-chat/debug-logs/<sessionId>/main.jsonl` (spans format)

The old `chatSessions/` directory is no longer populated on these newer versions.

## Changes

### `src/core/parser-vscode.ts`
- **`findVsCodeDirs()`**: Added `~/.vscode-server` and `~/.vscode-server-insiders` paths for Remote SSH support.
- **`harnessFromPath()`**: Fixed — `.vscode-server` paths now return `'Copilot'` instead of `'Local Agent'`.
- **`processWorkspaceEntry/Async()`**: Added parsing for transcripts and debug-logs with deduplication.

### `src/core/parser-debug-logs.ts` *(new file)*
Parser for the Copilot Chat span format. Each `main.jsonl` line is a span: `session_start`, `user_message`, `llm_request`, `tool_call`, `agent_response`, `turn_end`.

### `src/webview/panel-llm.ts`
- Added Claude/o4-mini to model fallback list in `selectModel()`
- Clear `modelOptions` on JSON parse failure to disable structured output before retrying

## Result

Before: 0 Copilot sessions on Remote SSH.
After: 172 sessions loaded, all 3 harnesses visible in the dashboard.
