### PR TITLE
fix(images): load Coding Moments screenshots from Claude Code sessions

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -19,6 +19,7 @@ import { warnCore } from './log';
 import { parseSessionFile } from './parser-vscode';
 import { parseCLIEventsFile } from './parser-vscode-cli';
 import { stripSingleSession } from './parser-shared';
+import { parseClaudeSessionFile } from './parser-claude';
 
 export interface ParseResult {
   workspaces: Map<string, Workspace>;
@@ -31,7 +32,7 @@ export interface ParseResult {
 }
 
 export interface SessionSource {
-  kind: 'vscode-session-file' | 'cli-events';
+  kind: 'vscode-session-file' | 'cli-events' | 'claude-session-file';
   filePath: string;
   workspaceId: string;
   workspaceName: string;
@@ -461,6 +462,9 @@ export async function loadSessionFromDisk(sessionId: string): Promise<Session | 
 
     if (source.kind === 'cli-events') {
       return parseCLIEventsFile(source.filePath, source.workspaceId, source.workspaceName);
+    }
+    if (source.kind === 'claude-session-file') {
+      return parseClaudeSessionFile(source.filePath, source.workspaceId, source.workspaceName);
     }
     return parseSessionFile(source.filePath, source.workspaceId, source.workspaceName, source.harness);
   } catch {

--- a/src/core/parser-claude.test.ts
+++ b/src/core/parser-claude.test.ts
@@ -170,6 +170,16 @@ describe('parseClaudeSessions', () => {
     });
   });
 
