### PR TITLE
fix: compute burndown e2e month label in the browser to match the page's locale

### DIFF
--- a/tests/e2e/burndown.spec.ts
+++ b/tests/e2e/burndown.spec.ts
@@ -45,10 +45,14 @@ test.describe('Burndown', () => {
 
   test('shows current month', async ({ page }) => {
     const content = await page.textContent('#content');
-    // The burndown page defaults to the live current month (page-burndown.ts uses new Date()
-    // and formatMonthLabel's toLocaleString), so derive the expected label the same way
-    // instead of hard-coding it — otherwise the assertion goes stale every month rollover.
-    const expectedMonth = new Date().toLocaleString('default', { month: 'long', year: 'numeric' });
+    // page-burndown.ts formats the month with toLocaleString('default') in the BROWSER, so
+    // compute the expected label in the same runtime via page.evaluate. Deriving it in Node
+    // would use the OS default locale, which can differ from the browser's (e.g. a German
+    // host renders "Juni" in Node but the page shows "June"). This still tracks the live
+    // month without hard-coding it, so it never goes stale on a month rollover.
+    const expectedMonth = await page.evaluate(() =>
+      new Date().toLocaleString('default', { month: 'long', year: 'numeric' }),
+    );
     expect(content).toContain(expectedMonth);
   });
 });


### PR DESCRIPTION
## Problem

`tests/e2e/burndown.spec.ts` › "shows current month" fails on any non-en-US host.

The assertion (made dynamic in #88) derives the expected month in the **Node** test process:

```js
const expectedMonth = new Date().toLocaleString('default', { month: 'long', year: 'numeric' });
```

but `page-burndown.ts` formats the label the same way in the **browser** (`formatMonthLabel`). Node and Chromium can resolve the `'default'` locale differently — on a German-locale host Node yields `"Juni 2026"` while the page renders `"June 2026"` — so the assertion fails everywhere off en-US, even though the app is correct. CI stays green only because it runs en-US, where the two runtimes happen to agree.

## Fix

Compute the expected label inside the page via `page.evaluate`, so it always uses the same runtime and locale as the rendered label — while still tracking the live month with no hard-coding (preserving #88's intent: no monthly staleness).

```js
const expectedMonth = await page.evaluate(() =>
  new Date().toLocaleString('default', { month: 'long', year: 'numeric' }),
);
```

## Verification

`tests/e2e/burndown.spec.ts` passes 5/5 on a German-locale (de-AT) host — previously 4/5, with this test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)