### PR TITLE
feat: add Context Files (skills/, AGENTS.md polish) — closes #60

### DIFF
--- a/.claude/skills/package-extension.md
+++ b/.claude/skills/package-extension.md
@@ -1,0 +1,1 @@
+../../skills/package-extension.md

--- a/.claude/skills/update-docs.md
+++ b/.claude/skills/update-docs.md
@@ -1,0 +1,1 @@
+../../skills/update-docs.md

--- a/.github/instructions/package-extension.md
+++ b/.github/instructions/package-extension.md
@@ -1,0 +1,1 @@
+../../skills/package-extension.md

--- a/.github/instructions/update-docs.md
+++ b/.github/instructions/update-docs.md
@@ -1,0 +1,1 @@
+../../skills/update-docs.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,25 @@
+---
+name: AI Engineer Coach
+description: VS Code extension that analyzes local AI session logs and surfaces insights in a webview dashboard. Read-only, zero telemetry, all analysis runs on the user's machine.
+---
+
 # AGENTS.md
 
-Context for AI agents working in this repository. AI Engineer Coach is a VS Code extension that
-analyzes local AI session logs and surfaces insights in a webview dashboard. Read-only, zero
-telemetry, all analysis runs on the user's machine.
+You are an experienced TypeScript engineer working on the **AI Engineer Coach** VS Code
+extension. Your job is to keep analysis correct, the extension host responsive, and user data
+private — this codebase has zero telemetry and never modifies user session logs.
 
 If you're a human, [`README.md`](README.md) is the better starting point.
+
+## Tech stack
+
+- **Node** ≥ 20 (CI uses Node 22)
+- **TypeScript** 6.0.3, strict mode
+- **VS Code engine** `^1.120.0` (`@types/vscode` 1.120.0)
+- **Bundler** esbuild 0.28.0 (`esbuild.mjs`, output → `dist/extension.js`)
+- **Tests** vitest 4.1.7 (unit + inline rule tests), Playwright 1.60.0 (e2e webview)
+- **Lint** eslint 10.4.0
+- **Docs site** Hugo (sources in `docs/content/`, published to `microsoft.github.io/AI-Engineering-Coach/`)
 
 ## Repository map
 
@@ -125,6 +140,38 @@ point at the source markdown so they resolve on GitHub too.
   - [Agentic SDLC](docs/content/level-up/sdlc.md)
   - [Share](docs/content/level-up/share.md)
 