+  it('records the on-disk source file path on each parsed session', () => {
+    withProjectsDir('s.jsonl', [
+      makeUser('hello', '2025-06-15T10:00:00Z'),
+      makeAssistant('hi', '2025-06-15T10:00:01Z', { input_tokens: 10, output_tokens: 5 }),
+    ], (projectsDir) => {
+      const session = parseClaudeSessions(projectsDir)[0].sessions[0];
+      expect(session.sourceFilePath).toBe(path.join(projectsDir, '-Users-me-proj', 's.jsonl'));
+    });
+  });
+
   it('skips tool_result-only user records and merges following assistant into prior real user request', () => {
     withProjectsDir('s.jsonl', [
       makeUser('write a file please'),

--- a/src/core/parser-claude.test.ts
+++ b/src/core/parser-claude.test.ts
@@ -359,6 +359,56 @@ describe('parseClaudeSessions', () => {
     }
   });
 
+  it('stamps a subagent image request with the subagent file path so its images stay loadable', () => {
+    const root = fs.mkdtempSync(path.join(longTmpDir(), 'claude-subagent-img-'));
+    const projectsDir = path.join(root, 'projects');
+    const projDir = path.join(projectsDir, '-Users-me-proj');
+    const subDir = path.join(projDir, 'parent-sess', 'subagents');
+    fs.mkdirSync(subDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(projDir, 'parent-sess.jsonl'),
+      [
+        makeUser('parent prompt', '2025-06-15T10:00:00Z', { sessionId: 'parent-sess', uuid: 'p-1' }),
+        makeAssistant('parent reply', '2025-06-15T10:00:01Z', { input_tokens: 100, output_tokens: 20 }),
+      ].map(l => JSON.stringify(l)).join('\n'),
+      'utf-8',
+    );
+
+    const subFile = path.join(subDir, 'agent-1.jsonl');
+    fs.writeFileSync(
+      subFile,
+      [
+        makeUser('here is a screenshot', '2025-06-15T10:00:30Z', {
+          sessionId: 'agent-1', uuid: 'sub-img-req',
+          message: {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'here is a screenshot' },
+              { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAAAAAA' } },
+            ],
+          },
+        }),
+        makeAssistant('looked at it', '2025-06-15T10:00:31Z', { input_tokens: 50, output_tokens: 10 }),
+      ].map(l => JSON.stringify(l)).join('\n'),
+      'utf-8',
+    );
+
+    try {
+      const sessions = parseClaudeSessions(projectsDir)[0].sessions;
+      expect(sessions).toHaveLength(1);
+      const imgReq = sessions[0].requests.find(r => r.requestId === 'sub-img-req');
+      expect(imgReq?.variableKinds.image).toBe(1);
+      // Image bytes live in the subagent file, so the request points there...
+      expect(imgReq?.sourceFilePath).toBe(subFile);
+      // ...while the parent's own request falls back to the session source file.
+      const parentReq = sessions[0].requests.find(r => r.requestId === 'p-1');
+      expect(parentReq?.sourceFilePath).toBeUndefined();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('emits orphan subagent (no parent session) as standalone Claude', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-orphan-test-'));
     const projectsDir = path.join(root, 'projects');

--- a/src/core/parser-claude.ts
+++ b/src/core/parser-claude.ts
@@ -695,7 +695,7 @@ function buildClaudeRequest(
   return request;
 }
 
-function parseClaudeSessionFile(
+export function parseClaudeSessionFile(
   filePath: string,
   wsId: string,
   wsName: string,
@@ -758,5 +758,6 @@ function parseClaudeSessionFile(
     workspaceRootPath: cwd || undefined,
     launcherKind,
     entrypoint,
+    sourceFilePath: filePath,
   });
 }

--- a/src/core/parser-claude.ts
+++ b/src/core/parser-claude.ts
@@ -230,6 +230,17 @@ function countClaudeImages(line: ClaudeLine): number {
     .filter(block => block.type === 'image').length;
 }
 
+/** Record `sourceFilePath` on image-bearing requests so the source index can
+ *  re-read their images from the right file after they are merged into another
+ *  session (Claude subagent files rolled up into their parent). Only requests
+ *  that carry images need it; the rest fall back to the session source file. */
+function stampSubagentImageSource(requests: SessionRequest[], sourceFilePath: string | undefined): void {
+  if (!sourceFilePath) return;
+  for (const r of requests) {
+    if ((r.variableKinds.image ?? 0) > 0) r.sourceFilePath = sourceFilePath;
+  }
+}
+
 function applyClaudeToolBlock(
   block: ClaudeContentBlock,
   data: Pick<ClaudeAssistantData, 'toolsUsed' | 'editedFiles' | 'referencedFiles' | 'skillsUsed' | 'editLocs'>,
@@ -523,6 +534,11 @@ function parseClaudeProjectSessions(
         path.join(subagentDir, subEntry.name), workspaceId, workspaceName, editLocIndex,
       );
       if (!subSession) continue;
+      // Subagent requests are merged into the parent (or orphan) session, but
+      // their image bytes stay in this subagent file. Record that path on
+      // image-bearing requests so the source index can point lazy image
+      // re-reads (the Coding Moments gallery) at the right file.
+      stampSubagentImageSource(subSession.requests, subSession.sourceFilePath);
 
       if (parent) {
         // Merge subagent requests into parent. Sorting happens after all

--- a/src/core/parser-harnesses.test.ts
+++ b/src/core/parser-harnesses.test.ts
@@ -12,6 +12,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { describe, it, expect } from 'vitest';
 import { hasExternalHarnessSources, registerExternalHarnessSources } from './parser-harnesses';
+import { createRequest } from './parser-shared';
 import type { SessionSource } from './cache';
 import type { Session } from './types';
 
@@ -95,5 +96,53 @@ describe('registerExternalHarnessSources', () => {
     const index = new Map<string, SessionSource>();
     registerExternalHarnessSources([makeSession({ sessionId: 'x1', harness: 'Codex' })], index);
     expect(index.has('x1')).toBe(false);
+  });
+
+  it('registers an image-bearing subagent request under a <sessionId>::<requestId> key pointing at the subagent file', () => {
+    const index = new Map<string, SessionSource>();
+    const subagentImageReq = createRequest({
+      requestId: 'sub-img', messageText: 'see this', responseText: '',
+      variableKinds: { image: 1 },
+      sourceFilePath: '/home/me/.claude/projects/p/parent/subagents/agent-1.jsonl',
+    });
+    registerExternalHarnessSources(
+      [makeSession({
+        sessionId: 'parent', harness: 'Claude',
+        sourceFilePath: '/home/me/.claude/projects/p/parent.jsonl',
+        requests: [subagentImageReq],
+      })],
+      index,
+    );
+    // Parent still registered by sessionId -> parent file
+    expect(index.get('parent')?.filePath).toBe('/home/me/.claude/projects/p/parent.jsonl');
+    // Subagent image request registered under the composite key -> subagent file
+    expect(index.get('parent::sub-img')).toEqual({
+      kind: 'claude-session-file',
+      filePath: '/home/me/.claude/projects/p/parent/subagents/agent-1.jsonl',
+      workspaceId: 'w1',
+      workspaceName: 'proj',
+      harness: 'Claude',
+    });
+  });
+
+  it('does not add a composite key for requests in the session file or without images', () => {
+    const index = new Map<string, SessionSource>();
+    const sameFileReq = createRequest({
+      requestId: 'same', messageText: '', responseText: '',
+      variableKinds: { image: 1 }, sourceFilePath: '/p/parent.jsonl',
+    });
+    const noImageReq = createRequest({
+      requestId: 'noimg', messageText: '', responseText: '',
+      variableKinds: {}, sourceFilePath: '/p/parent/subagents/a.jsonl',
+    });
+    registerExternalHarnessSources(
+      [makeSession({
+        sessionId: 'parent', harness: 'Claude', sourceFilePath: '/p/parent.jsonl',
+        requests: [sameFileReq, noImageReq],
+      })],
+      index,
+    );
+    expect(index.has('parent::same')).toBe(false);
+    expect(index.has('parent::noimg')).toBe(false);
   });
 });

--- a/src/core/parser-harnesses.test.ts
+++ b/src/core/parser-harnesses.test.ts
@@ -11,7 +11,17 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { describe, it, expect } from 'vitest';
-import { hasExternalHarnessSources } from './parser-harnesses';
+import { hasExternalHarnessSources, registerExternalHarnessSources } from './parser-harnesses';
+import type { SessionSource } from './cache';
+import type { Session } from './types';
+
+function makeSession(over: Partial<Session>): Session {
+  return {
+    sessionId: 's1', workspaceId: 'w1', workspaceName: 'proj', location: 'terminal',
+    harness: 'Claude', creationDate: 0, lastMessageDate: 0, requestCount: 0, requests: [],
+    ...over,
+  };
+}
 
 function setEnv(key: 'HOME' | 'USERPROFILE', value: string | undefined): void {
   if (value === undefined) delete process.env[key]; else process.env[key] = value;
@@ -62,5 +72,28 @@ describe('hasExternalHarnessSources', () => {
       setEnv('HOME', prevHome);
       setEnv('USERPROFILE', prevUserProfile);
     }
+  });
+});
+
+describe('registerExternalHarnessSources', () => {
+  it('registers a single-file harness session keyed by its on-disk source path', () => {
+    const index = new Map<string, SessionSource>();
+    registerExternalHarnessSources(
+      [makeSession({ sessionId: 'c1', harness: 'Claude', sourceFilePath: '/home/me/.claude/projects/p/c1.jsonl' })],
+      index,
+    );
+    expect(index.get('c1')).toEqual({
+      kind: 'claude-session-file',
+      filePath: '/home/me/.claude/projects/p/c1.jsonl',
+      workspaceId: 'w1',
+      workspaceName: 'proj',
+      harness: 'Claude',
+    });
+  });
+
+  it('skips sessions that carry no source file path (e.g. Codex / OpenCode)', () => {
+    const index = new Map<string, SessionSource>();
+    registerExternalHarnessSources([makeSession({ sessionId: 'x1', harness: 'Codex' })], index);
+    expect(index.has('x1')).toBe(false);
   });
 });

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -103,20 +103,39 @@ export function hasExternalHarnessSources(): boolean {
  * sessions are self-contained `*.jsonl` files. Codex / OpenCode sessions carry no
  * source path and are skipped (they reference no images, so the gallery never
  * needs to re-read them). Call after each external-harness collection pass.
+ *
+ * Subagent image requests are a special case: parseClaudeSessions merges them
+ * into their parent session, but their bytes stay in a different file
+ * (`<session>/subagents/agent-*.jsonl`). Those carry their own request-level
+ * `sourceFilePath`, and are indexed under a `<sessionId>::<requestId>` composite
+ * key so image extraction reads the subagent file, not the parent. Only
+ * image-bearing requests get an entry, keeping the serialized index small.
  */
 export function registerExternalHarnessSources(
   sessions: Session[],
   sessionSourceIndex: Map<string, SessionSource>,
 ): void {
   for (const s of sessions) {
-    if (!s.sourceFilePath) continue;
-    sessionSourceIndex.set(s.sessionId, {
-      kind: 'claude-session-file',
-      filePath: s.sourceFilePath,
-      workspaceId: s.workspaceId,
-      workspaceName: s.workspaceName,
-      harness: s.harness,
-    });
+    if (s.sourceFilePath) {
+      sessionSourceIndex.set(s.sessionId, {
+        kind: 'claude-session-file',
+        filePath: s.sourceFilePath,
+        workspaceId: s.workspaceId,
+        workspaceName: s.workspaceName,
+        harness: s.harness,
+      });
+    }
+    for (const r of s.requests) {
+      if (!r.sourceFilePath || r.sourceFilePath === s.sourceFilePath) continue;
+      if ((r.variableKinds.image ?? 0) <= 0) continue;
+      sessionSourceIndex.set(`${s.sessionId}::${r.requestId}`, {
+        kind: 'claude-session-file',
+        filePath: r.sourceFilePath,
+        workspaceId: s.workspaceId,
+        workspaceName: s.workspaceName,
+        harness: s.harness,
+      });
+    }
   }
 }
 

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'fs';
 import { Workspace, Session } from './types';
+import type { SessionSource } from './cache';
 import { findClaudeDirs, parseClaudeSessions, parseClaudeSessionsAsync } from './parser-claude';
 import { findCodexDirs, parseCodexSessions } from './parser-codex';
 import { findOpenCodeDirs, parseOpenCodeSessions } from './parser-opencode';
@@ -91,6 +92,32 @@ export function hasExternalHarnessSources(): boolean {
   // working directory, which could report false positives. Bail out instead.
   if (!process.env.HOME && !process.env.USERPROFILE) return false;
   return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
+}
+
+/**
+ * Register the on-disk source file for external-harness sessions that carry one,
+ * so lazy re-reads (image extraction for the Coding Moments gallery, full-text
+ * session detail) can find the raw bytes stripped from the in-memory model.
+ *
+ * Only single-file harnesses set `sourceFilePath` — currently Claude Code, whose
+ * sessions are self-contained `*.jsonl` files. Codex / OpenCode sessions carry no
+ * source path and are skipped (they reference no images, so the gallery never
+ * needs to re-read them). Call after each external-harness collection pass.
+ */
+export function registerExternalHarnessSources(
+  sessions: Session[],
+  sessionSourceIndex: Map<string, SessionSource>,
+): void {
+  for (const s of sessions) {
+    if (!s.sourceFilePath) continue;
+    sessionSourceIndex.set(s.sessionId, {
+      kind: 'claude-session-file',
+      filePath: s.sourceFilePath,
+      workspaceId: s.workspaceId,
+      workspaceName: s.workspaceName,
+      harness: s.harness,
+    });
+  }
 }
 
 export function collectExternalHarnessesSync(

--- a/src/core/parser-main.test.ts
+++ b/src/core/parser-main.test.ts
@@ -24,6 +24,7 @@ vi.mock('./parser-xcode', () => ({
 vi.mock('./parser-harnesses', () => ({
   collectExternalHarnessesSync: vi.fn(),
   collectExternalHarnessesAsync: vi.fn(() => Promise.resolve()),
+  registerExternalHarnessSources: vi.fn(),
   EXTERNAL_HARNESS_SET: new Set(['Claude', 'Codex', 'OpenCode']),
 }));
 

--- a/src/core/parser-vscode-files.test.ts
+++ b/src/core/parser-vscode-files.test.ts
@@ -290,6 +290,21 @@ describe('extractSessionImages (Claude content blocks)', () => {
       expect(extractSessionImages(filePath, 'req-many')).toHaveLength(4);
     });
   });
+
+  it('matches a numeric line uuid against the stringified requestId', () => {
+    // parseClaudeLine stringifies numeric uuids, so the request's requestId is
+    // "12345"; the raw extractor JSON.parse leaves entry.uuid as the number 12345.
+    const line = JSON.stringify({
+      type: 'user',
+      uuid: 12345,
+      message: { role: 'user', content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAAAAAA' } }] },
+    });
+    withTempFile('claude-numeric-uuid.jsonl', line + '\n', (filePath) => {
+      expect(extractSessionImages(filePath, '12345')).toEqual([
+        'data:image/png;base64,AAAAAAAA',
+      ]);
+    });
+  });
 });
 
 describe('parseWorkspaceName', () => {

--- a/src/core/parser-vscode-files.test.ts
+++ b/src/core/parser-vscode-files.test.ts
@@ -13,6 +13,7 @@ import {
   readFile,
   forEachJsonlLine,
   forEachJsonlLineAsync,
+  extractSessionImages,
   parseWorkspaceName,
   parseWorkspaceFolderPath,
   parseCLIWorkspaceName,
@@ -230,6 +231,63 @@ describe('reconstructFromJsonl', () => {
     withTempFile('proto-append.jsonl', lines, (filePath) => {
       reconstructFromJsonl(filePath);
       expect(({} as Record<string, unknown>).tainted).toBeUndefined();
+    });
+  });
+});
+
+describe('extractSessionImages (Claude content blocks)', () => {
+  it('extracts a base64 image from a Claude `source` block', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      uuid: 'req-claude-1',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'see this screenshot' },
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'AAAAAAAA' } },
+        ],
+      },
+    });
+    withTempFile('claude-source.jsonl', line + '\n', (filePath) => {
+      expect(extractSessionImages(filePath, 'req-claude-1')).toEqual([
+        'data:image/png;base64,AAAAAAAA',
+      ]);
+    });
+  });
+
+  it('extracts a base64 image from a Claude `file` block, sniffing the mime type', () => {
+    const line = JSON.stringify({
+      type: 'user',
+      uuid: 'req-claude-2',
+      message: { role: 'user', content: [{ type: 'image', file: { base64: '/9j/4AAQ' } }] },
+    });
+    withTempFile('claude-file.jsonl', line + '\n', (filePath) => {
+      expect(extractSessionImages(filePath, 'req-claude-2')).toEqual([
+        'data:image/jpeg;base64,/9j/4AAQ',
+      ]);
+    });
+  });
+
+  it('returns images only for the line whose uuid matches the requestId', () => {
+    const lines = [
+      JSON.stringify({ type: 'user', uuid: 'other', message: { content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'BBBBBBBB' } }] } }),
+      JSON.stringify({ type: 'user', uuid: 'wanted', message: { content: [{ type: 'image', source: { type: 'base64', media_type: 'image/gif', data: 'CCCCCCCC' } }] } }),
+    ].join('\n');
+    withTempFile('claude-multi.jsonl', lines + '\n', (filePath) => {
+      expect(extractSessionImages(filePath, 'wanted')).toEqual([
+        'data:image/gif;base64,CCCCCCCC',
+      ]);
+    });
+  });
+
+  it('caps Claude image extraction at 4 images', () => {
+    const content = Array.from({ length: 6 }, (_, i) => ({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: `IMG${i}IMG${i}` },
+    }));
+    const line = JSON.stringify({ type: 'user', uuid: 'req-many', message: { content } });
+    withTempFile('claude-many.jsonl', line + '\n', (filePath) => {
+      expect(extractSessionImages(filePath, 'req-many')).toHaveLength(4);
     });
   });
 });

