### PR TITLE
Configurable AI model selection with automatic fallback (fixes #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Configurable AI model selection with automatic fallback: new `aiEngineerCoach.preferredModel` setting and an "AI Model" picker in the dashboard sidebar. Auto mode iterates available Copilot models and skips any that return an empty response (e.g. models disabled for a plan or organization), fixing AI features failing silently (#91).
+
 ## 0.1.0 — First Release
 
 - Dashboard with timeline, output, and consumption views

--- a/package.json
+++ b/package.json
@@ -42,6 +42,16 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "AI Engineer Coach",
+      "properties": {
+        "aiEngineerCoach.preferredModel": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Preferred GitHub Copilot language model id used for the extension's AI features (skill generation, quizzes, code reviews, rule compilation, etc.).\n\nLeave empty to **auto-select**: the extension picks the most capable available model and automatically falls through to the next one if a model is disabled for your Copilot plan or organization (which otherwise returns an empty response).\n\nYou can also change this from the **AI Model** picker in the dashboard sidebar."
+        }
+      }
+    },
     "commands": [
       {
         "command": "aiEngineerCoach.open",

--- a/src/core/llm-models.test.ts
+++ b/src/core/llm-models.test.ts
@@ -1,0 +1,84 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { describe, it, expect } from 'vitest';
+import { scoreFamily, orderModelsByPreference, dedupeModelsById } from './llm-models';
+
+describe('scoreFamily', () => {
+  it('ranks stronger capability tiers ahead of weaker ones', () => {
+    expect(scoreFamily('claude-opus-4.8')).toBeLessThan(scoreFamily('claude-sonnet-4.5'));
+    expect(scoreFamily('gpt-5.4')).toBeLessThan(scoreFamily('gpt-4o'));
+    expect(scoreFamily('gpt-4o')).toBeLessThan(scoreFamily('claude-haiku-4'));
+  });
+
+  it('prefers the higher version within the same tier', () => {
+    expect(scoreFamily('claude-opus-4.8')).toBeLessThan(scoreFamily('claude-opus-4.6'));
+    expect(scoreFamily('gpt-5.4')).toBeLessThan(scoreFamily('gpt-5.1'));
+  });
+
+  it('is case-insensitive on the family prefix', () => {
+    expect(scoreFamily('CLAUDE-OPUS-4.8')).toBe(scoreFamily('claude-opus-4.8'));
+  });
+
+  it('sinks non-chat helper families below every tier and unknown families', () => {
+    const helper = scoreFamily('copilot-utility');
+    expect(helper).toBeGreaterThan(scoreFamily('claude-haiku-4'));
+    expect(helper).toBeGreaterThan(scoreFamily('some-unknown-model-9'));
+  });
+
+  it('places unknown families mid-pack (after known tiers, before helpers)', () => {
+    const unknown = scoreFamily('mystery-model-2');
+    expect(unknown).toBeGreaterThan(scoreFamily('claude-haiku-4'));
+    expect(unknown).toBeLessThan(scoreFamily('copilot-utility'));
+  });
+});
+
+describe('orderModelsByPreference', () => {
+  const models = [
+    { id: 'a', family: 'gpt-4o' },
+    { id: 'b', family: 'claude-opus-4.8' },
+    { id: 'c', family: 'copilot-utility' },
+    { id: 'd', family: 'gpt-5.4' },
+  ];
+
+  it('orders by capability with helper models last (org-neutral)', () => {
+    const ordered = orderModelsByPreference(models);
+    expect(ordered.map(m => m.id)).toEqual(['b', 'd', 'a', 'c']);
+  });
+
+  it('floats the preferred model (matched by id) to the front', () => {
+    const ordered = orderModelsByPreference(models, 'a');
+    expect(ordered[0].id).toBe('a');
+  });
+
+  it('floats the preferred model (matched by family) to the front', () => {
+    const ordered = orderModelsByPreference(models, 'copilot-utility');
+    expect(ordered[0].id).toBe('c');
+  });
+
+  it('falls back to capability order when the preferred model is unavailable', () => {
+    const ordered = orderModelsByPreference(models, 'not-installed');
+    expect(ordered[0].id).toBe('b');
+  });
+});
+
+describe('dedupeModelsById', () => {
+  it('keeps the first occurrence of each id and drops exact duplicates', () => {
+    const input = [
+      { id: 'x', family: 'gpt-5.4' },
+      { id: 'x', family: 'gpt-5.4' },
+      { id: 'y', family: 'claude-opus-4.8' },
+    ];
+    expect(dedupeModelsById(input).map(m => m.id)).toEqual(['x', 'y']);
+  });
+
+  it('keeps distinct ids that happen to share a family', () => {
+    const input = [
+      { id: 'auto', family: 'auto' },
+      { id: 'gpt-5.3-codex', family: 'auto' },
+    ];
+    expect(dedupeModelsById(input).map(m => m.id)).toEqual(['auto', 'gpt-5.3-codex']);
+  });
+});

--- a/src/core/llm-models.ts
+++ b/src/core/llm-models.ts
@@ -1,0 +1,205 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type * as vscodeType from 'vscode';
+import { runtimeDebug } from './runtime-debug';
+
+/**
+ * Central language-model selection for every AI feature in the extension
+ * (dashboard panels, chat helpers and the rule compiler).
+ *
+ * The user's preferred model is read from a single source of truth — the
+ * `aiEngineerCoach.preferredModel` setting — with an in-memory override that is
+ * applied immediately when the model is changed at runtime (e.g. via the
+ * dashboard picker). Leaving the setting empty means "auto": iterate every
+ * available model, skipping any that return an empty response.
+ *
+ * This module has no static dependency on the `vscode` module (only a
+ * type-only import, which is erased at compile time) so its pure helpers can be
+ * unit-tested in a plain Node context — `require('vscode')` simply throws there
+ * and `getVscode()` returns undefined.
+ */
+
+const CONFIG_SECTION = 'aiEngineerCoach';
+const CONFIG_KEY = 'preferredModel';
+
+/**
+ * Generic capability tiers for Auto mode, strongest first. Matched as
+ * case-insensitive prefixes against a model's family, so new point releases
+ * (e.g. a future `claude-opus-4.9` or `gpt-5.6`) are picked up automatically
+ * without edits. Within the same tier the higher version number wins
+ * (see {@link scoreFamily}).
+ *
+ * This ordering is a vendor-neutral "prefer a more capable general-purpose
+ * model" heuristic only. It deliberately does NOT encode any assumption about
+ * which models a particular Copilot plan or organization has enabled — a model
+ * that is disabled simply returns an empty response and {@link listCandidateModels}
+ * transparently falls through to the next candidate.
+ */
+const LLM_TIER_PREFIXES = [
+  'claude-opus',
+  'gpt-5',
+  'claude-sonnet',
+  'gemini-3',
+  'gpt-4o',
+  'gpt-4',
+  'gemini-2',
+  'claude-haiku',
+];
+
+/**
+ * Families that are not general-purpose chat models and so should never lead in
+ * Auto mode (still selectable manually). These are utility/helper models, not a
+ * judgement about any organization's enabled set. They sink below the tiers but
+ * stay available as a last resort.
+ */
+const LLM_NON_CHAT_PREFIXES = ['copilot-utility'];
+
+/**
+ * Score a family for Auto ordering: lower is better. Tier index dominates; a
+ * higher version number breaks ties within a tier (so `claude-opus-4.8` beats
+ * `claude-opus-4.6`). Non-chat helper models are pushed past every tier.
+ *
+ * Exported for unit testing — it is a pure function of the family string.
+ */
+export function scoreFamily(family: string): number {
+  const f = family.toLowerCase();
+  const versionPenalty = (): number => {
+    // Largest version number in the family => smallest penalty, in (0, 1].
+    const nums = f.match(/\d+(?:\.\d+)?/g)?.map(Number) ?? [];
+    const v = nums.length > 0 ? Math.max(...nums) : 0;
+    return 1 / (1 + v); // higher version => smaller penalty
+  };
+  if (LLM_NON_CHAT_PREFIXES.some(p => f.startsWith(p))) {
+    return 1000; // helper models last, but still ahead of nothing
+  }
+  const tier = LLM_TIER_PREFIXES.findIndex(p => f.startsWith(p));
+  if (tier === -1) return 500 + versionPenalty(); // unknown family, mid-pack
+  return tier * 10 + versionPenalty();
+}
+
+/**
+ * Order models by Auto preference (strongest capability first) and, when a
+ * preferred id/family is supplied, float the matching model to the very front.
+ *
+ * Exported as a pure helper for unit testing; {@link listCandidateModels} wires
+ * it to the live `vscode.lm` model list.
+ */
+export function orderModelsByPreference<T extends { id: string; family: string }>(
+  models: readonly T[],
+  preferred?: string,
+): T[] {
+  const ordered = [...models].sort((a, b) => scoreFamily(a.family) - scoreFamily(b.family));
+  if (preferred) {
+    const i = ordered.findIndex(m => m.id === preferred || m.family === preferred);
+    if (i > 0) {
+      const [chosen] = ordered.splice(i, 1);
+      ordered.unshift(chosen);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * De-duplicate models by id. Copilot can return the exact same model multiple
+ * times (identical id) when more than one provider/session is registered;
+ * collapsing by id shows each model once while keeping distinct ids that happen
+ * to share a family (e.g. an `auto` entry vs the concrete model it resolves to).
+ *
+ * Exported as a pure helper for unit testing.
+ */
+export function dedupeModelsById<T extends { id: string }>(models: readonly T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const m of models) {
+    if (seen.has(m.id)) continue;
+    seen.add(m.id);
+    out.push(m);
+  }
+  return out;
+}
+
+/** Applied immediately when the user changes model at runtime; also persisted. */
+let runtimeOverride: string | undefined;
+
+function getVscode(): typeof vscodeType | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('vscode') as typeof vscodeType;
+  } catch {
+    return undefined;
+  }
+}
+
+export interface AvailableModel {
+  id: string;
+  name: string;
+  family: string;
+  vendor: string;
+}
+
+/**
+ * The preferred model id or family: the in-memory runtime override first, then
+ * the `aiEngineerCoach.preferredModel` setting. Returns undefined for "auto".
+ */
+export function getPreferredModelId(): string | undefined {
+  if (runtimeOverride && runtimeOverride.trim().length > 0) return runtimeOverride.trim();
+  const vscode = getVscode();
+  const v = vscode?.workspace.getConfiguration(CONFIG_SECTION).get<string>(CONFIG_KEY);
+  return v && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+/**
+ * Set the preferred model. Updates the in-memory override (so it takes effect
+ * for the next request without waiting for the settings write) and persists it
+ * to the user setting so the choice applies to every AI feature and survives a
+ * reload. Pass undefined/'' to restore auto-pick.
+ */
+export async function setPreferredModelId(id: string | undefined): Promise<void> {
+  runtimeOverride = id && id.trim().length > 0 ? id.trim() : undefined;
+  const vscode = getVscode();
+  if (vscode) {
+    try {
+      await vscode.workspace
+        .getConfiguration(CONFIG_SECTION)
+        .update(CONFIG_KEY, runtimeOverride ?? '', vscode.ConfigurationTarget.Global);
+    } catch {
+      /* persisting to settings is best-effort; the runtime override still applies */
+    }
+  }
+  runtimeDebug('llm', 'preferred-model-set', `id=${runtimeOverride ?? '(auto)'}`);
+}
+
+/** List the Copilot chat models currently available to the extension (de-duplicated). */
+export async function listAvailableModels(): Promise<AvailableModel[]> {
+  const vscode = getVscode();
+  if (!vscode?.lm) return [];
+  const all = await vscode.lm.selectChatModels({});
+  return dedupeModelsById(all.map(m => ({ id: m.id, name: m.name, family: m.family, vendor: m.vendor })));
+}
+
+/**
+ * Enumerate available Copilot chat models, ordered with the explicitly chosen
+ * model (if any) first, then by capability tier. Some Copilot plans/orgs
+ * disable specific models — a disabled model can still be *selected* but then
+ * returns an empty response, so callers iterate this list and fall through to
+ * the next candidate rather than relying on a single pick.
+ */
+export async function listCandidateModels(): Promise<vscodeType.LanguageModelChat[]> {
+  const vscode = getVscode();
+  if (!vscode?.lm) {
+    throw new Error('No language model API available. Make sure GitHub Copilot is installed and signed in.');
+  }
+  const all = await vscode.lm.selectChatModels({});
+  if (all.length === 0) {
+    throw new Error('No language model available. Make sure GitHub Copilot is installed and signed in.');
+  }
+  const preferred = getPreferredModelId();
+  const ordered = orderModelsByPreference(all, preferred);
+  runtimeDebug('llm', 'models-available',
+    `preferred=${preferred ?? '(auto)'} count=${ordered.length} ` +
+    `models=${ordered.map(m => `${m.id}(${m.family})`).join(',')}`);
+  return ordered;
+}

--- a/src/core/rule-compiler.ts
+++ b/src/core/rule-compiler.ts
@@ -14,6 +14,7 @@
 import { FIELD_SCHEMA, FUNCTION_CATALOG } from './dsl/index';
 import { parseRule } from './rule-parser';
 import type { DetectionRule } from './types/rule-types';
+import { listCandidateModels } from './llm-models';
 
 /**
  * Result of compiling a natural-language description into a rule.
@@ -79,12 +80,14 @@ async function compileLlm(
     return null;
   }
 
-  const lm = vscode.lm;
-  if (!lm) return null;
+  if (!vscode.lm) return null;
 
-  const models = await lm.selectChatModels({ family: 'gpt-4.1' });
-  const model = models[0];
-  if (!model) return null;
+  let candidates: import('vscode').LanguageModelChat[];
+  try {
+    candidates = await listCandidateModels();
+  } catch {
+    return null;
+  }
 
   const systemPrompt = buildSystemPrompt();
   const userPrompt = buildUserPrompt(prompt, options);
@@ -94,16 +97,22 @@ async function compileLlm(
     vscode.LanguageModelChatMessage.User(userPrompt),
   ];
 
-  const response = await model.sendRequest(messages, {});
-  let result = '';
-  for await (const chunk of response.text) {
-    result += chunk;
-  }
+  // Iterate candidates so a model that is disabled for the plan/organization
+  // (which returns an empty response) transparently falls through to the next.
+  for (const model of candidates) {
+    const response = await model.sendRequest(messages, {});
+    let result = '';
+    for await (const chunk of response.text) {
+      result += chunk;
+    }
+    if (result.trim().length === 0) continue;
 
-  // Extract markdown from code block if wrapped
-  const fenced = result.match(/```(?:markdown)?\s*\n([\s\S]*?)```/);
-  if (fenced) return fenced[1].trim();
-  if (result.includes('---')) return result.trim();
+    // Extract markdown from code block if wrapped
+    const fenced = result.match(/```(?:markdown)?\s*\n([\s\S]*?)```/);
+    if (fenced) return fenced[1].trim();
+    if (result.includes('---')) return result.trim();
+    return null;
+  }
   return null;
 }
 

--- a/src/core/types/rpc-types.ts
+++ b/src/core/types/rpc-types.ts
@@ -134,6 +134,8 @@ export interface ExtensionMethodMap extends RpcMethodMap {
   getSdlcToolAnalysis: { params: { filter?: DateFilter } | Record<string, unknown>; result: { mcpServers: unknown[] } };
   getSdlcRepoScan: { params: Record<string, unknown> | undefined; result: { repos: unknown[] } };
   getSdlcGitHubData: { params: Record<string, unknown>; result: unknown };
+  listModels: { params: undefined; result: { models: { id: string; name: string; family: string; vendor: string }[]; selectedId?: string } };
+  setModel: { params: { id?: string }; result: { ok: boolean; selectedId?: string } };
   saveModelBudgets: { params: { budgets: Record<string, number> }; result: { ok: boolean } };
   loadModelBudgets: { params: Record<string, unknown> | undefined; result: Record<string, number> };
 }

--- a/src/webview/app.ts
+++ b/src/webview/app.ts
@@ -441,6 +441,8 @@ function onDataReady(currentWorkspace: string): void {
     }
   }).catch(() => {});
 
+  void populateModelFilter();
+
   navigateTo(currentPage);
   refreshNavBadges(currentFilter);
 }
@@ -614,6 +616,28 @@ if (harnessFilter) {
     }
     renderPageLater(currentPage);
     refreshNavBadges(currentFilter);
+  });
+}
+
+const modelFilter = document.getElementById('model-filter') as HTMLSelectElement | null;
+
+async function populateModelFilter(): Promise<void> {
+  if (!modelFilter) return;
+  try {
+    const res = await rpc<{ models: { id: string; name: string; family: string; vendor: string }[]; selectedId?: string }>('listModels');
+    modelFilter.length = 1; // keep "Auto (first available)" default option
+    for (const m of res.models) {
+      modelFilter.add(new Option(m.name || m.id, m.id));
+    }
+    modelFilter.value = res.selectedId ?? '';
+  } catch {
+    /* model list is best-effort; the Auto default still works */
+  }
+}
+
+if (modelFilter) {
+  modelFilter.addEventListener('change', () => {
+    void rpc('setModel', { id: modelFilter.value || undefined });
   });
 }
 

--- a/src/webview/panel-html.ts
+++ b/src/webview/panel-html.ts
@@ -56,6 +56,10 @@ export function getDashboardHtml(webview: vscode.Webview, extensionUri: vscode.U
         <label for="harness-filter">Harness</label>
         <select id="harness-filter"><option value="">All Harnesses</option></select>
       </div>
+      <div class="sidebar-filter">
+        <label for="model-filter">AI Model</label>
+        <select id="model-filter"><option value="">Auto (first available)</option></select>
+      </div>
     </div>
   </nav>
   <main id="content"></main>

--- a/src/webview/panel-llm.ts
+++ b/src/webview/panel-llm.ts
@@ -7,6 +7,18 @@
 
 import * as vscode from 'vscode';
 import { runtimeDebug } from '../core/runtime-debug';
+import {
+  listCandidateModels,
+  listAvailableModels,
+  setPreferredModelId,
+  getPreferredModelId,
+  type AvailableModel,
+} from '../core/llm-models';
+
+// Re-exported so existing importers keep a single entry point while model
+// selection lives centrally in core/llm-models.
+export { listAvailableModels, setPreferredModelId, getPreferredModelId };
+export type { AvailableModel };
 
 export interface JsonSchemaSpec {
   name: string;
@@ -317,26 +329,15 @@ function balanceTruncatedJson(input: string): string {
 }
 
 const LLM_MAX_RETRIES = 2;
-const LLM_FAMILY = 'gpt-5.4-mini';
 /** Hard cap for a single LLM streaming request (ms). Prevents the UI from
  *  spinning forever when the model hangs or the user never grants consent. */
 const LLM_REQUEST_TIMEOUT_MS = 90_000;
 
-/**
- * Pick a Copilot chat model. Tries the preferred family first, then a short
- * fallback list, then any available model. Throws a descriptive error when
- * nothing is available so callers can surface a useful message.
- */
-async function selectModel(): Promise<vscode.LanguageModelChat> {
-  const families = [LLM_FAMILY, 'gpt-5-mini', 'gpt-4.1-mini', 'gpt-4.1'];
-  for (const family of families) {
-    const models = await vscode.lm.selectChatModels({ family });
-    if (models.length > 0) return models[0];
-  }
-  const any = await vscode.lm.selectChatModels({});
-  if (any.length > 0) return any[0];
-  throw new Error('No language model available. Make sure GitHub Copilot is installed and signed in.');
-}
+/** Shown when every available model returns an empty response (all disabled). */
+const EMPTY_RESPONSE_MESSAGE =
+  'Every available language model returned an empty response after multiple attempts. ' +
+  'Some models can be disabled for your Copilot plan or organization. ' +
+  'Pick a specific model from the "AI Model" selector in the dashboard sidebar and try again.';
 
 /** Race a promise against a timeout. Rejects with a clear message on timeout. */
 function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
@@ -350,40 +351,65 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 }
 
 export async function callLlm(messages: vscode.LanguageModelChatMessage[]): Promise<string> {
-  const model = await selectModel();
+  const candidates = await listCandidateModels();
 
   let lastError: unknown;
-  for (let attempt = 0; attempt <= LLM_MAX_RETRIES; attempt++) {
-    const cts = new vscode.CancellationTokenSource();
-    try {
-      const streamText = async () => {
-        const response = await model.sendRequest(messages, {}, cts.token);
-        let text = '';
-        for await (const chunk of response.text) text += chunk;
+  let sawEmpty = false;
+  for (const model of candidates) {
+    for (let attempt = 0; attempt <= LLM_MAX_RETRIES; attempt++) {
+      const cts = new vscode.CancellationTokenSource();
+      try {
+        const streamText = async () => {
+          const response = await model.sendRequest(messages, {}, cts.token);
+          let text = '';
+          for await (const chunk of response.text) text += chunk;
+          return text;
+        };
+        const text = await withTimeout(streamText(), LLM_REQUEST_TIMEOUT_MS, 'LLM request');
+        // An empty response usually means this model is disabled for the plan or
+        // organization but still selectable — move on to the next candidate.
+        if (text.trim().length === 0) {
+          sawEmpty = true;
+          runtimeDebug('panel-llm', 'empty-response', `model=${model.id}(${model.family}) plain attempt=${attempt + 1}`);
+          break;
+        }
         return text;
-      };
-      return await withTimeout(streamText(), LLM_REQUEST_TIMEOUT_MS, 'LLM request');
-    } catch (err) {
-      cts.cancel();
-      lastError = err;
-      if (err instanceof vscode.CancellationError) throw err;
-    } finally {
-      cts.dispose();
+      } catch (err) {
+        cts.cancel();
+        lastError = err;
+        if (err instanceof vscode.CancellationError) throw err;
+      } finally {
+        cts.dispose();
+      }
     }
   }
-  throw lastError;
+  if (lastError instanceof Error) throw lastError;
+  throw new Error(sawEmpty ? EMPTY_RESPONSE_MESSAGE : 'LLM request failed');
 }
 
-export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[], jsonSchema?: JsonSchemaSpec): Promise<T> {
-  const model = await selectModel();
+type JsonAttemptOutcome<T> =
+  | { kind: 'value'; value: T }
+  | { kind: 'empty' }
+  | { kind: 'error'; error: unknown; parseFailures: number };
 
+/**
+ * Run the retry loop for a single model: stream the response, parse JSON,
+ * recover from structured-output rejections and nudge the model back to valid
+ * JSON. Returns a value on success, `empty` when the model returned nothing
+ * (likely disabled for the plan/organization) or `error` with the last failure.
+ */
+async function requestJsonFromModel<T>(
+  model: vscode.LanguageModelChat,
+  messages: vscode.LanguageModelChatMessage[],
+  jsonSchema?: JsonSchemaSpec,
+): Promise<JsonAttemptOutcome<T>> {
   const options: vscode.LanguageModelChatRequestOptions = jsonSchema
     ? { modelOptions: structuredOutputOptions(jsonSchema) }
     : {};
-
+  const retryMessages = [...messages];
   let lastError: unknown;
   let parseFailures = 0;
-  const retryMessages = [...messages];
+  let sawEmpty = false;
 
   for (let attempt = 0; attempt <= LLM_MAX_RETRIES; attempt++) {
     const cts = new vscode.CancellationTokenSource();
@@ -391,25 +417,34 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
     try {
       const response = await model.sendRequest(retryMessages, options, cts.token);
       for await (const chunk of response.text) text += chunk;
+      // An empty response usually means this model is disabled for the plan or
+      // organization but still selectable. Drop structured output first (in
+      // case that is the cause), then signal the caller to try the next model.
+      if (text.trim().length === 0) {
+        sawEmpty = true;
+        runtimeDebug('panel-llm', 'empty-response',
+          `model=${model.id}(${model.family}) schema=${jsonSchema?.name ?? 'none'} attempt=${attempt + 1} hadModelOptions=${options.modelOptions !== undefined}`);
+        if (options.modelOptions) { options.modelOptions = undefined; continue; }
+        break;
+      }
       try {
-        return JSON.parse(text.trim()) as T;
+        return { kind: 'value', value: JSON.parse(text.trim()) as T };
       } catch {
-        return parseLlmJson<T>(text);
+        return { kind: 'value', value: parseLlmJson<T>(text) };
       }
     } catch (err) {
       lastError = err;
-      const schemaName = jsonSchema?.name ?? 'none';
       runtimeDebug('panel-llm', 'call-failed',
-        `schema=${schemaName} attempt=${attempt + 1} structured=${options.modelOptions !== undefined} ` +
+        `schema=${jsonSchema?.name ?? 'none'} attempt=${attempt + 1} structured=${options.modelOptions !== undefined} ` +
         `model=${model.id} textLen=${text.length} error=${err instanceof Error ? err.message : String(err)}`);
       if (err instanceof vscode.CancellationError) { cts.dispose(); throw err; }
       // Drop structured output so later attempts can recover in plain mode.
-      if (jsonSchema && options.modelOptions && lastError instanceof Error &&
-          /response_format|modelOptions|not supported|JSON|parse/i.test(lastError.message)) {
+      if (jsonSchema && options.modelOptions && err instanceof Error &&
+          /response_format|modelOptions|not supported|JSON|parse/i.test(err.message)) {
         options.modelOptions = undefined;
       }
-      // On parse failures, nudge the model to return valid JSON on the next attempt
-      if (lastError instanceof Error && /JSON|parse/i.test(lastError.message)) {
+      // On parse failures, nudge the model to return valid JSON on the next attempt.
+      if (err instanceof Error && /JSON|parse/i.test(err.message)) {
         parseFailures++;
         if (retryMessages.length === messages.length) {
           retryMessages.push(vscode.LanguageModelChatMessage.User(
@@ -422,8 +457,34 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
     }
   }
 
-  const label = parseFailures > 0
-    ? `LLM returned invalid JSON after ${LLM_MAX_RETRIES + 1} attempts. Please try again.`
-    : (lastError instanceof Error ? lastError.message : 'LLM request failed after retries');
+  if (sawEmpty) return { kind: 'empty' };
+  return { kind: 'error', error: lastError, parseFailures };
+}
+
+export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[], jsonSchema?: JsonSchemaSpec): Promise<T> {
+  const candidates = await listCandidateModels();
+
+  let lastError: unknown;
+  let parseFailures = 0;
+  let sawEmpty = false;
+
+  for (const model of candidates) {
+    const outcome = await requestJsonFromModel<T>(model, messages, jsonSchema);
+    if (outcome.kind === 'value') return outcome.value;
+    if (outcome.kind === 'empty') { sawEmpty = true; continue; }
+    lastError = outcome.error;
+    parseFailures += outcome.parseFailures;
+  }
+
+  let label: string;
+  if (parseFailures > 0) {
+    label = `LLM returned invalid JSON after ${LLM_MAX_RETRIES + 1} attempts. Please try again.`;
+  } else if (lastError instanceof Error) {
+    label = lastError.message;
+  } else if (sawEmpty) {
+    label = EMPTY_RESPONSE_MESSAGE;
+  } else {
+    label = 'LLM request failed after retries';
+  }
   throw new Error(label);
 }

--- a/src/webview/panel-request-service.ts
+++ b/src/webview/panel-request-service.ts
@@ -15,6 +15,9 @@ import { exportSummaryFiles } from '../summary-export-vscode';
 import {
   callLlm,
   callLlmJson,
+  listAvailableModels,
+  setPreferredModelId,
+  getPreferredModelId,
   SCHEMA_CATALOG_PICKS,
   SCHEMA_CODE_REVIEW,
   SCHEMA_CONTEXT_REVIEW,
@@ -45,7 +48,9 @@ type CustomPanelMethodName =
   | 'getWorkspaceDeps'
   | 'getSdlcToolAnalysis'
   | 'getSdlcRepoScan'
-  | 'getSdlcGitHubData';
+  | 'getSdlcGitHubData'
+  | 'listModels'
+  | 'setModel';
 
 type RequestHandler = (msg: RequestMessage) => void | Promise<void>;
 type QuizDifficulty = 'easy' | 'medium' | 'hard';
@@ -125,6 +130,8 @@ export class PanelRequestService {
     getSdlcToolAnalysis: this.handleGetSdlcToolAnalysis.bind(this),
     getSdlcRepoScan: this.handleGetSdlcRepoScan.bind(this),
     getSdlcGitHubData: this.handleGetSdlcGitHubData.bind(this),
+    listModels: this.handleListModels.bind(this),
+    setModel: this.handleSetModel.bind(this),
   };
 
   constructor(
@@ -240,6 +247,18 @@ ${context.packageDeps.length > 0 ? `- Key dependencies: ${context.packageDeps.sl
 ${context.focusSkills.length > 0 ? `- Skill focus areas: ${context.focusSkills.join(', ')}` : ''}
 
 Generate 3 ${context.difficulty} interview-style questions tailored to this developer's actual stack.`;
+  }
+
+  private async handleListModels(msg: RequestMessage): Promise<void> {
+    const models = await listAvailableModels();
+    postResponse(this.webview, msg.id, { models, selectedId: getPreferredModelId() });
+  }
+
+  private async handleSetModel(msg: RequestMessage): Promise<void> {
+    const params = (msg.params ?? {}) as Record<string, unknown>;
+    const id = isString(params.id) ? params.id : undefined;
+    await setPreferredModelId(id);
+    postResponse(this.webview, msg.id, { ok: true, selectedId: getPreferredModelId() });
   }
 
   private async handleExportSummary(msg: RequestMessage): Promise<void> {


### PR DESCRIPTION
## Description

The extension's AI features (skill generation, quizzes, code reviews, did-you-know, rule compilation, etc.) previously selected a **single** Copilot chat model by family (`gpt-5.4-mini` → `gpt-5-mini` → `gpt-4.1-mini` → `gpt-4.1`, then first-available). When that model is **disabled for the user's Copilot plan or organization**, it is still *selectable* via `vscode.lm.selectChatModels` but returns an **empty response**. The empty text then fails JSON parsing, so AI features error out — or silently produce nothing — with no actionable guidance for the user.

This PR makes model selection configurable and resilient:

- **New `src/core/llm-models.ts`** — a single source of truth for model selection:
  - New `aiEngineerCoach.preferredModel` setting plus an in-memory runtime override (so a change applies to the next request immediately and persists across reloads).
  - **Auto mode** orders available models by a vendor-neutral capability heuristic (`scoreFamily`) and **iterates** them, transparently skipping any model that returns an empty response instead of relying on a single pick.
  - De-duplicates models by id (Copilot can return the same model multiple times).
  - Pure helpers (`scoreFamily`, `orderModelsByPreference`, `dedupeModelsById`) are unit-tested.
- **`panel-llm.ts`** — `callLlm`/`callLlmJson` iterate candidate models and skip empty responses. When **every** model returns empty, they throw a clear message pointing the user at the new **"AI Model"** picker. Existing JSON-repair (`balanceTruncatedJson`) and structured-output fallback behaviour are preserved.
- **Dashboard sidebar** — adds an **"AI Model"** dropdown bound to the setting via new `listModels` / `setModel` RPCs (`panel-html.ts`, `app.ts`, `panel-request-service.ts`, `rpc-types.ts`).
- **`rule-compiler.ts`** — uses the shared candidate list instead of a hardcoded `gpt-4.1` family, so rule compilation benefits from the same fallback.

The capability ordering is deliberately **organization-neutral**: it does not assume which models any particular plan has enabled — a disabled model simply returns empty and the loop falls through to the next candidate.

## Related Issues

Fixes #91

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
  - Note: one pre-existing, environment-sensitive test (`src/core/parser-vscode.test.ts` › `findVsCodeDirs`) fails on a clean `main` checkout as well; it is unrelated to this change.
- [x] Changes are covered by tests (if applicable) — `src/core/llm-models.test.ts` (11 cases for scoring, ordering, and de-duplication)
- [x] Documentation updated (if applicable) — the new setting is self-documenting via its `markdownDescription` in `package.json`
