### PR TITLE
feat(parser): add Kilo session parser support

### DIFF
--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -10,6 +10,7 @@ import { Workspace, Session } from './types';
 import { findClaudeDirs, parseClaudeSessions, parseClaudeSessionsAsync } from './parser-claude';
 import { findCodexDirs, parseCodexSessions } from './parser-codex';
 import { findOpenCodeDirs, parseOpenCodeSessions } from './parser-opencode';
+import { findKiloDirs, parseKiloSessions } from './parser-kilo';
 
 type WorkspaceMap = Map<string, Workspace>;
 
@@ -69,6 +70,14 @@ const EXTERNAL_HARNESSES: ExternalHarnessCollector[] = [
       }
     },
   },
+  {
+    name: 'Kilo',
+    collectSync(ctx) {
+      for (const kiloDir of findKiloDirs()) {
+        for (const session of parseKiloSessions(kiloDir)) addSession(ctx.workspaces, ctx.sessions, session, kiloDir);
+      }
+    },
+  },
 ];
 
 export interface ExternalHarnessProgressHandlers {
@@ -78,7 +87,7 @@ export interface ExternalHarnessProgressHandlers {
   yieldToLoop?: () => Promise<void>;
 }
 
-/** Returns true if any external-harness (Claude Code, Codex, OpenCode) session
+/** Returns true if any external-harness (Claude Code, Codex, OpenCode, Kilo) session
  *  source exists on disk. The dashboard uses this so it does not abort when the
  *  only available logs come from a non-VS Code harness — e.g. a headless
  *  Remote-SSH host that has Claude Code sessions under `~/.claude/projects` but
@@ -88,7 +97,7 @@ export function hasExternalHarnessSources(): boolean {
   // string and probe relative paths (e.g. `.claude/projects`) under the current
   // working directory, which could report false positives. Bail out instead.
   if (!process.env.HOME && !process.env.USERPROFILE) return false;
-  return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
+  return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0 || findKiloDirs().length > 0;
 }
 
 export function collectExternalHarnessesSync(workspaces: WorkspaceMap, sessions: Session[]): void {
@@ -106,6 +115,7 @@ export const EXTERNAL_HARNESS_SET = new Set<string>([
   'Claude',
   'Codex',
   'OpenCode',
+  'Kilo',
 ]);
 
 export async function collectExternalHarnessesAsync(

--- a/src/core/parser-kilo.test.ts
+++ b/src/core/parser-kilo.test.ts
@@ -1,0 +1,343 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Tests for the Kilo parser — verifies that SQLite-backed sessions are
+ * parsed correctly, including token data, tool calls, and edge cases. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { findKiloDirs, parseKiloSessions } from './parser-kilo';
+import { DatabaseSync } from 'node:sqlite';
+
+let _tmpDir: string | undefined;
+
+function tmpDir(): string {
+  if (!_tmpDir) throw new Error('tmpDir not set');
+  return _tmpDir;
+}
+
+function createDb(): DatabaseSync {
+  _tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-parser-test-'));
+  const dbPath = path.join(_tmpDir!, 'kilo.db');
+  const db = new DatabaseSync(dbPath, { open: true });
+
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      workspace_id TEXT,
+      slug TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      path TEXT,
+      title TEXT NOT NULL,
+      version TEXT NOT NULL,
+      agent TEXT,
+      model TEXT,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL REFERENCES session(id),
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL REFERENCES message(id),
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE workspace (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      name TEXT NOT NULL DEFAULT '',
+      directory TEXT,
+      branch TEXT,
+      extra TEXT,
+      project_id TEXT NOT NULL,
+      time_used INTEGER NOT NULL
+    );
+  `);
+  return db;
+}
+
+function cleanup(): void {
+  if (_tmpDir) {
+    fs.rmSync(_tmpDir, { recursive: true, force: true });
+    _tmpDir = undefined;
+  }
+}
+
+describe('findKiloDirs', () => {
+  it('returns empty when no database exists', () => {
+    const dirs = findKiloDirs();
+    expect(Array.isArray(dirs)).toBe(true);
+  });
+});
+
+describe('parseKiloSessions', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('returns empty for empty database', () => {
+    const db = createDb();
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('returns empty when no messages exist', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess1', 'proj1', 'my-project', '/home/user/proj', 'My Project', '1', 1700000000000, 1700000000000);
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(0);
+  });
+
+  it('parses a simple user+assistant pair with token data', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess1', 'proj1', 'my-project', '/home/user/proj', 'My Project', '1', 1700000000000, 1700000000000);
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('m1', 'sess1', 1700000000000, 1700000000000,
+        JSON.stringify({
+          id: 'm1', sessionID: 'sess1', role: 'user',
+          time: { created: 1700000000000 },
+          agent: 'code',
+        }));
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('m2', 'sess1', 1700000001000, 1700000001000,
+        JSON.stringify({
+          id: 'm2', sessionID: 'sess1', role: 'assistant', parentID: 'm1',
+          time: { created: 1700000001000, completed: 1700000002000 },
+          modelID: 'claude-sonnet-4', providerID: 'anthropic',
+          tokens: { input: 1000, output: 200, reasoning: 0, cache: { read: 500, write: 100 } },
+        }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    const reqs = sessions[0].requests;
+    expect(reqs).toHaveLength(1);
+    expect(reqs[0].modelId).toBe('anthropic/claude-sonnet-4');
+    expect(reqs[0].promptTokens).toBe(1600); // 1000 + 500 + 100
+    expect(reqs[0].completionTokens).toBe(200);
+    expect(reqs[0].cacheReadTokens).toBe(500);
+    expect(reqs[0].cacheWriteTokens).toBe(100);
+    expect(reqs[0].agentName).toBe('code');
+  });
+
+  it('records zero-token assistants as data, not missing', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess2', 'proj1', 'proj', '/home/user/proj', 'Proj', '1', 1700000000000, 1700000000000);
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u1', 'sess2', 1700000000000, 1700000000000,
+        JSON.stringify({ id: 'u1', sessionID: 'sess2', role: 'user', time: { created: 1700000000000 } }));
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('a1', 'sess2', 1700000001000, 1700000001000,
+        JSON.stringify({
+          id: 'a1', sessionID: 'sess2', role: 'assistant', parentID: 'u1',
+          time: { created: 1700000001000, completed: 1700000002000 },
+          modelID: 'claude-sonnet-4', providerID: 'anthropic',
+          tokens: { input: 0, output: 0 },
+        }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].requests[0].promptTokens).toBe(0);
+    expect(sessions[0].requests[0].completionTokens).toBe(0);
+  });
+
+  it('marks request as missing when no assistant message exists', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess3', 'proj1', 'proj', '/home/user/proj', 'Proj', '1', 1700000000000, 1700000000000);
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u1', 'sess3', 1700000000000, 1700000000000,
+        JSON.stringify({ id: 'u1', sessionID: 'sess3', role: 'user', time: { created: 1700000000000 } }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].requests[0].promptTokens).toBeNull();
+    expect(sessions[0].requests[0].completionTokens).toBeNull();
+  });
+
+  it('extracts tools used, edited files, and referenced files from tool parts', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess4', 'proj1', 'proj', '/home/user/proj', 'Proj', '1', 1700000000000, 1700000000000);
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u1', 'sess4', 1700000000000, 1700000000000,
+        JSON.stringify({ id: 'u1', sessionID: 'sess4', role: 'user', time: { created: 1700000000000 }, agent: 'code' }));
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('a1', 'sess4', 1700000001000, 1700000001000,
+        JSON.stringify({
+          id: 'a1', sessionID: 'sess4', role: 'assistant', parentID: 'u1',
+          time: { created: 1700000001000, completed: 1700000003000 },
+          modelID: 'claude-sonnet-4', providerID: 'anthropic',
+          tokens: { input: 500, output: 50 },
+        }));
+
+    db.prepare(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?, ?)`)
+      .run('p1', 'a1', 'sess4', 1700000001500, 1700000001500,
+        JSON.stringify({
+          type: 'tool', tool: 'write', callID: 'call1',
+          state: { status: 'completed', input: { filePath: '/home/user/proj/src/index.ts', content: 'console.log("hi");' }, output: '' },
+        }));
+
+    db.prepare(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?, ?)`)
+      .run('p2', 'a1', 'sess4', 1700000002000, 1700000002000,
+        JSON.stringify({
+          type: 'tool', tool: 'read', callID: 'call2',
+          state: { status: 'completed', input: { filePath: '/home/user/proj/src/utils.ts' }, output: '...' },
+        }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    const req = sessions[0].requests[0];
+    expect(req.toolsUsed).toEqual(['write', 'read']);
+    expect(req.editedFiles).toEqual(['/home/user/proj/src/index.ts']);
+    expect(req.referencedFiles).toEqual(['/home/user/proj/src/utils.ts']);
+  });
+
+  it('stores session directory as workspaceRootPath', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess5', 'proj1', 'proj', '/home/user/proj', 'Proj', '1', 1700000000000, 1700000000000);
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u1', 'sess5', 1700000000000, 1700000000000,
+        JSON.stringify({ id: 'u1', sessionID: 'sess5', role: 'user', time: { created: 1700000000000 } }));
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('a1', 'sess5', 1700000001000, 1700000001000,
+        JSON.stringify({
+          id: 'a1', sessionID: 'sess5', role: 'assistant', parentID: 'u1',
+          time: { created: 1700000001000, completed: 1700000002000 },
+          modelID: 'claude-sonnet-4', providerID: 'anthropic',
+          tokens: { input: 100, output: 20 },
+        }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].workspaceRootPath).toBe('/home/user/proj');
+  });
+
+  it('uses workspace name from workspace table when available', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO workspace (id, type, name, directory, branch, project_id, time_used)
+      VALUES (?, ?, ?, ?, ?, ?, ?)`)
+      .run('ws1', 'local', 'My Awesome Project', '/home/user/proj', 'main', 'proj1', 1700000000000);
+
+    db.prepare(`INSERT INTO session (id, project_id, workspace_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess6', 'proj1', 'ws1', 'proj', '/home/user/proj', 'proj', '1', 1700000000000, 1700000000000);
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u1', 'sess6', 1700000000000, 1700000000000,
+        JSON.stringify({ id: 'u1', sessionID: 'sess6', role: 'user', time: { created: 1700000000000 } }));
+
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('a1', 'sess6', 1700000001000, 1700000001000,
+        JSON.stringify({
+          id: 'a1', sessionID: 'sess6', role: 'assistant', parentID: 'u1',
+          time: { created: 1700000001000, completed: 1700000002000 },
+          modelID: 'claude-sonnet-4', providerID: 'anthropic',
+          tokens: { input: 100, output: 20 },
+        }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].workspaceName).toBe('My Awesome Project');
+  });
+
+  it('handles multiple requests in a session', () => {
+    const db = createDb();
+    db.prepare(`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run('sess7', 'proj1', 'proj', '/home/user/proj', 'Proj', '1', 1700000000000, 1700000000000);
+
+    // First user+assistant pair
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u1', 'sess7', 1700000000000, 1700000000000,
+        JSON.stringify({ id: 'u1', sessionID: 'sess7', role: 'user', time: { created: 1700000000000 }, agent: 'code' }));
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('a1', 'sess7', 1700000001000, 1700000001000,
+        JSON.stringify({
+          id: 'a1', sessionID: 'sess7', role: 'assistant', parentID: 'u1',
+          time: { created: 1700000001000, completed: 1700000002000 },
+          modelID: 'claude-sonnet-4', providerID: 'anthropic',
+          tokens: { input: 100, output: 20 },
+        }));
+
+    // Second user+assistant pair
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('u2', 'sess7', 1700000003000, 1700000003000,
+        JSON.stringify({ id: 'u2', sessionID: 'sess7', role: 'user', time: { created: 1700000003000 }, agent: 'code' }));
+    db.prepare(`INSERT INTO message (id, session_id, time_created, time_updated, data)
+      VALUES (?, ?, ?, ?, ?)`)
+      .run('a2', 'sess7', 1700000004000, 1700000004000,
+        JSON.stringify({
+          id: 'a2', sessionID: 'sess7', role: 'assistant', parentID: 'u2',
+          time: { created: 1700000004000, completed: 1700000005000 },
+          modelID: 'gpt-4o', providerID: 'openai',
+          tokens: { input: 200, output: 50 },
+        }));
+
+    db.close();
+    const sessions = parseKiloSessions(tmpDir());
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].requests).toHaveLength(2);
+    expect(sessions[0].requests[0].modelId).toBe('anthropic/claude-sonnet-4');
+    expect(sessions[0].requests[1].modelId).toBe('openai/gpt-4o');
+  });
+});

--- a/src/core/parser-kilo.ts
+++ b/src/core/parser-kilo.ts
@@ -1,0 +1,369 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Kilo session parser
+ *
+ * Data layout:
+ *   ~/.local/share/kilo/kilo.db -- SQLite database
+ *
+ * The session table holds session metadata (id, project_id, workspace_id, slug,
+ * directory, path, title, agent, model, time_created, time_updated).
+ * The message table holds messages with a JSON `data` column containing
+ * the message info (role, time, agent, model, tokens, cost, etc.).
+ * The part table holds parts with a JSON `data` column containing
+ * the part payload (text, tool, reasoning, step-start/finish, etc.).
+ *
+ * Messages have: id, session_id, time_created, time_updated,
+ *   data: { role (user|assistant), time: {created, completed?}, agent,
+ *          model: {providerID, modelID, variant?}, tokens: {input, output, ...},
+ *          cost, finish, parentID, variant }
+ * Parts have: id, message_id, session_id, time_created, time_updated,
+ *   data: { type (text|tool|reasoning|step-start|step-finish|...), ... }
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { DatabaseSync } from 'node:sqlite';
+import { Session, SessionRequest } from './types';
+import { assertTrustedPath, createRequest, createSession, detectDevcontainerFromRequests } from './parser-shared';
+import { canonicalizeReasoningEffort, extractReasoningEffortFromModelId } from './helpers';
+
+interface KiloSessionRow {
+  id: string;
+  project_id: string;
+  workspace_id: string | null;
+  slug: string;
+  directory: string;
+  path: string | null;
+  title: string;
+  version: string;
+  agent: string | null;
+  model: string | null;
+  time_created: number;
+  time_updated: number;
+}
+
+interface KiloMessageRow {
+  id: string;
+  session_id: string;
+  time_created: number;
+  time_updated: number;
+  data: string;
+}
+
+interface KiloPartRow {
+  id: string;
+  message_id: string;
+  session_id: string;
+  time_created: number;
+  time_updated: number;
+  data: string;
+}
+
+interface KiloWorkspaceRow {
+  id: string;
+  type: string;
+  name: string;
+  directory: string | null;
+  branch: string | null;
+}
+
+interface KiloAssistantData {
+  responseText: string;
+  toolsUsed: string[];
+  editedFiles: string[];
+  referencedFiles: string[];
+  modelId: string;
+  totalElapsed: number | null;
+  lastTs: number | null;
+  tokenSource: { input?: number; output?: number; reasoning?: number; cache?: { read?: number; write?: number } } | null;
+}
+
+const WRITE_TOOLS = new Set(['write', 'edit', 'create', 'patch', 'apply_patch', 'multi_edit', 'replace']);
+const READ_TOOLS = new Set(['read', 'glob', 'grep', 'bash', 'ls', 'find', 'search_file', 'search_content', 'list_files', 'list_code_definition_names']);
+
+export function findKiloDirs(): string[] {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const dirs: string[] = [];
+
+  const kiloDir = path.join(home, '.local', 'share', 'kilo');
+  if (fs.existsSync(path.join(kiloDir, 'kilo.db'))) dirs.push(kiloDir);
+
+  return dirs;
+}
+
+function projectNameFromDir(directory: string): string {
+  return directory.replaceAll('\\', '/').replace(/\/+$/, '').split('/').pop() || 'unknown';
+}
+
+function getKiloUserText(userData: Record<string, unknown>, partsByMsg: Map<string, Record<string, unknown>[]>, msgId: string): string {
+  const userParts = partsByMsg.get(msgId) || [];
+  const userTextFromParts = userParts
+    .filter(p => String(p.type) === 'text' && typeof p.text === 'string')
+    .map(p => String(p.text!))
+    .join('\n');
+  if (userTextFromParts) return userTextFromParts;
+  const summary = userData.summary as Record<string, unknown> | undefined;
+  return typeof summary?.title === 'string' ? summary.title : '';
+}
+
+function findAssistantMessage(messages: KiloMessageRow[], startIndex: number, parentId: string, parsedData: Map<string, Record<string, unknown>>): KiloMessageRow | null {
+  for (let i = startIndex; i < messages.length; i++) {
+    const candidate = messages[i];
+    const data = parsedData.get(candidate.id);
+    if (!data) continue;
+    if (String(data.role) === 'assistant' && String(data.parentID) === parentId) return candidate;
+  }
+  const next = messages[startIndex];
+  if (next) {
+    const data = parsedData.get(next.id);
+    if (data && String(data.role) === 'assistant') return next;
+  }
+  return null;
+}
+
+function getInputPath(input: Record<string, unknown> | undefined, key: string): string | null {
+  const value = input?.[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function applyKiloPart(
+  partData: Record<string, unknown>,
+  data: Pick<KiloAssistantData, 'toolsUsed' | 'editedFiles' | 'referencedFiles'>,
+  textParts: string[],
+): void {
+  const type = String(partData.type || '');
+  if (type === 'text' && typeof partData.text === 'string') {
+    textParts.push(partData.text);
+    return;
+  }
+
+  if (type === 'reasoning' && typeof partData.text === 'string') {
+    textParts.push(partData.text);
+    return;
+  }
+
+  if (type !== 'tool' || !partData.tool) return;
+
+  const tool = String(partData.tool);
+  data.toolsUsed.push(tool);
+
+  const state = partData.state as Record<string, unknown> | undefined;
+  const stateInput = state?.input as Record<string, unknown> | undefined;
+  const input = stateInput || {};
+
+  const filePath = getInputPath(input, 'filePath')
+    ?? getInputPath(input, 'file_path')
+    ?? getInputPath(input, 'path')
+    ?? null;
+  if (!filePath) return;
+
+  const toolLower = tool.toLowerCase();
+  if (WRITE_TOOLS.has(toolLower)) {
+    data.editedFiles.push(filePath);
+    const content = typeof input.content === 'string' ? input.content
+      : typeof input.code === 'string' ? input.code
+        : typeof input.new_string === 'string' ? input.new_string
+          : typeof state?.output === 'string' ? state.output
+            : null;
+    if (content) {
+      const ext = filePath.split('.').pop() || 'unknown';
+      textParts.push(`\n\`\`\`${ext}\n${content}\n\`\`\`\n`);
+    }
+  } else if (READ_TOOLS.has(toolLower)) {
+    data.referencedFiles.push(filePath);
+  }
+}
+
+function collectKiloAssistantData(
+  assistantData: Record<string, unknown> | null,
+  partsByMsg: Map<string, Record<string, unknown>[]>,
+  userTs: number | null,
+  lastTs: number | null,
+): KiloAssistantData {
+  const result: KiloAssistantData = {
+    responseText: '',
+    toolsUsed: [],
+    editedFiles: [],
+    referencedFiles: [],
+    modelId: '',
+    totalElapsed: null,
+    lastTs,
+    tokenSource: null,
+  };
+  if (!assistantData) return result;
+
+  const time = assistantData.time as Record<string, unknown> | undefined;
+  const assistantTs = typeof time?.completed === 'number' ? time.completed
+    : typeof time?.created === 'number' ? time.created
+      : null;
+  if (assistantTs && (!result.lastTs || assistantTs > result.lastTs)) result.lastTs = assistantTs;
+  if (userTs && assistantTs) result.totalElapsed = assistantTs - userTs;
+
+  result.modelId = `${String(assistantData.providerID || '')}/${String(assistantData.modelID || '')}`;
+  if (result.modelId === '/') result.modelId = '';
+
+  result.tokenSource = (assistantData.tokens as KiloAssistantData['tokenSource']) ?? null;
+
+  const textParts: string[] = [];
+  const parts = partsByMsg.get(String((assistantData as Record<string, unknown>).id)) || [];
+  for (const part of parts) {
+    applyKiloPart(part, result, textParts);
+  }
+  result.responseText = textParts.join('\n');
+
+  return result;
+}
+
+function getKiloWorkspace(
+  rawSession: KiloSessionRow,
+  wsRow: KiloWorkspaceRow | null,
+): { wsId: string; wsName: string } {
+  const wsId = `kilo-${rawSession.id}`;
+  if (wsRow?.name) {
+    return { wsId: `kilo-ws-${wsRow.id}`, wsName: wsRow.name };
+  }
+  return {
+    wsId,
+    wsName: rawSession.directory
+      ? projectNameFromDir(rawSession.directory)
+      : rawSession.title || rawSession.slug || 'unknown',
+  };
+}
+
+function buildKiloRequest(
+  userData: Record<string, unknown>,
+  partsByMsg: Map<string, Record<string, unknown>[]>,
+  assistantData: KiloAssistantData,
+  userTs: number | null,
+): SessionRequest {
+  const cacheRead = assistantData.tokenSource?.cache?.read ?? 0;
+  const cacheWrite = assistantData.tokenSource?.cache?.write ?? 0;
+  const hasTokenData = assistantData.tokenSource != null;
+
+  const variant = typeof userData.variant === 'string' ? userData.variant : undefined;
+
+  return createRequest({
+    requestId: String(userData.id || ''),
+    timestamp: userTs,
+    messageText: getKiloUserText(userData, partsByMsg, String(userData.id || '')),
+    responseText: assistantData.responseText,
+    agentName: String(userData.agent || 'Kilo'),
+    agentMode: String(userData.agent || 'agent'),
+    modelId: assistantData.modelId,
+    toolsUsed: assistantData.toolsUsed,
+    editedFiles: [...new Set(assistantData.editedFiles)],
+    referencedFiles: [...new Set(assistantData.referencedFiles)],
+    totalElapsed: assistantData.totalElapsed,
+    promptTokens: hasTokenData ? (assistantData.tokenSource?.input ?? 0) + cacheRead + cacheWrite : null,
+    completionTokens: hasTokenData ? (assistantData.tokenSource?.output ?? 0) : null,
+    cacheReadTokens: cacheRead > 0 ? cacheRead : null,
+    cacheWriteTokens: cacheWrite > 0 ? cacheWrite : null,
+    reasoningEffort: canonicalizeReasoningEffort(variant ?? null)
+      ?? extractReasoningEffortFromModelId(assistantData.modelId),
+  });
+}
+
+function parseKiloSession(db: DatabaseSync, rawSession: KiloSessionRow): Session | null {
+  if (!rawSession.id) return null;
+
+  const messageRows = db.prepare(
+    'SELECT * FROM message WHERE session_id = ? ORDER BY time_created, id',
+  ).all(rawSession.id) as unknown as KiloMessageRow[];
+  if (messageRows.length === 0) return null;
+
+  const parsedData = new Map<string, Record<string, unknown>>();
+  for (const row of messageRows) {
+    try {
+      parsedData.set(row.id, JSON.parse(row.data));
+    } catch {
+      continue;
+    }
+  }
+
+  const partRows = db.prepare(
+    'SELECT * FROM part WHERE session_id = ? ORDER BY message_id, id',
+  ).all(rawSession.id) as unknown as KiloPartRow[];
+  const partsByMsg = new Map<string, Record<string, unknown>[]>();
+  for (const row of partRows) {
+    let partData: Record<string, unknown>;
+    try {
+      partData = JSON.parse(row.data);
+    } catch {
+      continue;
+    }
+    partData.id = row.id;
+    partData.sessionID = row.session_id;
+    partData.messageID = row.message_id;
+    const list = partsByMsg.get(row.message_id);
+    if (list) list.push(partData);
+    else partsByMsg.set(row.message_id, [partData]);
+  }
+
+  let wsRow: KiloWorkspaceRow | null = null;
+  if (rawSession.workspace_id) {
+    wsRow = db.prepare('SELECT * FROM workspace WHERE id = ?').get(rawSession.workspace_id) as unknown as KiloWorkspaceRow | null;
+  }
+  const { wsId, wsName } = getKiloWorkspace(rawSession, wsRow);
+
+  const requests: SessionRequest[] = [];
+  let firstTs: number | null = null;
+  let lastTs: number | null = null;
+
+  for (let i = 0; i < messageRows.length; i++) {
+    const row = messageRows[i];
+    const data = parsedData.get(row.id);
+    if (!data) continue;
+    if (String(data.role) !== 'user') continue;
+
+    const userTs = typeof (data.time as Record<string, unknown> | undefined)?.created === 'number'
+      ? (data.time as Record<string, unknown>).created as number
+      : null;
+    if (userTs && (!firstTs || userTs < firstTs)) firstTs = userTs;
+
+    const assistantMsg = findAssistantMessage(messageRows, i + 1, row.id, parsedData);
+    const assistantRowData = assistantMsg ? parsedData.get(assistantMsg.id) ?? null : null;
+    const assistantData = collectKiloAssistantData(assistantRowData, partsByMsg, userTs, lastTs);
+    lastTs = assistantData.lastTs;
+    requests.push(buildKiloRequest(data, partsByMsg, assistantData, userTs));
+  }
+
+  if (requests.length === 0) return null;
+
+  return createSession({
+    sessionId: rawSession.id,
+    workspaceId: wsId,
+    workspaceName: wsName,
+    location: 'terminal',
+    harness: 'Kilo',
+    creationDate: firstTs || rawSession.time_created || null,
+    lastMessageDate: lastTs || rawSession.time_updated || null,
+    requests,
+    hasDevcontainer: detectDevcontainerFromRequests(requests, rawSession.directory),
+    workspaceRootPath: rawSession.directory || rawSession.path || undefined,
+  });
+}
+
+export function parseKiloSessions(kiloDir: string): Session[] {
+  const dbPath = path.join(kiloDir, 'kilo.db');
+  assertTrustedPath(dbPath);
+  if (!fs.existsSync(dbPath)) return [];
+
+  const db = new DatabaseSync(dbPath, { open: true, readOnly: true });
+  try {
+    const sessionRows = db.prepare(
+      'SELECT * FROM session ORDER BY time_created DESC',
+    ).all() as unknown as KiloSessionRow[];
+
+    const sessions: Session[] = [];
+    for (const rawSession of sessionRows) {
+      const session = parseKiloSession(db, rawSession);
+      if (session) sessions.push(session);
+    }
+    return sessions;
+  } finally {
+    db.close();
+  }
+}

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -62,6 +62,7 @@ function getTrustedRoots(): string[] {
     roots.push(path.resolve(home, '.claude'));
     roots.push(path.resolve(home, '.codex'));
     roots.push(path.resolve(home, '.local', 'share', 'opencode'));
+    roots.push(path.resolve(home, '.local', 'share', 'kilo'));
     roots.push(path.resolve(home, '.config', 'github-copilot'));
   }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->
Add support for [kilo code ](https://kilo.ai/)
Kilo code is a fork of opencode
The PR replicates most of the opencode parser

- Add `parser-kilo.ts` with `findKiloDirs()` and `parseKiloSessions()`
- Register the Kilo harness in `parser-harnesses.ts`
- Include `parser-kilo.test.ts` with  test coverage
- Add Kilo to trusted roots in `parser-shared.ts`

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [x] Changes are covered by tests (if applicable)
- [x] Documentation updated (if applicable)