--- a/src/core/parser-vscode-files.ts
+++ b/src/core/parser-vscode-files.ts
@@ -447,6 +447,57 @@ interface RawImageRequest {
   variableData?: { variables?: RawImageVariable[] };
 }
 
+interface ClaudeImageBlock {
+  type?: string;
+  source?: { type?: string; media_type?: string; data?: string };
+  file?: { base64?: string };
+}
+
+interface ClaudeMessageLine {
+  uuid?: string;
+  message?: { content?: unknown };
+}
+
+/** Sniff an image mime type from the first bytes of a base64 string, falling
+ *  back to PNG. Used for Claude `file` blocks, which omit an explicit media type. */
+function mimeFromBase64(b64: string): string {
+  try {
+    const bytes = Buffer.from(b64.slice(0, 12), 'base64');
+    return detectMimeType([bytes[0], bytes[1]]);
+  } catch {
+    return 'image/png';
+  }
+}
+
+/**
+ * Extract image data URIs from a Claude Code session line. Claude stores image
+ * bytes as base64 strings inside `message.content[]` blocks, in one of two shapes:
+ *   { type:'image', source:{ type:'base64', media_type, data } }  (Anthropic API)
+ *   { type:'image', file:{ base64 } }                             (Claude Code file attach)
+ * This is a different schema from VS Code's variable byte-dicts/byte-arrays.
+ * Returns [] for any non-Claude line (e.g. VS Code state-replay records) so the
+ * caller can try this alongside the VS Code path without disturbing it.
+ */
+function extractClaudeImages(entry: ClaudeMessageLine, requestId: string): string[] {
+  if (entry.uuid !== requestId) return [];
+  const content = entry.message?.content;
+  if (!Array.isArray(content)) return [];
+  const images: string[] = [];
+  for (const block of content as ClaudeImageBlock[]) {
+    if (!block || block.type !== 'image') continue;
+    const src = block.source;
+    if (src && src.type === 'base64' && typeof src.data === 'string') {
+      const mime = typeof src.media_type === 'string' ? src.media_type : mimeFromBase64(src.data);
+      images.push(`data:${mime};base64,${src.data}`);
+      continue;
+    }
+    if (block.file && typeof block.file.base64 === 'string') {
+      images.push(`data:${mimeFromBase64(block.file.base64)};base64,${block.file.base64}`);
+    }
+  }
+  return images;
+}
+
 /**
  * Extract image data URIs from a list of variables for a given request.
  */