+## Code style
+
+Strict TypeScript, no `any` in new code, prefer named exports, keep heavy work off the
+extension-host thread.
+
+```ts
+// Good: typed, narrow, awaitable, off-thread.
+export async function parseSessions(
+  logsDirs: string[],
+  onProgress: (p: LoadProgress) => void,
+): Promise<ParseResult> {
+  return runWorker('parse-worker', { logsDirs }, onProgress);
+}
+
+// Bad: untyped, blocks the extension host, swallows errors.
+export function parseSessions(logsDirs) {
+  try { return require('./parser').parseSync(logsDirs); } catch { return null; }
+}
+```
+
+Rule and metric files use YAML frontmatter (`id`, `name`, `severity`, …) followed by markdown
+body and an optional `# Tests` block. See [`docs/AUTHORING_RULES.md`](docs/AUTHORING_RULES.md).
+
+## Git workflow
+
+- Branch from `main`: `feat/<scope>`, `fix/<scope>`, `docs/<scope>`, `chore/<scope>`.
+- Commits use Conventional Commits prefixes (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`,
+  `test:`).
+- Run `npm run check` (and `npm run test:e2e` if you touched the webview) before pushing.
+- Reference the issue in the commit body or PR description (`Resolves #123`).
+- See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the CLA + review process.
+
 ## Conventions
 
 - **No telemetry, no network calls** in core analysis paths. The optional AI features (rule
@@ -134,3 +181,31 @@ point at the source markdown so they resolve on GitHub too.
 - **Inclusive language.** Prefer allowlist/denylist, primary/replica, etc.
 - **Author over generate.** Rules and skills are markdown — write them by hand or via the Rule
   Editor, not as opaque generated artifacts.
+
+## Boundaries
+
+✅ **Always:**
+
+- Run `npm run check` before declaring work complete.
+- Add or update inline `# Tests` blocks when changing rule or metric behavior.
+- Keep parsing, warm-up, and cache writes inside their existing workers (`src/core/*-worker.ts`).
+- Use repo-relative markdown links so they resolve on GitHub and in the published Hugo site.
+
+⚠️ **Ask first:**
+
+- Adding a runtime dependency (bundle-size budget enforced by `npm run check-size`).
+- Introducing a network call from the extension host or a worker.
+- Changing the rule trust flow (`pending → review → approve → reload`) or the DSL surface.
+- Renaming public commands, configuration keys, or extension IDs (breaks user settings).
+- Bumping `engines.vscode` or the Node version.
+
+🚫 **Never:**
+
+- Commit secrets, tokens, `.env` files, or anything matching `local/`, `marketing/`,
+  `PROPOSED_FIXES.md`, or other `.gitignore` entries.
+- Edit generated artifacts: `dist/`, `docs/public/`, `*.vsix`, `node_modules/`,
+  `test-results/`, `.vscode-test/`.
+- Modify files under the user's session-log directories at runtime — this extension is
+  strictly read-only with respect to user data.
+- Add telemetry, analytics, or remote logging.
+- Skip hooks (`--no-verify`) or push with failing `npm run check`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,37 +1,136 @@
+# AGENTS.md
+
+Context for AI agents working in this repository. AI Engineer Coach is a VS Code extension that
+analyzes local AI session logs and surfaces insights in a webview dashboard. Read-only, zero
+telemetry, all analysis runs on the user's machine.
+
+If you're a human, [`README.md`](README.md) is the better starting point.
+
+## Repository map
+
+```
+AI-Engineering-Coach/
+├── src/
+│   ├── extension.ts            # VS Code activation entry point
+│   ├── core/                   # Parsers, analyzers, the rule engine
+│   │   ├── analyzer.ts          # Top-level coordinator across analyzer-*.ts
+│   │   ├── parser.ts            # Reads session logs from disk
+│   │   ├── parse-worker.ts      # Worker thread: logsDirs → progress + result/error
+│   │   ├── warm-up-worker.ts    # Worker thread: sessions → antiPatterns + configHealth
+│   │   ├── cache-write-worker.ts# Worker thread: persists cache payload
+│   │   ├── metric-engine.ts     # DSL evaluator for rules and metrics
+│   │   ├── rule-loader.ts       # Loads built-in + personal + project rule layers
+│   │   ├── rule-trust.ts        # Trust gate (pending → review → approve → reload)
+│   │   ├── rules/<id>.md        # 45+ built-in detection rules (markdown + DSL)
+│   │   └── metrics/<id>.metric.md# Built-in metrics referenced by rules
+│   ├── webview/                # Dashboard UI: app.ts plus page-*.ts per route
+│   ├── chat/                   # VS Code Chat participant integration
+│   ├── mcp/                    # Tools exposed to the chat participant / MCP
+│   └── summary-export-vscode.ts# Markdown/JSON summary export
+├── docs/
+│   ├── content/                # Hugo source for https://microsoft.github.io/AI-Engineering-Coach/
+│   ├── AUTHORING_RULES.md      # How to author a rule or metric (DSL + tests)
+│   └── hugo.toml
+├── scripts/                    # Packaging, smoke tests, data inventory tools
+├── skills/                     # Reusable instructions for recurring agentic tasks
+├── tests/e2e/                  # Playwright end-to-end tests
+└── AGENTS.md                   # You are here
+```
+
+## Build, test, and ship
+
+| Task | Command |
+|---|---|
+| Install dependencies | `npm ci` |
+| Bundle the extension | `npm run build` |
+| Watch-mode rebuild | `npm run watch` |
+| Type-check | `npm run typecheck` |
+| Lint | `npm run lint` |
+| Spellcheck markdown + TS | `npm run spellcheck` |
+| Unit tests (vitest) | `npm test` |
+| All checks (CI gate) | `npm run check` |
+| End-to-end (Playwright) | `npm run test:e2e` |
+| Package the VSIX | `npm run package` (see [skills/package-extension.md](skills/package-extension.md)) |
+| Bundle-size budget | `npm run check-size` |
+
+CI runs `npm run check` (typecheck + lint + spellcheck + knip + test) plus the size check on
+every PR. Run those locally before pushing.
+
+## Skills
+
+Repo-specific instructions for recurring tasks live in [`skills/`](skills/). They are symlinked
+into [`.claude/skills/`](.claude/skills/) and [`.github/instructions/`](.github/instructions/)
+so popular agent harnesses pick them up automatically. See
+[`skills/README.md`](skills/README.md) for the authoring format.
+
+Available today:
+
+- [`skills/update-docs.md`](skills/update-docs.md) — author or update a Hugo doc page.
+- [`skills/package-extension.md`](skills/package-extension.md) — produce an installable `.vsix`.
+
+## Rule and metric authoring
+
+Detection rules and metrics are the primary extensibility surface — markdown files with YAML
+front matter and a small DSL, no code changes required.
+
+- Built-in rules: [`src/core/rules/<id>.md`](src/core/rules/) (45+ today)
+- Built-in metrics: [`src/core/metrics/<id>.metric.md`](src/core/metrics/)
+- Authoring guide with annotated examples: [`docs/AUTHORING_RULES.md`](docs/AUTHORING_RULES.md)
+- Trust layers (built-in / personal / project) gated through
+  [`src/core/rule-trust.ts`](src/core/rule-trust.ts)
+
+Rules ship with inline `# Tests` blocks that run as part of `npm test`.
+
 ## Workers
 
-- [warm-up-worker.ts](src/core/warm-up-worker.ts): `sessions` -> `antiPatterns` + `configHealth`.
-- [parse-worker.ts](src/core/parse-worker.ts): `logsDirs` -> `progress` + `result`/`error`.
-- [cache-write-worker.ts](src/core/cache-write-worker.ts): writes cache payload.
+Heavy lifting happens off the extension host thread:
 
-## Local Rule Trust Flow
+- [`src/core/parse-worker.ts`](src/core/parse-worker.ts) — `logsDirs` → `progress` + `result`/`error`.
+- [`src/core/warm-up-worker.ts`](src/core/warm-up-worker.ts) — `sessions` → `antiPatterns` + `configHealth`.
+- [`src/core/cache-write-worker.ts`](src/core/cache-write-worker.ts) — persists the cache payload.
 
-Rules move pending→review→approve→reload; edits revoke trust. See [anti-patterns](docs/content/improve/anti-patterns.md) and [rule editor](docs/content/improve/rule-editor.md).
+## Local rule trust flow
 
-## Documentation Index
+Rules move pending → review → approve → reload; edits revoke trust. See
+[`docs/content/improve/anti-patterns.md`](docs/content/improve/anti-patterns.md) and
+[`docs/content/improve/rule-editor.md`](docs/content/improve/rule-editor.md).
 
-This is a quick map of the docs tree so readers and agents can see the available pages at a glance.
+## Documentation index
 
-- [Features](/features/)
-- [Getting Started](/getting-started/)
-  - [Installation](/getting-started/installation/)
-  - [Supported Tools](/getting-started/supported-tools/)
-- [Improve](/improve/)
-  - [Anti-Patterns](/improve/anti-patterns/)
-  - [Context Health](/improve/context-health/)
-  - [Data Explorer](/improve/data-explorer/)
-  - [Rule Editor](/improve/rule-editor/)
-  - [Rule Playground](/improve/rule-playground/)
-  - [Skill Finder](/improve/skill-finder/)
-- [Level Up](/level-up/)
-  - [Achievements](/level-up/achievements/)
-  - [Learning Center](/level-up/learning/)
-  - [Agentic SDLC](/level-up/sdlc/)
-  - [Share](/level-up/share/)
-- [Measure](/measure/)
-  - [Burndown](/measure/burndown/)
-  - [Output](/measure/output/)
-  - [Activity Patterns](/measure/patterns/)
-- [Observe](/observe/)
-  - [Dashboard](/observe/dashboard/)
-  - [Timeline](/observe/timeline/)
+These pages are published at https://microsoft.github.io/AI-Engineering-Coach/. The links below
+point at the source markdown so they resolve on GitHub too.
+
+- Top-level: [`docs/content/_index.md`](docs/content/_index.md)
+- Features: [`docs/content/features/_index.md`](docs/content/features/_index.md)
+- Getting Started
+  - [Installation](docs/content/getting-started/installation.md)
+  - [Supported Tools](docs/content/getting-started/supported-tools.md)
+- Observe
+  - [Dashboard](docs/content/observe/dashboard.md)
+  - [Timeline](docs/content/observe/timeline.md)
+- Measure
+  - [Output](docs/content/measure/output.md)
+  - [Burndown](docs/content/measure/burndown.md)
+  - [Activity Patterns](docs/content/measure/patterns.md)
+- Improve
+  - [Anti-Patterns](docs/content/improve/anti-patterns.md)
+  - [Rule Editor](docs/content/improve/rule-editor.md)
+  - [Rule Playground](docs/content/improve/rule-playground.md)
+  - [Data Explorer](docs/content/improve/data-explorer.md)
+  - [Skill Finder](docs/content/improve/skill-finder.md)
+  - [Context Health](docs/content/improve/context-health.md)
+- Level Up
+  - [Achievements](docs/content/level-up/achievements.md)
+  - [Learning Center](docs/content/level-up/learning.md)
+  - [Agentic SDLC](docs/content/level-up/sdlc.md)
+  - [Share](docs/content/level-up/share.md)
+
+## Conventions
+
+- **No telemetry, no network calls** in core analysis paths. The optional AI features (rule
+  compiler, skill finder, context review) use the VS Code Copilot language model API only when
+  the user explicitly invokes them.
+- **Read-only with respect to user data.** The extension never modifies session log files.
+- **Inclusive language.** Prefer allowlist/denylist, primary/replica, etc.
+- **Author over generate.** Rules and skills are markdown — write them by hand or via the Rule
+  Editor, not as opaque generated artifacts.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,51 @@
+# Skills
+
+Reusable instruction files for recurring tasks in this repo. Each skill is a single markdown
+file with YAML front matter that names it and describes when an AI agent should invoke it.
+
+## Available skills
+
+| Skill | When to use |
+|---|---|
+| [update-docs](update-docs.md) | Update or add a page under `docs/content/` |
+| [package-extension](package-extension.md) | Build the `.vsix` via `npm run package` |
+
+## Layout
+
+Skills live here as the canonical source. Symlinks in harness-specific directories make them
+auto-discoverable by popular AI coding harnesses without duplicating content:
+
+| Harness | Path | Notes |
+|---|---|---|
+| Claude Code | [`.claude/skills/`](../.claude/skills/) | Symlinks to files in this directory |
+| GitHub Copilot / awesome-copilot | [`.github/instructions/`](../.github/instructions/) | Symlinks to files in this directory |
+
+When you add a skill, create the symlinks too:
+
+```bash
+ln -s ../../skills/<skill>.md .claude/skills/<skill>.md
+ln -s ../../skills/<skill>.md .github/instructions/<skill>.md
+```
+
+## Authoring
+
+Front matter:
+
+```yaml
+---
+name: kebab-case-id
+description: One-line summary an agent reads to decide whether the skill applies.
+when_to_use: Concrete trigger phrases or situations.
+---
+```
+
+Body sections we use consistently:
+
+- A short overview of what the skill produces or changes.
+- Prerequisites, then the **Steps** as commands the agent can run.
+- Troubleshooting for common failure modes.
+- An **Anti-patterns** section describing what *not* to do — these prevent regressions when
+  agents pattern-match from training data instead of from this repo.
+
+Keep skills repo-specific. Generic agentic-engineering tips belong in
+[`AGENTS.md`](../AGENTS.md), not here.

--- a/skills/package-extension.md
+++ b/skills/package-extension.md
@@ -1,0 +1,93 @@
+---
+name: package-extension
+description: Build the AI Engineer Coach VS Code extension into an installable .vsix.
+when_to_use: User asks to "package the extension", "build a vsix", "make a release artifact",
+  or wants to test a local build in VS Code.
+---
+
+# Package Extension
+
+Produces `ai-engineer-coach-<version>.vsix` at the repo root, suitable for
+`code --install-extension`.
+
+## Prerequisites
+
+- Node.js (matches `engines.vscode` of `^1.120.0` from `package.json`; any recent LTS works).
+- `npm ci` to install dependencies — do **not** use `npm install` for a packaging build, since
+  the lockfile is the source of truth.
+- `vsce` is invoked through `npx`; no global install needed.
+
+## Steps
+
+```bash
+npm ci
+npm run package
+```
+
+`npm run package` runs [`scripts/package-readme-swap.mjs`](../scripts/package-readme-swap.mjs),
+which:
+
+1. Renames the GitHub-facing `README.md` to `README.github.md`.
+2. Copies `README.extension.md` into `README.md` (this is the README the Marketplace shows).
+3. Runs `vsce package --allow-missing-repository --no-dependencies`, which itself triggers the
+   `vscode:prepublish` script → `npm run build` → `node esbuild.mjs` to bundle into
+   `dist/extension.js`.
+4. Restores the original `README.md` regardless of build success.
+
+The `--no-dependencies` flag is required because runtime dependencies are bundled into
+`dist/extension.js` by esbuild; `node_modules/` is excluded via `.vscodeignore`.
+
+## Output
+
+- `ai-engineer-coach-<version>.vsix` at the repo root.
+- `dist/extension.js` (the bundled entry point).
+
+Install locally to smoke-test:
+
+```bash
+code --install-extension ai-engineer-coach-*.vsix
+```
+
+Then **AI Engineer Coach: Open Dashboard** from the command palette.
+
+## Size budgets
+
+[`scripts/check-bundle-size.mjs`](../scripts/check-bundle-size.mjs) enforces:
+
+- `dist/extension.js` ≤ 2 MB
+- Any `*.vsix` at the repo root ≤ 5 MB
+
+Run it after packaging:
+
+```bash
+npm run check-size
+```
+
+## Troubleshooting
+
+- **`README.github.md` left behind** — the swap script aborted before its `finally` could rename
+  the file back. Manually `mv README.github.md README.md` before re-running.
+- **`vsce: command not found`** — `npx vsce` should resolve through `node_modules/.bin/`; run
+  `npm ci` if it doesn't, since `vsce` is a transitive dev dependency.
+- **`Missing publisher name`** — the `publisher` field in `package.json` is required; do not
+  remove it when bumping the version.
+- **Bundle over budget** — usually a new dependency that wasn't tree-shaken. Check
+  `npm run analyze:data-inventory` and the esbuild output, then either drop the dep or split it
+  into a dynamic import.
+- **Spellcheck or lint fails first** — `npm run check` (typecheck + lint + spellcheck + knip +
+  test) is what CI runs; fix those before packaging if the goal is a release.
+
+## Versioning
+
+Bump `version` in `package.json`, add a `CHANGELOG.md` entry, then commit before packaging so
+the `.vsix` filename matches the released tag. Do not amend the commit after building — it's
+fine to ship a `.vsix` whose embedded git SHA differs from the tag.
+
+## Anti-patterns
+
+- Don't run `vsce package` directly — you'll ship `README.md` (the GitHub one with screenshots
+  and badges) instead of `README.extension.md`.
+- Don't commit the `.vsix`; it's listed in `.gitignore` style via convention. Attach it to a
+  GitHub Release instead.
+- Don't disable `--no-dependencies` "to be safe" — it will bloat the package past the 5 MB
+  budget and double-ship code that's already bundled.

--- a/skills/update-docs.md
+++ b/skills/update-docs.md
@@ -1,0 +1,108 @@
+---
+name: update-docs
+description: Update or add a documentation page under docs/content/ (Hugo static site).
+when_to_use: User asks to "update the docs", "add a doc page", "fix the documentation", or
+  changes a feature whose page is published at https://microsoft.github.io/AI-Engineering-Coach/.
+---
+
+# Update Docs
+
+The published docs at https://microsoft.github.io/AI-Engineering-Coach/ are built from
+[`docs/`](../docs/) with Hugo. Each page is a markdown file with YAML front matter; section
+landing pages are `_index.md`.
+
+## Layout
+
+```
+docs/
+├── hugo.toml                      # site config
+├── AUTHORING_RULES.md             # rule and metric authoring guide (separate doc, not Hugo)
+├── content/
+│   ├── _index.md                  # site home
+│   ├── features/_index.md
+│   ├── getting-started/{installation,supported-tools}.md
+│   ├── improve/{anti-patterns,context-health,data-explorer,
+│   │            rule-editor,rule-playground,skill-finder}.md
+│   ├── level-up/{achievements,learning,sdlc,share}.md
+│   ├── measure/{burndown,output,patterns}.md
+│   └── observe/{dashboard,timeline}.md
+└── themes/                        # Hugo theme; do not edit
+```
+
+The page URL maps from the file path: `docs/content/improve/skill-finder.md` →
+`/improve/skill-finder/`.
+
+## Front matter
+
+Every content page starts with:
+
+```yaml
+---
+title: "Skill Finder"
+weight: 20            # ordering inside the section
+description: "One-line summary used in section listings"
+---
+```
+
+Section index files (`_index.md`) use the same front matter; their `weight` orders the section in
+the top-level nav.
+
+## Internal links
+
+Inside `docs/content/`, link to other pages by their **site path**:
+
+```markdown
+See the [Rule Editor](/improve/rule-editor/) for live-test details.
+```
+
+Outside `docs/content/` — including from `AGENTS.md`, `README.md`, or `CONTRIBUTING.md` — these
+site paths do **not** resolve on GitHub. Use a repo-relative path instead:
+
+```markdown
+See [docs/content/improve/rule-editor.md](docs/content/improve/rule-editor.md).
+```
+
+## Screenshots
+
+- Drop the image at `docs/static/screenshots/<slug>.png`. Hugo serves it at
+  `/screenshots/<slug>.png`.
+- Reuse an existing dashboard screenshot from `assets/` only if it already shows the page; do not
+  copy assets into `docs/static/` to avoid drift.
+- Reference inside a doc page:
+
+  ```markdown
+  ![Skill Finder](/screenshots/screen-skill-finder.png)
+  ```
+
+## Local preview
+
+Hugo is not pinned in this repo. Install it locally
+(`brew install hugo` / `go install github.com/gohugoio/hugo@latest`) then:
+
+```bash
+cd docs
+hugo server -D
+```
+
+The PDF build (`docs/build-pdf.sh`) is optional; CI doesn't require it for a docs PR.
+
+## Cross-references to update
+
+When you add or rename a page, also update:
+
+- `AGENTS.md` Documentation Index at the repo root.
+- The section's `_index.md` bullet list (e.g. `docs/content/improve/_index.md`).
+- Any sibling pages that link to the renamed page.
+- `README.md` "Pages" tables if the change affects feature framing.
+
+## Spellcheck
+
+`npm run spellcheck` runs cspell over `docs/**/*.md`. Add genuine new terms (product names,
+acronyms) to `cspell.json` — do not silence the check inline.
+
+## Anti-patterns
+
+- Don't add a doc page without an entry in the section's `_index.md` — the nav skips it.
+- Don't link to `https://microsoft.github.io/AI-Engineering-Coach/...` from within `docs/content/`
+  pages; use the relative site path so local preview works too.
+- Don't write content that duplicates `README.md` — link to the doc page from the README instead.


### PR DESCRIPTION
## Summary

Resolves #60. Establishes the repo's "Context Files" surface for AI agents.

- **`skills/`** — repo-specific instructions for the two recurring tasks called out in the issue:
  - [`skills/update-docs.md`](skills/update-docs.md) — author or update a Hugo doc page.
  - [`skills/package-extension.md`](skills/package-extension.md) — produce an installable `.vsix`.
  - [`skills/README.md`](skills/README.md) — authoring format and the symlink convention.
- **Symlinks** so popular harnesses auto-discover skills without duplicating content:
  - `.claude/skills/*.md` → Claude Code
  - `.github/instructions/*.md` → Copilot / `awesome-copilot`
- **`AGENTS.md`** rewritten and polished against the [GitHub blog rubric][1]:
  - Replaces broken Hugo-style `/improve/...` links with repo-relative paths that resolve on GitHub.
  - YAML frontmatter, explicit persona, repo map, build/test commands, rule + skill authoring pointers, local trust flow.
  - Tech stack with pinned versions (Node, TS, vitest, Playwright, esbuild, eslint, VS Code engine).
  - Code style with a good-vs-bad TypeScript snippet.
  - Git workflow (branch naming, Conventional Commits, pre-push checks).
  - Three-tier boundaries: ✅ Always / ⚠️ Ask first / 🚫 Never — with explicit never-commit-secrets and never-edit-generated-artifacts lists.

[1]: https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/

Markdown-only change. No runtime/build code touched.

## Test plan

- [x] `npm run spellcheck` passes
- [x] All `AGENTS.md` repo-relative links resolve in GitHub's preview
- [x] `skills/` symlinks resolve to the same content under `.claude/skills/` and `.github/instructions/`
- [ ] Reviewer sanity-check: skills are scoped to one task each, not a generalist dumping ground
- [ ] Reviewer sanity-check: boundaries reflect actual repo conventions (no telemetry, read-only user data, bundle-size budget)