### PR TITLE
fix(metric-engine): make calibration serialization locale-independent

### DIFF
--- a/src/core/metric-engine.ts
+++ b/src/core/metric-engine.ts
@@ -331,8 +331,8 @@ export function calibrate(
  */
 export function serializeCalibration(cal: CalibrationResult): string {
   const lines = ['<!-- calibration:'];
-  lines.push(`  dataset: ${cal.datasetSize.toLocaleString()} ${cal.scope}`);
-  lines.push(`  flagged: ${cal.flaggedCount.toLocaleString()} (${cal.flaggedPct}%)`);
+  lines.push(`  dataset: ${cal.datasetSize.toLocaleString('en-US')} ${cal.scope}`);
+  lines.push(`  flagged: ${cal.flaggedCount.toLocaleString('en-US')} (${cal.flaggedPct}%)`);
   if (cal.distribution) {
     lines.push(`  p25: ${cal.distribution.p25}, p50: ${cal.distribution.p50}, p75: ${cal.distribution.p75}`);
     lines.push(`  min: ${cal.distribution.min}, max: ${cal.distribution.max}`);


### PR DESCRIPTION
## Description

`serializeCalibration()` formats numbers with `Number#toLocaleString()` and **no locale argument**, so the thousands separator follows the host machine's default locale:

- en-US runner → `dataset: 1,234 requests`
- de-DE / de-AT (and many other locales) → `dataset: 1 234 requests` (a U+202F narrow no-break space)

This function emits a **machine-embedded markdown comment** (`<!-- calibration: … -->`) — a serialization artifact, not user-facing display. Locale-dependent output there is non-deterministic across developer/CI machines: it produces spurious diffs, can bake an invisible non-breaking space into committed files, and would break round-trip parsing of the block. It also makes the existing `serializeCalibration` unit test (which asserts `dataset: 1,234 requests`) fail on any non-en-US locale while passing on en-US CI.

### Fix

Pin the serialization to `en-US`, the project's canonical format. en-US output is byte-identical (CI unaffected); all other locales become deterministic. User-facing `toLocaleString()` call sites (webview/UI) are intentionally left locale-adaptive.

```diff
-  lines.push(`  dataset: ${cal.datasetSize.toLocaleString()} ${cal.scope}`);
-  lines.push(`  flagged: ${cal.flaggedCount.toLocaleString()} (${cal.flaggedPct}%)`);
+  lines.push(`  dataset: ${cal.datasetSize.toLocaleString('en-US')} ${cal.scope}`);
+  lines.push(`  flagged: ${cal.flaggedCount.toLocaleString('en-US')} (${cal.flaggedPct}%)`);
```

## Related Issues

None — found while running the test suite on a non-en-US (de-AT) machine, where `serializeCalibration`'s test goes red.

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [x] Changes are covered by tests (the existing `serializeCalibration` test now passes on every locale)
- [ ] Documentation updated (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