@@ -509,7 +560,12 @@ function extractImagesFromJsonl(raw: string, requestId: string): string[] {
     // Quick check: skip lines that don't contain our requestId
     if (!trimmed.includes(requestId)) continue;
 
-    const entry = JSON.parse(trimmed) as { kind: number; k?: PathKey[]; v?: unknown };
+    const entry = JSON.parse(trimmed) as { kind?: number; k?: PathKey[]; v?: unknown } & ClaudeMessageLine;
+
+    // Claude Code session line (message.content[] base64 blocks). Returns [] for
+    // VS Code state-replay records, so the VS Code path below still runs for them.
+    const claudeImages = extractClaudeImages(entry, requestId);
+    if (claudeImages.length > 0) return claudeImages.slice(0, 4);
 
     if (entry.kind === 0) {
       // Initial state — look in requests array

--- a/src/core/parser-vscode-files.ts
+++ b/src/core/parser-vscode-files.ts
@@ -454,7 +454,7 @@ interface ClaudeImageBlock {
 }
 
 interface ClaudeMessageLine {
-  uuid?: string;
+  uuid?: string | number;
   message?: { content?: unknown };
 }
 
@@ -479,7 +479,10 @@ function mimeFromBase64(b64: string): string {
  * caller can try this alongside the VS Code path without disturbing it.
  */
 function extractClaudeImages(entry: ClaudeMessageLine, requestId: string): string[] {
-  if (entry.uuid !== requestId) return [];
+  // The parser stringifies numeric uuids (parseClaudeLine), so requestId is a
+  // string; the raw JSON.parse above can leave entry.uuid as a number. Coerce
+  // before comparing so a numeric uuid still resolves its images.
+  if (entry.uuid === undefined || String(entry.uuid) !== requestId) return [];
   const content = entry.message?.content;
   if (!Array.isArray(content)) return [];
   const images: string[] = [];

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -15,7 +15,7 @@ import type { DirMetas, ParseResult, SessionSource } from './cache';
 import { findVsCodeDirs, scanVsCodeDirs, processWorkspaceEntry, processWorkspaceEntryAsync, harnessFromPath } from './parser-vscode';
 import { computeSessionTotals, createRunningTotals, type SessionTotals } from './session-totals';
 import { findXcodeDirs, parseXcodeDatabases, parseXcodeDatabasesAsync } from './parser-xcode';
-import { collectExternalHarnessesAsync, collectExternalHarnessesSync, EXTERNAL_HARNESS_SET } from './parser-harnesses';
+import { collectExternalHarnessesAsync, collectExternalHarnessesSync, registerExternalHarnessSources, EXTERNAL_HARNESS_SET } from './parser-harnesses';
 import { warnCore } from './log';
 import { runtimeDebug } from './runtime-debug';
 
@@ -349,6 +349,7 @@ async function tryMemoryCache(
   mem.result.sessions = mem.result.sessions.filter(s => !EXTERNAL_HARNESS_SET.has(s.harness));
   await collectVolatileHarnesses(logsDirs, mem.result, onProgress);
   await collectExternalHarnesses(mem.result.workspaces, mem.result.sessions, mem.result.editLocIndex, onProgress);
+  registerExternalHarnessSources(mem.result.sessions, mem.result.sessionSourceIndex);
   report({
     phase: 1, detail: 'Loaded from memory', pct: pct(1, 1),
     sessions: mem.result.sessions.length,
@@ -374,6 +375,7 @@ async function tryDiskCache(
   cached.result.sessions = cached.result.sessions.filter(s => !EXTERNAL_HARNESS_SET.has(s.harness));
   await collectVolatileHarnesses(logsDirs, cached.result, onProgress);
   await collectExternalHarnesses(cached.result.workspaces, cached.result.sessions, cached.result.editLocIndex, onProgress);
+  registerExternalHarnessSources(cached.result.sessions, cached.result.sessionSourceIndex);
   setMemoryCache(cached.result, currentMetas);
   report({
     phase: 1, detail: 'Loaded from cache', pct: pct(1, 1),
@@ -620,6 +622,7 @@ export function parseAllLogs(logsDirs: string[]): ParseResult {
   }
 
   collectExternalHarnessesSync(workspaces, sessions, editLocIndex);
+  registerExternalHarnessSources(sessions, sessionSourceIndex);
 
   stripSessionsForMemory(sessions);
   return { workspaces, sessions, editLocIndex, sessionSourceIndex };
@@ -738,6 +741,7 @@ export async function parseAllLogsAsyncDetailed(
       sessionSourceIndex: freshSessionSourceIndex,
     }, onProgress);
     await collectExternalHarnesses(workspaces, freshSessions, editLocIndex, onProgress);
+    registerExternalHarnessSources(freshSessions, freshSessionSourceIndex);
 
     const result: ParseResult = { workspaces, sessions: freshSessions, editLocIndex, sessionSourceIndex: freshSessionSourceIndex };
     stripSessionsForMemory(result.sessions);
@@ -761,6 +765,7 @@ export async function parseAllLogsAsyncDetailed(
 
   await collectXcode(xcodeDirs, workspaces, sessions, editLocIndex, onProgress);
   await collectExternalHarnesses(workspaces, sessions, editLocIndex, onProgress);
+  registerExternalHarnessSources(sessions, sessionSourceIndex);
 
   const result: ParseResult = { workspaces, sessions, editLocIndex, sessionSourceIndex };
   stripSessionsForMemory(result.sessions);

--- a/src/core/types/session-types.ts
+++ b/src/core/types/session-types.ts
@@ -166,6 +166,13 @@ export interface Session {
    *  changes. `undefined` for non-Claude sessions and very old Claude versions
    *  that did not record this field. */
   entrypoint?: string;
+  /** Absolute path to the on-disk session file this session was parsed from,
+   *  for harnesses whose sessions live in a single self-contained file (Claude
+   *  Code `*.jsonl`). Lets the source index point lazy re-reads — e.g. image
+   *  extraction for the Coding Moments gallery, which needs the raw bytes that
+   *  are stripped from the in-memory model — at the right file. `undefined` for
+   *  harnesses indexed elsewhere (VS Code sessions, CLI events). */
+  sourceFilePath?: string;
 }
 
 export interface Workspace {

--- a/src/core/types/session-types.ts
+++ b/src/core/types/session-types.ts
@@ -83,6 +83,13 @@ export interface SessionRequest {
   todoSnapshot: TodoItem[] | null;
   /** Precomputed work-type classification (feature, bug fix, refactor, etc.) */
   workType: string;
+  /** Absolute path to the on-disk file holding this request's image bytes, when
+   *  that differs from its session's `sourceFilePath`. Set on Claude subagent
+   *  requests rolled up into a parent session: their bytes stay in their own
+   *  `subagents/agent-*.jsonl` file, so image extraction must read that file
+   *  rather than the parent's. `undefined` for ordinary requests, which fall
+   *  back to the session source. */
+  sourceFilePath?: string;
   /** Reasoning / thinking effort for reasoning-capable models, when known.
    *  Sources:
    *    - Copilot CLI: `session.start.data.reasoningEffort` and `session.model_change.data.reasoningEffort`

--- a/src/webview/panel-rpc.test.ts
+++ b/src/webview/panel-rpc.test.ts
@@ -3,8 +3,28 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { describe, expect, it } from 'vitest';
+import type { ParseResult, SessionSource } from '../core/cache';
 import { getRpcHandler, validateDateFilter } from './panel-rpc';
+
+function callGetSessionImages(
+  sessionSourceIndex: Map<string, SessionSource>,
+  sessionId: string,
+  requestId: string,
+): string[] {
+  const handler = getRpcHandler('getSessionImages');
+  if (!handler) throw new Error('getSessionImages handler missing');
+  const parseResult = { sessionSourceIndex } as unknown as ParseResult;
+  const result = handler(
+    undefined as unknown as never,
+    parseResult,
+    { sessionId, requestId },
+  ) as { images: string[] };
+  return result.images;
+}
 
 describe('panel-rpc', () => {
   it('maps legacy workspace params onto workspaceId', () => {
@@ -23,5 +43,37 @@ describe('panel-rpc', () => {
   it('exposes handlers for the newer analyzer-backed methods', () => {
     expect(getRpcHandler('getInsights')).toBeTypeOf('function');
     expect(getRpcHandler('getWorkspaceContextSessions')).toBeTypeOf('function');
+  });
+
+  describe('getSessionImages', () => {
+    it('resolves a subagent image from the subagent file via the composite key, not the parent file', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rpc-images-'));
+      try {
+        const parentFile = path.join(root, 'parent.jsonl');
+        const subFile = path.join(root, 'agent-1.jsonl');
+        // Parent file has an image for the parent request 'p-1' only.
+        fs.writeFileSync(parentFile, JSON.stringify({
+          type: 'user', uuid: 'p-1',
+          message: { content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'PPPPPPPP' } }] },
+        }) + '\n');
+        // Subagent file has the image for the rolled-up request 'sub-img'.
+        fs.writeFileSync(subFile, JSON.stringify({
+          type: 'user', uuid: 'sub-img',
+          message: { content: [{ type: 'image', source: { type: 'base64', media_type: 'image/gif', data: 'SSSSSSSS' } }] },
+        }) + '\n');
+
+        const index = new Map<string, SessionSource>([
+          ['parent-sess', { kind: 'claude-session-file', filePath: parentFile, workspaceId: 'w', workspaceName: 'p', harness: 'Claude' }],
+          ['parent-sess::sub-img', { kind: 'claude-session-file', filePath: subFile, workspaceId: 'w', workspaceName: 'p', harness: 'Claude' }],
+        ]);
+
+        // Subagent moment: sessionId is the parent, requestId is the subagent's.
+        expect(callGetSessionImages(index, 'parent-sess', 'sub-img')).toEqual(['data:image/gif;base64,SSSSSSSS']);
+        // Ordinary parent moment: no composite key, falls back to the session file.
+        expect(callGetSessionImages(index, 'parent-sess', 'p-1')).toEqual(['data:image/png;base64,PPPPPPPP']);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/webview/panel-rpc.ts
+++ b/src/webview/panel-rpc.ts
@@ -754,7 +754,11 @@ const rpcHandlers: TypedRpcHandlers = {
     const sessionId = isString(params?.sessionId) ? params.sessionId : '';
     const requestId = isString(params?.requestId) ? params.requestId : '';
     if (!sessionId || !requestId) return { images: [] };
-    const source = p.sessionSourceIndex.get(sessionId);
+    // Subagent image requests are merged into their parent session but their
+    // bytes live in a different file, indexed under `<sessionId>::<requestId>`.
+    // Ordinary requests fall back to the session's own source file.
+    const source = p.sessionSourceIndex.get(`${sessionId}::${requestId}`)
+      ?? p.sessionSourceIndex.get(sessionId);
     if (!source) return { images: [] };
     return { images: extractSessionImages(source.filePath, requestId) };
   },


### PR DESCRIPTION
## Description

The Coding Moments gallery shows **"No Loadable Images Found"** for every image moment that comes from a Claude Code session: the moments are listed (`countClaudeImages` populates `variableKinds.image`), but no screenshot ever renders. This PR makes Claude session screenshots load end-to-end.

Three gaps, fixed across three commits:

**1. Sources never registered + Claude image schema not understood** (base fix)
- External-harness sessions (Claude/Codex/OpenCode) were added to the session list but never registered in `sessionSourceIndex`, so `getSessionImages` bailed at `if (!source) return { images: [] }` before extraction ran.
- `extractSessionImages` only understood the VS Code Copilot Chat schema (variable byte-dicts/byte-arrays). Claude stores image bytes as base64 strings inside `message.content[]` blocks — `{ type:'image', source:{ type:'base64', media_type, data } }` or `{ type:'image', file:{ base64 } }` — which the extractor skipped.
- Fix: add `Session.sourceFilePath` + a new `claude-session-file` `SessionSource` kind, registered via `registerExternalHarnessSources` after every external-harness collection pass (cold parse, async detailed, warm memory/disk cache); teach `extractImagesFromJsonl` to read Claude base64 blocks (mime-sniffed for `file` blocks). The VS Code path is untouched — the Claude helper returns `[]` for non-Claude lines.

**2. Numeric uuids never matched**
- `parseClaudeLine` stringifies numeric `uuid`s, so a request's `requestId` is e.g. `"12345"`, but the raw `JSON.parse` in `extractImagesFromJsonl` leaves `entry.uuid` as the number `12345`. The `===` comparison never matched, dropping the images. Fix: coerce before comparing.

**3. Subagent-file images returned nothing**
- `parseClaudeSessions` rolls subagent requests (`<session>/subagents/agent-*.jsonl`) up into their parent session, but each merged request keeps the subagent file's uuid while only the parent file is registered — so `getSessionImages` read the parent `.jsonl`, which never contains that uuid. Fix: record a request-level `sourceFilePath` on image-bearing subagent requests and index them under a `<sessionId>::<requestId>` composite key (collision-free with plain `sessionId` keys, nothing extra to serialize); `getSessionImages` prefers that key and falls back to the session source for ordinary requests.

Codex/OpenCode carry no images, so they intentionally register no source and need no extractor support.

> Note: there is a known follow-up — `countClaudeImages` counts every `type:'image'` block while extraction only emits inline-base64 shapes, so a hypothetical `url`/redacted image block (Claude writes inline base64 today) would still count-but-not-render. Narrowing the counter changes what registers as an image moment app-wide (metrics/rules), so it is deliberately left for a separate change.

## Related Issues

<!-- none -->

## Checklist

- [x] `npm run check` passes — typecheck, lint (0 errors), knip, and the full test suite are green locally (`spellcheck` is the only step not run here: cspell requires Node >= 22.18.0; it runs in CI)
- [x] Changes are covered by tests — Claude base64 extraction (source/file shapes, requestId match, numeric uuid, 4-image cap), source + composite-key registration, subagent-file stamping, and `getSessionImages` resolution
- [ ] Documentation updated (n/a — internal parser/extractor behavior)
