### PR TITLE
test(parser-vscode): make non-Windows server-dir test platform-independent

### DIFF
--- a/src/core/parser-vscode.test.ts
+++ b/src/core/parser-vscode.test.ts
@@ -766,6 +766,11 @@ describe('findVsCodeDirs — VS Code Server', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-engineer-coach-vscode-'));
     const home = process.env.HOME;
     const userProfile = process.env.USERPROFILE;
+    // findVsCodeDirs() branches on process.platform: on win32 it reads editions from
+    // %APPDATA% and skips the .vscode-server block entirely. This test exercises the
+    // non-Windows layout (~/.config + ~/.vscode-server), so pin the platform rather than
+    // relying on the host OS — otherwise it (correctly) returns [] when run on Windows.
+    const realPlatform = process.platform;
     const expected = [
       path.join(root, '.config', 'Code', 'User', 'workspaceStorage'),
       path.join(root, '.config', 'Code - Insiders', 'User', 'workspaceStorage'),
@@ -777,12 +782,14 @@ describe('findVsCodeDirs — VS Code Server', () => {
 
     process.env.HOME = root;
     process.env.USERPROFILE = '';
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
 
     try {
       expect(findVsCodeDirs()).toEqual(expected);
     } finally {
       process.env.HOME = home;
       process.env.USERPROFILE = userProfile;
+      Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
       fs.rmSync(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
### Problem

`findVsCodeDirs()` branches on `process.platform` — on `win32` it reads the `Code` / `Code - Insiders` editions from `%APPDATA%` and skips the `.vscode-server` block entirely (VS Code Server doesn't run natively on Windows).

The test *"includes server workspaceStorage paths on non-Windows hosts"* builds a non-Windows layout (`~/.config/Code/...` + `~/.vscode-server/...`) and asserts all four directories come back — but it never stubs `process.platform`. So it only passes when the **test process itself** runs on a non-Windows OS:

- ✅ Green on Linux CI
- ❌ Red for any Windows contributor running `npm test` locally — the function (correctly) returns `[]`, so the assertion fails.

### Fix

Pin `process.platform` to `'linux'` for the duration of the test and restore it in the existing `finally` block. This makes the test deterministic across Windows, macOS, and Linux.

Test-only change — production behavior is unchanged (returning `[]` on real Windows is correct).

### Verification

- Reproduced **red → green** on a Windows host: `src/core/parser-vscode.test.ts` 39/39 passing after the fix.
- `tsc --noEmit` clean.
- `eslint src/core/parser-vscode.test.ts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
