### PR TITLE
fix(e2e): derive burndown current-month assertion from the clock

### DIFF
--- a/tests/e2e/burndown.spec.ts
+++ b/tests/e2e/burndown.spec.ts
@@ -45,6 +45,10 @@ test.describe('Burndown', () => {
 
   test('shows current month', async ({ page }) => {
     const content = await page.textContent('#content');
-    expect(content).toContain('May 2026');
+    // The burndown page defaults to the live current month (page-burndown.ts uses new Date()
+    // and formatMonthLabel's toLocaleString), so derive the expected label the same way
+    // instead of hard-coding it — otherwise the assertion goes stale every month rollover.
+    const expectedMonth = new Date().toLocaleString('default', { month: 'long', year: 'numeric' });
+    expect(content).toContain(expectedMonth);
   });
 });


### PR DESCRIPTION
## Description

The `Burndown › shows current month` e2e test hard-coded `expect(content).toContain('May 2026')`. The burndown page, however, derives its month label from the **live system clock**:

- `src/webview/page-burndown.ts` defaults `selectedMonth` from `new Date()`, and
- renders it via `formatMonthLabel` → `new Date(year, month - 1).toLocaleString('default', { month: 'long', year: 'numeric' })`.

So the assertion only passed during **May 2026** and fails on every later month — the page correctly renders "June 2026", "July 2026", … while the test still expects "May 2026". It is a time-bomb assertion that silently rots on each month rollover.

This derives the expected label the same way the component does, so the test tracks the current month instead of a hard-coded string:

```ts
const expectedMonth = new Date().toLocaleString('default', { month: 'long', year: 'numeric' });
expect(content).toContain(expectedMonth);
```

Test-only change — no production code touched.

## Related Issues

_None._

## Checklist

- [ ] `npm run check` passes — deferred to CI for this test-only change (`eslint`/`cspell` are scoped to `src/`, not `tests/`).
- [x] Changes are covered by tests — this *is* the test; the `tests/e2e/burndown.spec.ts` burndown spec runs green (5/5) in an environment where the e2e harness bootstraps.
- [x] Documentation updated — n/a (test-only).
