### PR TITLE
added pi harness to AI Engineering Coach...

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -17,6 +17,7 @@ AI Engineer Coach reads logs from multiple AI coding tools:
 | **Claude** | Session files from Anthropic's CLI-based coding assistant |
 | **Codex** | Session history from OpenAI's terminal agent |
 | **OpenCode** | Session logs from the open-source terminal coding tool |
+| **Pi Coding Agent** | JSONL session logs from the Pi Coding Agent (`~/.pi/agent/sessions/`) |
 | **GitHub Copilot CLI** | Session state and history from the Copilot CLI terminal agent |
 
 ## How It Works

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -3,7 +3,7 @@ title: "Getting Started"
 weight: 10
 ---
 
-AI Engineer Coach is a VS Code extension that analyzes your AI-assisted coding sessions. It reads local log files from VS Code, GitHub Copilot for Xcode, Claude, Codex, OpenCode, and GitHub Copilot CLI, then presents detailed analytics in an interactive webview panel.
+AI Engineer Coach is a VS Code extension that analyzes your AI-assisted coding sessions. It reads local log files from VS Code, GitHub Copilot for Xcode, Claude, Codex, OpenCode, Pi Coding Agent, and GitHub Copilot CLI, then presents detailed analytics in an interactive webview panel.
 
 ## Requirements
 

--- a/docs/content/getting-started/supported-tools.md
+++ b/docs/content/getting-started/supported-tools.md
@@ -32,6 +32,10 @@ Reads session history from OpenAI's Codex terminal agent. Captures prompts, comp
 
 Parses session logs from the open-source OpenCode terminal tool that supports multiple LLM backends.
 
+## Pi Coding Agent
+
+Reads JSONL session logs from the Pi Coding Agent, stored under `~/.pi/agent/sessions/`. Each session is parsed from its tree of entries (messages, model changes, tool calls) into a structured conversation, preserving the working directory, timestamps, model, and per-turn token usage.
+
 ## GitHub Copilot for Xcode
 
 Reads Copilot Chat conversation logs from Apple's Xcode IDE. Sessions are parsed from SQLite databases stored in the GitHub Copilot configuration directory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "vitest": "4.1.7"
       },
       "engines": {
-        "vscode": "^1.118.0"
+        "vscode": "^1.120.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -511,7 +511,6 @@
       "integrity": "sha512-IQA++Idqb8fZzkCbHq3+T+9yG9WpeaBxomOrG2KcR/Pj0CgnovzuApYKL2cc35UWLePboKinMeqEPiweFpHVug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=22.18.0"
       }
@@ -593,8 +592,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
       "integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.2",
@@ -734,16 +732,14 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
       "integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
       "integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -941,8 +937,7 @@
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
       "integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -1100,7 +1095,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1149,7 +1143,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1161,7 +1154,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -1174,7 +1166,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3226,7 +3217,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -3297,7 +3287,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -3486,7 +3475,6 @@
       "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.60.0",
@@ -3826,7 +3814,6 @@
       "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.7",
@@ -4208,7 +4195,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4651,7 +4637,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4891,7 +4876,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -6145,7 +6129,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6210,7 +6193,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8083,7 +8065,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9618,7 +9599,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
       "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10890,7 +10870,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11065,7 +11044,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11169,7 +11147,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -11305,7 +11282,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11412,7 +11388,6 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",

--- a/src/core/analyzer-insights.ts
+++ b/src/core/analyzer-insights.ts
@@ -614,10 +614,10 @@ export class InsightsAnalyzer extends AnalyzerBase {
       { feature: 'Plan Mode', description: 'Separate planning step before implementation', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude'] },
       { feature: 'Skills', description: 'Domain-specific knowledge modules', harnesses: ['Local Agent', 'Local Agent (Insiders)'] },
       { feature: 'Slash Commands', description: '/fix, /explain, /tests, /doc', harnesses: ['Local Agent', 'Local Agent (Insiders)'] },
-      { feature: 'Multi-file Edits', description: 'Edit multiple files in a single turn', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude', 'Codex'] },
-      { feature: 'Terminal Access', description: 'Run commands as part of agent workflow', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude', 'Codex', 'OpenCode'] },
+      { feature: 'Multi-file Edits', description: 'Edit multiple files in a single turn', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude', 'Codex', 'Pi Coding Agent'] },
+      { feature: 'Terminal Access', description: 'Run commands as part of agent workflow', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude', 'Codex', 'OpenCode', 'Pi Coding Agent'] },
       { feature: 'File References', description: 'Reference specific files in prompts', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude'] },
-      { feature: 'Parallel Sessions', description: 'Run multiple conversations simultaneously', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude', 'Codex'] },
+      { feature: 'Parallel Sessions', description: 'Run multiple conversations simultaneously', harnesses: ['Local Agent', 'Local Agent (Insiders)', 'Claude', 'Codex', 'Pi Coding Agent'] },
     ];
   }
 

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -10,6 +10,7 @@ import { Workspace, Session } from './types';
 import { findClaudeDirs, parseClaudeSessions, parseClaudeSessionsAsync } from './parser-claude';
 import { findCodexDirs, parseCodexSessions } from './parser-codex';
 import { findOpenCodeDirs, parseOpenCodeSessions } from './parser-opencode';
+import { findPiDirs, parsePiSessions } from './parser-pi';
 
 type WorkspaceMap = Map<string, Workspace>;
 
@@ -69,6 +70,14 @@ const EXTERNAL_HARNESSES: ExternalHarnessCollector[] = [
       }
     },
   },
+  {
+    name: 'Pi Coding Agent',
+    collectSync(ctx) {
+      for (const piDir of findPiDirs()) {
+        for (const session of parsePiSessions(piDir)) addSession(ctx.workspaces, ctx.sessions, session, piDir);
+      }
+    },
+  },
 ];
 
 export interface ExternalHarnessProgressHandlers {
@@ -88,7 +97,7 @@ export function hasExternalHarnessSources(): boolean {
   // string and probe relative paths (e.g. `.claude/projects`) under the current
   // working directory, which could report false positives. Bail out instead.
   if (!process.env.HOME && !process.env.USERPROFILE) return false;
-  return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
+  return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0 || findPiDirs().length > 0;
 }
 
 export function collectExternalHarnessesSync(workspaces: WorkspaceMap, sessions: Session[]): void {
@@ -106,6 +115,7 @@ export const EXTERNAL_HARNESS_SET = new Set<string>([
   'Claude',
   'Codex',
   'OpenCode',
+  'Pi Coding Agent',
 ]);
 
 export async function collectExternalHarnessesAsync(

--- a/src/core/parser-pi-extra.test.ts
+++ b/src/core/parser-pi-extra.test.ts
@@ -1,0 +1,411 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Extra edge-case coverage for the Pi Coding Agent parser. Templated on the
+ * Codex (OpenAI terminal agent) extra-coverage suite — empty/invalid input,
+ * header fallbacks, tree-entry handling, tool/skill extraction, model
+ * switching, multi-round token accumulation, and multi-file scanning. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { parsePiSessions } from './parser-pi';
+import { MAX_FILE_SIZE } from './parser-shared';
+
+type PiFixture = {
+  /** Encoded project dir + filename, e.g. `--Users-me-proj--/sess.jsonl`. */
+  relativePath: string;
+  content: string | object[];
+};
+
+function encodeCwd(cwd: string): string {
+  return '--' + cwd.replace(/^\//, '').replaceAll('/', '-') + '--';
+}
+
+function stringifyLines(lines: object[]): string {
+  return lines.map(line => JSON.stringify(line)).join('\n');
+}
+
+function withPiRoot(run: (sessionsDir: string) => void): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-parser-extra-'));
+  const sessionsDir = path.join(root, '.pi', 'agent', 'sessions');
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  try {
+    run(sessionsDir);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writePiFixture(sessionsDir: string, relativePath: string, content: string | object[]): void {
+  const filePath = path.join(sessionsDir, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, typeof content === 'string' ? content : stringifyLines(content), 'utf-8');
+}
+
+function withPiFiles(files: PiFixture[], run: (sessionsDir: string) => void): void {
+  withPiRoot((sessionsDir) => {
+    for (const file of files) writePiFixture(sessionsDir, file.relativePath, file.content);
+    run(sessionsDir);
+  });
+}
+
+/** Convenience: one session file under `/Users/me/proj`. */
+function withPiFile(lines: (string | object)[], run: (sessionsDir: string) => void): void {
+  const content = lines.map(l => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n');
+  withPiRoot((sessionsDir) => {
+    writePiFixture(sessionsDir, `${encodeCwd('/Users/me/proj')}/sess_uuid.jsonl`, content);
+    run(sessionsDir);
+  });
+}
+
+const HEADER = {
+  type: 'session', version: 3, id: 'sess-uuid-1234-5678',
+  timestamp: '2026-06-02T07:20:57.002Z', cwd: '/Users/me/proj',
+};
+
+/** Parse a single expected session from a set of lines. */
+function parseSingleSession(lines: (string | object)[]) {
+  let session: ReturnType<typeof parsePiSessions>[number] | undefined;
+  withPiFile(lines, (sessionsDir) => {
+    const sessions = parsePiSessions(sessionsDir);
+    expect(sessions).toHaveLength(1);
+    session = sessions[0];
+  });
+  return session!;
+}
+
+describe('parsePiSessions extra coverage', () => {
+  describe('empty and invalid input', () => {
+    it('returns no sessions for an empty file', () => {
+      withPiFile([''], (sessionsDir) => {
+        expect(parsePiSessions(sessionsDir)).toEqual([]);
+      });
+    });
+
+    it('returns no sessions for a header-only file with no message entries', () => {
+      withPiFile([HEADER], (sessionsDir) => {
+        expect(parsePiSessions(sessionsDir)).toEqual([]);
+      });
+    });
+
+    it('returns no sessions for invalid JSON lines only', () => {
+      withPiFile(['{not valid json}', 'still not json'], (sessionsDir) => {
+        expect(parsePiSessions(sessionsDir)).toEqual([]);
+      });
+    });
+
+    it('ignores invalid JSON lines when valid entries exist', () => {
+      withPiFile([
+        JSON.stringify(HEADER),
+        '{broken',
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hello' } },
+        'not json either',
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'world' }], usage: { input: 1, output: 1 } } },
+      ], (sessionsDir) => {
+        const sessions = parsePiSessions(sessionsDir);
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].requests[0].messageText).toBe('hello');
+        expect(sessions[0].requests[0].responseText).toBe('world');
+      });
+    });
+  });
+
+  describe('header handling', () => {
+    it('falls back to the file name for sessionId when the header has no id', () => {
+      const headerNoId = { type: 'session', version: 3, timestamp: '2026-06-02T07:20:57.002Z', cwd: '/Users/me/proj' };
+      const session = parseSingleSession([
+        headerNoId,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hi' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'yo' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.sessionId).toBe('sess_uuid');
+    });
+
+    it('treats the first line as an entry when it is not a session header', () => {
+      // No header line at all: the file starts directly with message entries.
+      const session = parseSingleSession([
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'no header here' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'ok' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.requests).toHaveLength(1);
+      expect(session.requests[0].messageText).toBe('no header here');
+      // cwd is recovered from the encoded directory name.
+      expect(session.workspaceRootPath).toBe('/Users/me/proj');
+    });
+
+    it('uses the header timestamp as the session creation date', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T08:00:00.000Z', message: { role: 'user', content: 'hi' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T08:00:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'yo' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.creationDate).toBe(new Date('2026-06-02T07:20:57.002Z').getTime());
+    });
+  });
+
+  describe('message content shapes', () => {
+    it('accepts a plain string as user content', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'plain string prompt' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'ok' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.requests[0].messageText).toBe('plain string prompt');
+    });
+
+    it('joins multiple assistant text blocks with newlines and excludes thinking', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hi' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: {
+            role: 'assistant', model: 'm', usage: { input: 1, output: 1 },
+            content: [
+              { type: 'thinking', thinking: 'internal reasoning' },
+              { type: 'text', text: 'line one' },
+              { type: 'text', text: 'line two' },
+            ],
+          },
+        },
+      ]);
+      expect(session.requests[0].responseText).toBe('line one\nline two');
+      expect(session.requests[0].responseText).not.toContain('internal reasoning');
+    });
+
+    it('ignores message entries without a recognizable role', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hi' } },
+        { type: 'message', id: 'x1', parentId: 'u1', timestamp: '2026-06-02T07:21:00.500Z', message: { content: 'no role here' } },
+        { type: 'message', id: 'a1', parentId: 'x1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'ok' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.requests).toHaveLength(1);
+      expect(session.requests[0].responseText).toBe('ok');
+    });
+  });
+
+  describe('tool call handling', () => {
+    it('marks write-tool targets as edited and surfaces written content as a code block', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'write it' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: {
+            role: 'assistant', model: 'm', usage: { input: 1, output: 1 },
+            content: [{ type: 'toolCall', id: 't1', name: 'write', arguments: { path: 'src/new.ts', content: 'export const x = 1;' } }],
+          },
+        },
+      ]);
+      expect(session.requests[0].toolsUsed).toEqual(['write']);
+      expect(session.requests[0].editedFiles).toEqual(['src/new.ts']);
+      expect(session.requests[0].aiCode.length).toBeGreaterThan(0);
+      expect(session.requests[0].aiCode[0].language).toBe('typescript');
+    });
+
+    it('records a write tool with no path without crashing and edits nothing', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'go' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: { role: 'assistant', model: 'm', usage: { input: 1, output: 1 }, content: [{ type: 'toolCall', id: 't1', name: 'write', arguments: {} }] },
+        },
+      ]);
+      expect(session.requests[0].toolsUsed).toEqual(['write']);
+      expect(session.requests[0].editedFiles).toEqual([]);
+    });
+
+    it('records read tools as referenced files, not edits', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'read it' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: { role: 'assistant', model: 'm', usage: { input: 1, output: 1 }, content: [{ type: 'toolCall', id: 't1', name: 'read', arguments: { path: 'src/app.ts' } }] },
+        },
+      ]);
+      expect(session.requests[0].referencedFiles).toEqual(['src/app.ts']);
+      expect(session.requests[0].editedFiles).toEqual([]);
+    });
+
+    it('deduplicates the same edited file referenced multiple times in a turn', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'edit twice' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: {
+            role: 'assistant', model: 'm', usage: { input: 1, output: 1 },
+            content: [
+              { type: 'toolCall', id: 't1', name: 'edit', arguments: { path: 'src/app.ts', new_string: 'a' } },
+              { type: 'toolCall', id: 't2', name: 'edit', arguments: { path: 'src/app.ts', new_string: 'b' } },
+            ],
+          },
+        },
+      ]);
+      expect(session.requests[0].editedFiles).toEqual(['src/app.ts']);
+    });
+  });
+
+  describe('skill extraction', () => {
+    it('extracts a skill from a bashExecution command that references SKILL.md', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'use a skill' } },
+        { type: 'message', id: 'b1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'bashExecution', command: 'cat /Users/me/.pi/skills/pdf-tools/SKILL.md', output: '...', exitCode: 0 } },
+        { type: 'message', id: 'a1', parentId: 'b1', timestamp: '2026-06-02T07:21:02.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'done' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.requests[0].skillsUsed).toContain('pdf-tools');
+      expect(session.requests[0].toolsUsed).toContain('bash');
+    });
+
+    it('extracts a skill from a bash toolCall command argument', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'use a skill' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: { role: 'assistant', model: 'm', usage: { input: 1, output: 1 }, content: [{ type: 'toolCall', id: 't1', name: 'bash', arguments: { command: 'cat /Users/me/.pi/skills/data-viz/SKILL.md' } }] },
+        },
+      ]);
+      expect(session.requests[0].skillsUsed).toContain('data-viz');
+    });
+  });
+
+  describe('model switching and cancellation', () => {
+    it('propagates a model_change entry to later turns', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'first' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'claude-opus-4-8', content: [{ type: 'text', text: 'one' }], usage: { input: 1, output: 1 } } },
+        { type: 'model_change', id: 'mc', parentId: 'a1', timestamp: '2026-06-02T07:21:02.000Z', provider: 'openai', modelId: 'gpt-5.5' },
+        { type: 'message', id: 'u2', parentId: 'mc', timestamp: '2026-06-02T07:21:03.000Z', message: { role: 'user', content: 'second' } },
+        // Assistant message omits `model` — should inherit the changed default.
+        { type: 'message', id: 'a2', parentId: 'u2', timestamp: '2026-06-02T07:21:04.000Z', message: { role: 'assistant', content: [{ type: 'text', text: 'two' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.requests).toHaveLength(2);
+      expect(session.requests[0].modelId).toBe('claude-opus-4-8');
+      expect(session.requests[1].modelId).toBe('gpt-5.5');
+    });
+
+    it('marks a turn canceled when the assistant stopReason is aborted', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'go' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', stopReason: 'aborted', content: [{ type: 'text', text: 'partial' }], usage: { input: 1, output: 1 } } },
+      ]);
+      expect(session.requests[0].isCanceled).toBe(true);
+    });
+  });
+
+  describe('token accumulation', () => {
+    it('sums usage across multiple assistant rounds within a single turn', () => {
+      // A user turn followed by two assistant messages (a tool round + a final
+      // answer) — common in agentic loops. Token usage accumulates per turn.
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'do a task' } },
+        {
+          type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+          message: { role: 'assistant', model: 'm', stopReason: 'toolUse', usage: { input: 100, output: 10, cacheRead: 50, cacheWrite: 5 }, content: [{ type: 'toolCall', id: 't1', name: 'read', arguments: { path: 'a.ts' } }] },
+        },
+        { type: 'message', id: 't1r', parentId: 'a1', timestamp: '2026-06-02T07:21:02.000Z', message: { role: 'toolResult', toolCallId: 't1', toolName: 'read', content: [{ type: 'text', text: 'file body' }], isError: false } },
+        {
+          type: 'message', id: 'a2', parentId: 't1r', timestamp: '2026-06-02T07:21:03.000Z',
+          message: { role: 'assistant', model: 'm', stopReason: 'stop', usage: { input: 200, output: 20, cacheRead: 100, cacheWrite: 0 }, content: [{ type: 'text', text: 'all done' }] },
+        },
+      ]);
+      expect(session.requests).toHaveLength(1);
+      // promptTokens = (100+50+5) + (200+100+0) = 455
+      expect(session.requests[0].promptTokens).toBe(455);
+      expect(session.requests[0].completionTokens).toBe(30);
+      expect(session.requests[0].cacheReadTokens).toBe(150);
+      expect(session.requests[0].cacheWriteTokens).toBe(5);
+    });
+
+    it('leaves token fields null when no assistant usage is present', () => {
+      const session = parseSingleSession([
+        HEADER,
+        { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hi' } },
+        { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'no usage' }] } },
+      ]);
+      expect(session.requests[0].promptTokens).toBeNull();
+      expect(session.requests[0].completionTokens).toBeNull();
+    });
+  });
+
+  describe('multiple session files', () => {
+    it('parses sessions across multiple encoded project directories', () => {
+      withPiFiles([
+        {
+          relativePath: `${encodeCwd('/Users/me/project-a')}/2026-06-02T07-00-00-000Z_aaa.jsonl`,
+          content: [
+            { type: 'session', version: 3, id: 'sess-a', timestamp: '2026-06-02T07:00:00.000Z', cwd: '/Users/me/project-a' },
+            { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:00:01.000Z', message: { role: 'user', content: 'a' } },
+            { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:00:02.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'one' }], usage: { input: 1, output: 1 } } },
+          ],
+        },
+        {
+          relativePath: `${encodeCwd('/Users/me/project-b')}/2026-06-02T08-00-00-000Z_bbb.jsonl`,
+          content: [
+            { type: 'session', version: 3, id: 'sess-b', timestamp: '2026-06-02T08:00:00.000Z', cwd: '/Users/me/project-b' },
+            { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T08:00:01.000Z', message: { role: 'user', content: 'b' } },
+            { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T08:00:02.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'two' }], usage: { input: 1, output: 1 } } },
+          ],
+        },
+      ], (sessionsDir) => {
+        const sessions = parsePiSessions(sessionsDir);
+        expect(sessions).toHaveLength(2);
+        expect(sessions.map(s => s.sessionId).sort()).toEqual(['sess-a', 'sess-b']);
+        expect(sessions.map(s => s.workspaceName).sort()).toEqual(['project-a', 'project-b']);
+      });
+    });
+
+    it('ignores non-jsonl files while scanning project directories', () => {
+      withPiFiles([
+        {
+          relativePath: `${encodeCwd('/Users/me/proj')}/2026-06-02T07-00-00-000Z_keep.jsonl`,
+          content: [
+            HEADER,
+            { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'keep me' } },
+            { type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'ok' }], usage: { input: 1, output: 1 } } },
+          ],
+        },
+        { relativePath: `${encodeCwd('/Users/me/proj')}/notes.txt`, content: 'just some notes, not a session' },
+      ], (sessionsDir) => {
+        const sessions = parsePiSessions(sessionsDir);
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].sessionId).toBe('sess-uuid-1234-5678');
+      });
+    });
+  });
+
+  describe('oversized files', () => {
+    it('skips a session file larger than the shared in-memory cap', () => {
+      withPiRoot((sessionsDir) => {
+        const filePath = path.join(sessionsDir, `${encodeCwd('/Users/me/proj')}/huge.jsonl`);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        const fd = fs.openSync(filePath, 'w');
+        try {
+          fs.writeSync(fd, JSON.stringify(HEADER) + '\n');
+          const filler = JSON.stringify({ type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'x'.repeat(1024) } }) + '\n';
+          let written = 0;
+          while (written <= MAX_FILE_SIZE) {
+            fs.writeSync(fd, filler);
+            written += filler.length;
+          }
+        } finally {
+          fs.closeSync(fd);
+        }
+        // readFileSafe returns null for oversized files → no session produced.
+        expect(parsePiSessions(sessionsDir)).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/core/parser-pi.test.ts
+++ b/src/core/parser-pi.test.ts
@@ -1,0 +1,219 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Tests for the Pi Coding Agent parser — verifies that the JSONL session
+ * tree (SessionHeader + message/model_change/etc. entries) is folded into
+ * the internal session/request format, that cwd/timestamp/role/model and
+ * message content are preserved, and that unsupported entry types are
+ * ignored safely. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect } from 'vitest';
+import { findPiDirs, parsePiSessions } from './parser-pi';
+
+/** Write a minimal Pi session tree under a project subdirectory whose name
+ *  encodes `cwd` the way Pi does (`/` -> `-`, wrapped in `--`). */
+function withPiSession(
+  cwd: string,
+  header: object,
+  entries: object[],
+  run: (sessionsDir: string, filePath: string) => void,
+): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-parser-test-'));
+  const sessionsDir = path.join(root, '.pi', 'agent', 'sessions');
+  const encoded = '--' + cwd.replace(/^\//, '').replaceAll('/', '-') + '--';
+  const projDir = path.join(sessionsDir, encoded);
+  fs.mkdirSync(projDir, { recursive: true });
+  const file = path.join(projDir, '2026-06-02T07-20-57-002Z_019e8734-fbaa-702d-81e3-3e22fec1f7eb.jsonl');
+  const lines = [header, ...entries].map(l => JSON.stringify(l)).join('\n');
+  fs.writeFileSync(file, lines, 'utf-8');
+  try { run(sessionsDir, file); } finally { fs.rmSync(root, { recursive: true, force: true }); }
+}
+
+const HEADER = {
+  type: 'session',
+  version: 3,
+  id: '019e8734-fbaa-702d-81e3-3e22fec1f7eb',
+  timestamp: '2026-06-02T07:20:57.002Z',
+  cwd: '/Users/me/proj',
+};
+
+describe('parsePiSessions', () => {
+  it('parses a basic user/assistant turn and preserves cwd, model, content', () => {
+    withPiSession('/Users/me/proj', HEADER, [
+      { type: 'model_change', id: 'm0', parentId: null, timestamp: '2026-06-02T07:20:57.100Z', provider: 'anthropic', modelId: 'claude-opus-4-8' },
+      {
+        type: 'message', id: 'a1', parentId: 'm0', timestamp: '2026-06-02T07:21:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Where are my logs stored?' }] },
+      },
+      {
+        type: 'message', id: 'a2', parentId: 'a1', timestamp: '2026-06-02T07:21:05.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'hmm' }, { type: 'text', text: 'Under ~/.pi/agent/sessions.' }],
+          provider: 'anthropic', model: 'claude-opus-4-8', stopReason: 'stop',
+          usage: { input: 10, output: 20, cacheRead: 100, cacheWrite: 50, totalTokens: 180 },
+        },
+      },
+    ], (sessionsDir) => {
+      const sessions = parsePiSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      const s = sessions[0];
+      expect(s.harness).toBe('Pi Coding Agent');
+      expect(s.workspaceRootPath).toBe('/Users/me/proj');
+      expect(s.workspaceName).toBe('proj');
+      expect(s.requests).toHaveLength(1);
+
+      const req = s.requests[0];
+      expect(req.messageText).toBe('Where are my logs stored?');
+      expect(req.responseText).toContain('Under ~/.pi/agent/sessions.');
+      // thinking blocks are not folded into the response text
+      expect(req.responseText).not.toContain('hmm');
+      expect(req.modelId).toBe('claude-opus-4-8');
+      expect(req.timestamp).toBe(new Date('2026-06-02T07:21:00.000Z').getTime());
+      // promptTokens = uncached input + cacheRead + cacheWrite = 10 + 100 + 50
+      expect(req.promptTokens).toBe(160);
+      expect(req.completionTokens).toBe(20);
+      expect(req.cacheReadTokens).toBe(100);
+      expect(req.cacheWriteTokens).toBe(50);
+    });
+  });
+
+  it('captures tool calls: edits, references, and bash commands', () => {
+    withPiSession('/Users/me/proj', HEADER, [
+      {
+        type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z',
+        message: { role: 'user', content: 'Add a file' },
+      },
+      {
+        type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:05.000Z',
+        message: {
+          role: 'assistant', model: 'claude-opus-4-8', stopReason: 'toolUse',
+          content: [
+            { type: 'toolCall', id: 't1', name: 'read', arguments: { path: '/Users/me/proj/a.ts' } },
+            { type: 'toolCall', id: 't2', name: 'write', arguments: { path: '/Users/me/proj/b.ts', content: 'export const x = 1;' } },
+            { type: 'toolCall', id: 't3', name: 'bash', arguments: { command: 'ls' } },
+          ],
+        },
+      },
+    ], (sessionsDir) => {
+      const sessions = parsePiSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      const req = sessions[0].requests[0];
+      expect(req.toolsUsed).toEqual(['read', 'write', 'bash']);
+      expect(req.editedFiles).toEqual(['/Users/me/proj/b.ts']);
+      expect(req.referencedFiles).toEqual(['/Users/me/proj/a.ts']);
+      // Written file content is surfaced so AI-code detection works
+      expect(req.aiCode.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('splits multiple user messages into separate turns', () => {
+    withPiSession('/Users/me/proj', HEADER, [
+      { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'first' } },
+      {
+        type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+        message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'one' }], usage: { input: 1, output: 1 } },
+      },
+      { type: 'message', id: 'u2', parentId: 'a1', timestamp: '2026-06-02T07:21:02.000Z', message: { role: 'user', content: 'second' } },
+      {
+        type: 'message', id: 'a2', parentId: 'u2', timestamp: '2026-06-02T07:21:03.000Z',
+        message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'two' }], usage: { input: 1, output: 1 } },
+      },
+    ], (sessionsDir) => {
+      const sessions = parsePiSessions(sessionsDir);
+      expect(sessions[0].requests).toHaveLength(2);
+      expect(sessions[0].requests[0].messageText).toBe('first');
+      expect(sessions[0].requests[1].messageText).toBe('second');
+    });
+  });
+
+  it('ignores unsupported entry types safely', () => {
+    withPiSession('/Users/me/proj', HEADER, [
+      { type: 'thinking_level_change', id: 't', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', thinkingLevel: 'high' },
+      { type: 'message', id: 'u1', parentId: 't', timestamp: '2026-06-02T07:21:01.000Z', message: { role: 'user', content: 'hi' } },
+      {
+        type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:02.000Z',
+        message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'hey' }], usage: { input: 1, output: 1 } },
+      },
+      { type: 'compaction', id: 'c', parentId: 'a1', timestamp: '2026-06-02T07:21:03.000Z', summary: 'earlier...', tokensBefore: 5000 },
+      { type: 'label', id: 'l', parentId: 'c', timestamp: '2026-06-02T07:21:04.000Z', targetId: 'u1', label: 'checkpoint' },
+      { type: 'session_info', id: 'si', parentId: 'l', timestamp: '2026-06-02T07:21:05.000Z', name: 'My session' },
+      { type: 'custom', id: 'cu', parentId: 'si', timestamp: '2026-06-02T07:21:06.000Z', customType: 'ext', data: { n: 1 } },
+      { type: 'some_future_type', id: 'ft', parentId: 'cu', timestamp: '2026-06-02T07:21:07.000Z' },
+    ], (sessionsDir) => {
+      const sessions = parsePiSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].requests).toHaveLength(1);
+      expect(sessions[0].requests[0].messageText).toBe('hi');
+      expect(sessions[0].requests[0].responseText).toBe('hey');
+    });
+  });
+
+  it('falls back to the encoded directory name for cwd when the header has none', () => {
+    const headerNoCwd = { type: 'session', version: 3, id: 'abc', timestamp: '2026-06-02T07:20:57.002Z' };
+    withPiSession('/Users/me/proj', headerNoCwd, [
+      { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hi' } },
+      {
+        type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+        message: { role: 'assistant', model: 'm', content: [{ type: 'text', text: 'hey' }], usage: { input: 1, output: 1 } },
+      },
+    ], (sessionsDir) => {
+      const sessions = parsePiSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].workspaceRootPath).toBe('/Users/me/proj');
+      expect(sessions[0].workspaceName).toBe('proj');
+    });
+  });
+
+  it('exposes aggregate token usage as Session.modelUsage', () => {
+    withPiSession('/Users/me/proj', HEADER, [
+      { type: 'message', id: 'u1', parentId: null, timestamp: '2026-06-02T07:21:00.000Z', message: { role: 'user', content: 'hi' } },
+      {
+        type: 'message', id: 'a1', parentId: 'u1', timestamp: '2026-06-02T07:21:01.000Z',
+        message: {
+          role: 'assistant', model: 'claude-opus-4-8',
+          content: [{ type: 'text', text: 'hey' }],
+          usage: { input: 100, output: 50, cacheRead: 200, cacheWrite: 10 },
+        },
+      },
+    ], (sessionsDir) => {
+      const sessions = parsePiSessions(sessionsDir);
+      const usage = sessions[0].modelUsage!['claude-opus-4-8'];
+      expect(usage).toBeDefined();
+      expect(usage.inputTokens).toBe(100);
+      expect(usage.outputTokens).toBe(50);
+      expect(usage.cacheReadTokens).toBe(200);
+      expect(usage.cacheWriteTokens).toBe(10);
+    });
+  });
+});
+
+describe('findPiDirs', () => {
+  function setEnv(key: 'HOME' | 'USERPROFILE', value: string | undefined): void {
+    if (value === undefined) delete process.env[key]; else process.env[key] = value;
+  }
+
+  it('discovers ~/.pi/agent/sessions when present', () => {
+    const prevHome = process.env.HOME;
+    const prevUserProfile = process.env.USERPROFILE;
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-home-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    try {
+      expect(findPiDirs()).toHaveLength(0);
+      fs.mkdirSync(path.join(home, '.pi', 'agent', 'sessions'), { recursive: true });
+      const dirs = findPiDirs();
+      expect(dirs).toHaveLength(1);
+      expect(dirs[0]).toBe(path.join(home, '.pi', 'agent', 'sessions'));
+    } finally {
+      setEnv('HOME', prevHome);
+      setEnv('USERPROFILE', prevUserProfile);
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/parser-pi.ts
+++ b/src/core/parser-pi.ts
@@ -1,0 +1,528 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Pi Coding Agent session parser
+ *
+ * Data layout (macOS / Linux / Windows):
+ *   ~/.pi/agent/sessions/--<encoded-cwd>--/<timestamp>_<uuid>.jsonl
+ *
+ * Where <encoded-cwd> is the working directory with `/` replaced by `-`, and
+ * the whole thing wrapped in leading/trailing `--`, e.g.
+ *   --Users-alice-Projects-pi-harness--
+ *
+ * Each .jsonl file is one session. The first line is a SessionHeader:
+ *   { type: "session", version, id, timestamp, cwd, parentSession? }
+ *
+ * Subsequent lines are tree entries that share a base shape:
+ *   { type, id, parentId, timestamp }
+ * Common entry types: message, model_change, thinking_level_change,
+ * compaction, branch_summary, custom, custom_message, label, session_info.
+ *
+ * `message` entries carry an `AgentMessage` under `message` with a `role`:
+ *   user | assistant | toolResult | bashExecution | custom |
+ *   branchSummary | compactionSummary
+ *
+ * The parser folds the linear entry sequence into user→assistant turns,
+ * matching the internal SessionRequest shape used by the other harnesses.
+ * Unsupported entry types are ignored safely.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ModelUsage, Session, SessionRequest } from './types';
+import { assertTrustedPath, createRequest, createSession, detectDevcontainerFromRequests, extractSkillNameFromPath, extractSkillPathsFromText, readFileSafe } from './parser-shared';
+import { extractReasoningEffortFromModelId } from './helpers';
+
+/* ---- Raw shapes ---- */
+
+interface PiSessionHeader {
+  type: 'session';
+  version?: number;
+  id?: string;
+  timestamp?: string;
+  cwd?: string;
+  parentSession?: string;
+}
+
+interface PiContentBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  // toolCall
+  id?: string;
+  name?: string;
+  arguments?: Record<string, unknown>;
+}
+
+interface PiUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+}
+
+interface PiMessage {
+  role: string;
+  content?: string | PiContentBlock[];
+  provider?: string;
+  model?: string;
+  usage?: PiUsage;
+  stopReason?: string;
+  // toolResult
+  toolName?: string;
+  isError?: boolean;
+  // bashExecution
+  command?: string;
+  output?: string;
+  // custom / custom_message message bodies
+  customType?: string;
+  // branchSummary / compactionSummary
+  summary?: string;
+}
+
+interface PiEntry {
+  type: string;
+  id?: string;
+  parentId?: string | null;
+  timestamp?: string;
+  message?: PiMessage;
+  // model_change
+  provider?: string;
+  modelId?: string;
+  // thinking_level_change
+  thinkingLevel?: string;
+  // compaction / branch_summary
+  summary?: string;
+  tokensBefore?: number;
+}
+
+/** Tool names (lowercase) that write/edit files in Pi. */
+const PI_WRITE_TOOLS = new Set([
+  'write', 'edit', 'create', 'patch', 'multi_edit', 'apply_patch', 'apply_diff',
+]);
+
+/** Tool names (lowercase) that read/reference files in Pi. */
+const PI_READ_TOOLS = new Set([
+  'read', 'glob', 'grep', 'ls', 'find',
+]);
+
+interface PiTurnState {
+  requests: SessionRequest[];
+  firstTs: number | null;
+  lastTs: number | null;
+  currentUserMessage: string;
+  currentUserTs: number | null;
+  currentAssistantTexts: string[];
+  currentToolsUsed: string[];
+  currentEditedFiles: string[];
+  currentReferencedFiles: string[];
+  currentSkillsUsed: string[];
+  turnModel: string;
+  /** Last model actually used by any assistant message — survives turn
+   *  flushes so session-level modelUsage can be attributed after the final flush. */
+  lastModel: string;
+  turnPromptTokens: number;
+  turnCompletionTokens: number;
+  turnCacheRead: number;
+  turnCacheWrite: number;
+  turnHasTokens: boolean;
+  turnCanceled: boolean;
+  totalInput: number;
+  totalOutput: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function projectNameFromCwd(cwd: string): string {
+  return cwd.replaceAll('\\', '/').replace(/\/+$/, '').split('/').pop() || 'unknown';
+}
+
+function tsToMillis(ts: string | undefined): number | null {
+  if (!ts) return null;
+  const ms = new Date(ts).getTime();
+  return Number.isFinite(ms) && ms > 0 ? ms : null;
+}
+
+/** Decode the `--Users-jvanvelu-Projects-foo--` directory name back into a cwd.
+ *  Best-effort fallback only — the SessionHeader `cwd` is authoritative when present. */
+function decodeProjectDirName(dirName: string): string {
+  const trimmed = dirName.replace(/^--/, '').replace(/--$/, '');
+  if (!trimmed) return '';
+  return '/' + trimmed.replaceAll('-', '/');
+}
+
+function contentBlocks(content: string | PiContentBlock[] | undefined): PiContentBlock[] {
+  if (typeof content === 'string') return content ? [{ type: 'text', text: content }] : [];
+  if (Array.isArray(content)) return content.filter((c): c is PiContentBlock => isRecord(c) && typeof c.type === 'string');
+  return [];
+}
+
+function textFromContent(content: string | PiContentBlock[] | undefined): string {
+  if (typeof content === 'string') return content;
+  return contentBlocks(content)
+    .filter(b => b.type === 'text' && typeof b.text === 'string')
+    .map(b => b.text as string)
+    .join('\n');
+}
+
+function createPiState(): PiTurnState {
+  return {
+    requests: [],
+    firstTs: null,
+    lastTs: null,
+    currentUserMessage: '',
+    currentUserTs: null,
+    currentAssistantTexts: [],
+    currentToolsUsed: [],
+    currentEditedFiles: [],
+    currentReferencedFiles: [],
+    currentSkillsUsed: [],
+    turnModel: '',
+    lastModel: '',
+    turnPromptTokens: 0,
+    turnCompletionTokens: 0,
+    turnCacheRead: 0,
+    turnCacheWrite: 0,
+    turnHasTokens: false,
+    turnCanceled: false,
+    totalInput: 0,
+    totalOutput: 0,
+    totalCacheRead: 0,
+    totalCacheWrite: 0,
+  };
+}
+
+function updateTimestamps(state: PiTurnState, ts: number | null): void {
+  if (!ts) return;
+  if (!state.firstTs || ts < state.firstTs) state.firstTs = ts;
+  if (!state.lastTs || ts > state.lastTs) state.lastTs = ts;
+}
+
+function flushPiTurn(state: PiTurnState, defaultModel: string): void {
+  if (!state.currentUserMessage && state.currentAssistantTexts.length === 0
+    && state.currentToolsUsed.length === 0 && state.currentEditedFiles.length === 0) {
+    return;
+  }
+
+  const responseText = state.currentAssistantTexts.join('\n');
+  const model = state.turnModel || defaultModel;
+  state.requests.push(createRequest({
+    requestId: `pi-${state.requests.length}`,
+    timestamp: state.currentUserTs,
+    messageText: state.currentUserMessage,
+    responseText,
+    isCanceled: state.turnCanceled,
+    agentName: 'Pi',
+    agentMode: 'agent',
+    modelId: model,
+    toolsUsed: state.currentToolsUsed,
+    editedFiles: [...new Set(state.currentEditedFiles)],
+    referencedFiles: [...new Set(state.currentReferencedFiles)],
+    skillsUsed: [...new Set(state.currentSkillsUsed)],
+    totalElapsed: state.currentUserTs && state.lastTs ? state.lastTs - state.currentUserTs : null,
+    promptTokens: state.turnHasTokens ? state.turnPromptTokens : null,
+    completionTokens: state.turnHasTokens ? state.turnCompletionTokens : null,
+    cacheReadTokens: state.turnHasTokens && state.turnCacheRead > 0 ? state.turnCacheRead : null,
+    cacheWriteTokens: state.turnHasTokens && state.turnCacheWrite > 0 ? state.turnCacheWrite : null,
+    reasoningEffort: extractReasoningEffortFromModelId(model),
+  }));
+
+  state.currentUserMessage = '';
+  state.currentUserTs = null;
+  state.currentAssistantTexts = [];
+  state.currentToolsUsed = [];
+  state.currentEditedFiles = [];
+  state.currentReferencedFiles = [];
+  state.currentSkillsUsed = [];
+  // Clear the explicit per-turn model so the next turn falls back to the
+  // current default (meta.model) unless its own assistant message sets one.
+  state.turnModel = '';
+  state.turnPromptTokens = 0;
+  state.turnCompletionTokens = 0;
+  state.turnCacheRead = 0;
+  state.turnCacheWrite = 0;
+  state.turnHasTokens = false;
+  state.turnCanceled = false;
+}
+
+function filePathFromArgs(args: Record<string, unknown> | undefined): string | null {
+  if (!args) return null;
+  for (const key of ['path', 'file_path', 'filename', 'filePath']) {
+    const v = args[key];
+    if (typeof v === 'string' && v) return v;
+  }
+  return null;
+}
+
+function contentFromArgs(args: Record<string, unknown> | undefined): string | null {
+  if (!args) return null;
+  for (const key of ['content', 'code', 'new_string', 'newText']) {
+    const v = args[key];
+    if (typeof v === 'string') return v;
+  }
+  return null;
+}
+
+function collectSkillsFromArgs(args: Record<string, unknown> | undefined, state: PiTurnState): void {
+  if (!args) return;
+  for (const key of ['command', 'cmd', 'script', 'input']) {
+    const v = args[key];
+    if (typeof v !== 'string') continue;
+    for (const skillPath of extractSkillPathsFromText(v)) {
+      state.currentReferencedFiles.push(skillPath);
+      const name = extractSkillNameFromPath(skillPath);
+      if (name) state.currentSkillsUsed.push(name);
+    }
+  }
+}
+
+function handleToolCall(block: PiContentBlock, state: PiTurnState): void {
+  const toolName = (block.name || 'unknown').trim();
+  state.currentToolsUsed.push(toolName);
+
+  const args = isRecord(block.arguments) ? block.arguments : undefined;
+  collectSkillsFromArgs(args, state);
+
+  const toolLower = toolName.toLowerCase();
+  const filePath = filePathFromArgs(args);
+  if (PI_WRITE_TOOLS.has(toolLower)) {
+    if (filePath) {
+      state.currentEditedFiles.push(filePath);
+      const content = contentFromArgs(args);
+      if (content) {
+        const ext = filePath.split('.').pop() || 'unknown';
+        state.currentAssistantTexts.push(`\n\`\`\`${ext}\n${content}\n\`\`\`\n`);
+      }
+    }
+  } else if (PI_READ_TOOLS.has(toolLower) && filePath) {
+    state.currentReferencedFiles.push(filePath);
+  }
+}
+
+function handleUserMessage(msg: PiMessage, state: PiTurnState, ts: number | null, defaultModel: string): void {
+  // A new user message begins a new turn.
+  flushPiTurn(state, defaultModel);
+  state.currentUserMessage = textFromContent(msg.content);
+  state.currentUserTs = ts;
+}
+
+function handleAssistantMessage(msg: PiMessage, state: PiTurnState): void {
+  for (const block of contentBlocks(msg.content)) {
+    if (block.type === 'text' && block.text) {
+      state.currentAssistantTexts.push(block.text);
+    } else if (block.type === 'toolCall') {
+      handleToolCall(block, state);
+    }
+    // thinking blocks are intentionally not folded into response text.
+  }
+
+  if (msg.model) {
+    state.turnModel = msg.model;
+    state.lastModel = msg.model;
+  }
+  if (msg.stopReason === 'aborted' || msg.stopReason === 'error') state.turnCanceled = true;
+
+  const usage = msg.usage;
+  if (usage) {
+    const input = typeof usage.input === 'number' ? usage.input : 0;
+    const output = typeof usage.output === 'number' ? usage.output : 0;
+    const cacheRead = typeof usage.cacheRead === 'number' ? usage.cacheRead : 0;
+    const cacheWrite = typeof usage.cacheWrite === 'number' ? usage.cacheWrite : 0;
+    // promptTokens = full input context (uncached input + cache read + cache write)
+    // so context-window analysis sees the whole context; cached portions are
+    // tracked separately for billing.
+    state.turnPromptTokens += input + cacheRead + cacheWrite;
+    state.turnCompletionTokens += output;
+    state.turnCacheRead += cacheRead;
+    state.turnCacheWrite += cacheWrite;
+    state.turnHasTokens = true;
+    state.totalInput += input;
+    state.totalOutput += output;
+    state.totalCacheRead += cacheRead;
+    state.totalCacheWrite += cacheWrite;
+  }
+}
+
+function handleMessageEntry(entry: PiEntry, state: PiTurnState, ts: number | null, defaultModel: string): void {
+  const msg = entry.message;
+  if (!msg || typeof msg.role !== 'string') return;
+
+  switch (msg.role) {
+    case 'user':
+      handleUserMessage(msg, state, ts, defaultModel);
+      return;
+    case 'assistant':
+      handleAssistantMessage(msg, state);
+      return;
+    case 'toolResult':
+      // Tool result content (file contents, command output) is already
+      // attributed via the originating toolCall on the assistant message,
+      // so the result body itself is not folded into the turn.
+      return;
+    case 'bashExecution':
+      if (msg.command) {
+        state.currentToolsUsed.push('bash');
+        for (const skillPath of extractSkillPathsFromText(msg.command)) {
+          state.currentReferencedFiles.push(skillPath);
+          const name = extractSkillNameFromPath(skillPath);
+          if (name) state.currentSkillsUsed.push(name);
+        }
+      }
+      return;
+    default:
+      // custom / branchSummary / compactionSummary message bodies and any
+      // future role are ignored safely (they do not map to a user turn).
+      return;
+  }
+}
+
+function handlePiEntry(entry: PiEntry, state: PiTurnState, meta: { model: string }): void {
+  const ts = tsToMillis(entry.timestamp);
+  updateTimestamps(state, ts);
+
+  switch (entry.type) {
+    case 'message':
+      handleMessageEntry(entry, state, ts, meta.model);
+      return;
+    case 'model_change':
+      // Only update the default model for *future* turns. The current turn's
+      // model is set from each assistant message's own `model` field, so
+      // overwriting state.turnModel here would retroactively relabel the
+      // in-flight (not-yet-flushed) turn. Turns without an explicit model fall
+      // back to meta.model at flush time.
+      if (typeof entry.modelId === 'string' && entry.modelId) meta.model = entry.modelId;
+      return;
+    // thinking_level_change, compaction, branch_summary, custom,
+    // custom_message, label, session_info and any unknown type are ignored.
+    default:
+      return;
+  }
+}
+
+function computeModelUsage(state: PiTurnState): Record<string, ModelUsage> | undefined {
+  if (state.totalInput <= 0 && state.totalOutput <= 0 && state.totalCacheRead <= 0) return undefined;
+  const model = state.lastModel || state.turnModel || 'untracked';
+  return {
+    [model]: {
+      inputTokens: state.totalInput,
+      outputTokens: state.totalOutput,
+      cacheReadTokens: state.totalCacheRead,
+      cacheWriteTokens: state.totalCacheWrite,
+    },
+  };
+}
+
+function parsePiHeader(rawLine: string): PiSessionHeader | null {
+  try {
+    const parsed: unknown = JSON.parse(rawLine);
+    if (!isRecord(parsed) || parsed.type !== 'session') return null;
+    return {
+      type: 'session',
+      version: typeof parsed.version === 'number' ? parsed.version : undefined,
+      id: typeof parsed.id === 'string' ? parsed.id : undefined,
+      timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : undefined,
+      cwd: typeof parsed.cwd === 'string' ? parsed.cwd : undefined,
+      parentSession: typeof parsed.parentSession === 'string' ? parsed.parentSession : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function parsePiEntry(rawLine: string): PiEntry | null {
+  try {
+    const parsed: unknown = JSON.parse(rawLine);
+    if (!isRecord(parsed) || typeof parsed.type !== 'string') return null;
+    return parsed as unknown as PiEntry;
+  } catch {
+    return null;
+  }
+}
+
+function parsePiSessionFile(filePath: string, fallbackDirName: string): Session | null {
+  assertTrustedPath(filePath);
+  const content = readFileSafe(filePath);
+  if (content == null) return null;
+
+  const lines = content.split('\n').filter(l => l.trim().length > 0);
+  if (lines.length === 0) return null;
+
+  const header = parsePiHeader(lines[0]);
+  const sessionId = header?.id || path.basename(filePath, '.jsonl');
+  const cwd = header?.cwd || decodeProjectDirName(fallbackDirName);
+
+  const state = createPiState();
+  const meta = { model: '' };
+
+  // Entries start on the second line. Be defensive: if the first line was not
+  // a recognizable header, treat it as an entry too.
+  const startIndex = header ? 1 : 0;
+  for (let i = startIndex; i < lines.length; i++) {
+    const entry = parsePiEntry(lines[i]);
+    if (entry) handlePiEntry(entry, state, meta);
+  }
+
+  flushPiTurn(state, meta.model);
+  if (state.requests.length === 0) return null;
+
+  const wsName = projectNameFromCwd(cwd);
+  const wsId = `pi-${wsName}-${sessionId.slice(0, 8)}`;
+  const modelUsage = computeModelUsage(state);
+
+  return createSession({
+    sessionId,
+    workspaceId: wsId,
+    workspaceName: wsName,
+    location: 'terminal',
+    harness: 'Pi Coding Agent',
+    creationDate: tsToMillis(header?.timestamp) || state.firstTs,
+    lastMessageDate: state.lastTs,
+    requests: state.requests,
+    modelUsage,
+    hasDevcontainer: detectDevcontainerFromRequests(state.requests, cwd),
+    workspaceRootPath: cwd || undefined,
+  });
+}
+
+export function findPiDirs(): string[] {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const dirs: string[] = [];
+  const sessionsDir = path.join(home, '.pi', 'agent', 'sessions');
+  if (fs.existsSync(sessionsDir)) dirs.push(sessionsDir);
+  return dirs;
+}
+
+function findAllJsonlFiles(dir: string): string[] {
+  const result: string[] = [];
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        result.push(...findAllJsonlFiles(full));
+      } else if (e.isFile() && e.name.endsWith('.jsonl')) {
+        result.push(full);
+      }
+    }
+  } catch {
+    /* skip unreadable dirs */
+  }
+  return result;
+}
+
+export function parsePiSessions(sessionsDir: string): Session[] {
+  const sessions: Session[] = [];
+  for (const filePath of findAllJsonlFiles(sessionsDir)) {
+    const dirName = path.basename(path.dirname(filePath));
+    const session = parsePiSessionFile(filePath, dirName);
+    if (session) sessions.push(session);
+  }
+  return sessions;
+}

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -61,6 +61,7 @@ function getTrustedRoots(): string[] {
     roots.push(path.resolve(home, '.copilot'));
     roots.push(path.resolve(home, '.claude'));
     roots.push(path.resolve(home, '.codex'));
+    roots.push(path.resolve(home, '.pi'));
     roots.push(path.resolve(home, '.local', 'share', 'opencode'));
     roots.push(path.resolve(home, '.config', 'github-copilot'));
   }

--- a/src/webview/page-config.ts
+++ b/src/webview/page-config.ts
@@ -12,7 +12,7 @@ import { html, render, StatCard, ComponentChildren } from './render';
 import { renderContextManagement } from './page-context-mgmt';
 
 /* Harness colors */
-const HC: Record<string, string> = { 'Local Agent': '#007acc', 'Local Agent (Insiders)': '#24bfa5', 'Xcode': '#147efb', 'Claude Code': '#d97706', 'GitHub Copilot CLI': '#8b5cf6', 'Codex CLI': '#ec4899', 'OpenCode': '#10b981' };
+const HC: Record<string, string> = { 'Local Agent': '#007acc', 'Local Agent (Insiders)': '#24bfa5', 'Xcode': '#147efb', 'Claude Code': '#d97706', 'GitHub Copilot CLI': '#8b5cf6', 'Codex CLI': '#ec4899', 'OpenCode': '#10b981', 'Pi': '#e11d48', 'Pi Coding Agent': '#e11d48' };
 function hc(h: string): string { return HC[h] || COLORS.muted; }
 
 /** Active treemap chart reference + workspace data for review highlighting */

--- a/src/webview/panel.ts
+++ b/src/webview/panel.ts
@@ -206,14 +206,14 @@ export class DashboardPanel {
       const dirs = findLogsDirs();
       const hasExternal = hasExternalHarnessSources();
       runtimeDebug('panel', 'logs-dirs-found', `count=${dirs.length} external=${hasExternal}`);
-      // External harnesses (Claude Code, Codex, OpenCode) are collected by the
+      // External harnesses (Claude Code, Codex, OpenCode, Pi Coding Agent) are collected by the
       // parse worker independently of `dirs`, so only abort when no source of
       // any kind is present. Otherwise a host with e.g. only Claude Code logs
       // (and no VS Code/Copilot directories) would never load.
       if (dirs.length === 0 && !hasExternal) {
         runtimeDebug('panel', 'loadData-no-dirs');
         if (!this.disposed) {
-          try { this.panel.webview.html = getErrorHtml('No AI coding session logs found. Looked for VS Code, GitHub Copilot (CLI and Xcode), Claude Code, Codex, and OpenCode sessions.'); } catch { /* disposed */ }
+          try { this.panel.webview.html = getErrorHtml('No AI coding session logs found. Looked for VS Code, GitHub Copilot (CLI and Xcode), Claude Code, Codex, OpenCode, and Pi Coding Agent sessions.'); } catch { /* disposed */ }
         }
         return;
       }

--- a/src/webview/shared.ts
+++ b/src/webview/shared.ts
@@ -325,6 +325,7 @@ export const HARNESS_COLORS: Record<string, string> = {
 
   'Codex': '#10b981',
   'OpenCode': '#8b5cf6',
+  'Pi Coding Agent': '#e11d48',
 };
 
 export function harnessColor(name: string, idx: number): string {


### PR DESCRIPTION
 Summary                                                                                                                                             
                                                                                                                                                     
 Added support for the Pi Coding Agent harness to AI Engineer Coach.                                                                                 
                                                                                                                                                     
 ### New files                                                                                                                                       
                                                                                                                                                     
 - src/core/parser-pi.ts — the Pi session parser:                                                                                                    
     - findPiDirs() discovers ~/.pi/agent/sessions/.                                                                                                 
     - parsePiSessions(dir) recursively scans **/*.jsonl, parses each file, and returns internal Session objects.                                    
     - Parses the first line as the SessionHeader (version, UUID, timestamp, cwd, parentSession). Falls back to decoding the --encoded-cwd--         
       directory name when the header lacks cwd.                                                                                                     
     - Folds the linear/tree entry sequence into user→assistant turns (SessionRequests), preserving cwd/workspace path, timestamps, role, model, and 
       message content.                                                                                                                              
     - Captures tool calls (read/write/bash etc.) into edited files, referenced files, tools used, and skills; surfaces written content for AI-code  
       detection; tracks per-turn and aggregate token usage (input/output/cache read/write).                                                         
     - Safely ignores unsupported entry types (thinking_level_change, compaction, branch_summary, custom, custom_message, label, session_info, and   
       unknown future types) and thinking/toolResult content.                                                                                        
 - src/core/parser-pi.test.ts — 7 tests covering basic turns, content/model/cwd preservation, tool-call capture, multi-turn splitting, safe ignoring 
   of unsupported entries, dir-name cwd fallback, and aggregate modelUsage.                                                                          
                                                                                                                                                     
 ### Registration & wiring                                                                                                                           
                                                                                                                                                     
 - parser-harnesses.ts — registered "Pi Coding Agent" as an external harness collector, added it to hasExternalHarnessSources() and                  
   EXTERNAL_HARNESS_SET.                                                                                                                             
 - parser-shared.ts — added ~/.pi to trusted path roots.                                                                                             
 - shared.ts / page-config.ts — added harness colors for the filter/UI.                                                                              
 - panel.ts — updated the "no logs found" message and comment.                                                                                       
 - analyzer-insights.ts — added Pi Coding Agent to the feature-comparison matrix.                                                                    
 - Docs (supported-tools.md, _index.md files) — documented the new harness.                                                                          
                                                                                                                                                     
 Verified against real Pi logs on disk (4 projects parsed correctly) and the full suite passes (1041 tests), with clean tsc/eslint/cspell.
<img width="574" height="378" alt="image" src="https://github.com/user-attachments/assets/87302a03-f9f1-46c3-ac4c-fd8da6d75fab" />

<img width="1147" height="413" alt="image" src="https://github.com/user-attachments/assets/59dd46d1-5637-4336-90b8-8558f90dd72d" />
