### PR TITLE
feat(image-gallery): add time-range filter to Coding Moments view

### DIFF
--- a/src/webview/page-image-gallery.test.ts
+++ b/src/webview/page-image-gallery.test.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+beforeAll(() => {
+  (globalThis as unknown as { acquireVsCodeApi: () => unknown }).acquireVsCodeApi = () => ({
+    postMessage: () => { /* noop */ },
+    getState: () => null,
+    setState: () => { /* noop */ },
+  });
+});
+
+const DAY = 86_400_000;
+
+describe('Coding Moments time-range filter', () => {
+  it('exposes ranges aligned with the Output tab (incl. All time)', async () => {
+    const { IMAGE_TIME_RANGES } = await import('./page-image-gallery');
+    const labels = IMAGE_TIME_RANGES.map(r => r.label);
+    expect(labels).toContain('Last 7 days');
+    expect(labels).toContain('Last 30 days');
+    expect(labels).toContain('All time');
+    // "All time" is represented by days === 0.
+    expect(IMAGE_TIME_RANGES.find(r => r.label === 'All time')?.days).toBe(0);
+  });
+
+  it('rangeStartTimestamp returns 0 for All time and a cutoff otherwise', async () => {
+    const { rangeStartTimestamp } = await import('./page-image-gallery');
+    const now = 1_000_000_000_000;
+    expect(rangeStartTimestamp(0, now)).toBe(0);
+    expect(rangeStartTimestamp(7, now)).toBe(now - 7 * DAY);
+    // Negative/garbage days are treated as "no lower bound".
+    expect(rangeStartTimestamp(-5, now)).toBe(0);
+  });
+
+  it('filterMomentsByRange keeps only moments within the window', async () => {
+    const { filterMomentsByRange } = await import('./page-image-gallery');
+    const now = 1_000_000_000_000;
+    const moments = [
+      { id: 'recent', timestamp: now - DAY / 2 },
+      { id: 'week', timestamp: now - 6 * DAY },
+      { id: 'old', timestamp: now - 40 * DAY },
+    ];
+
+    const last7 = filterMomentsByRange(moments, 7, now).map(m => m.id);
+    expect(last7).toEqual(['recent', 'week']);
+
+    const last24h = filterMomentsByRange(moments, 1, now).map(m => m.id);
+    expect(last24h).toEqual(['recent']);
+
+    // 0 days ("All time") returns everything untouched.
+    expect(filterMomentsByRange(moments, 0, now)).toBe(moments);
+  });
+
+  it('includes a moment exactly on the boundary', async () => {
+    const { filterMomentsByRange } = await import('./page-image-gallery');
+    const now = 1_000_000_000_000;
+    const moments = [{ id: 'edge', timestamp: now - 7 * DAY }];
+    expect(filterMomentsByRange(moments, 7, now).map(m => m.id)).toEqual(['edge']);
+  });
+});

--- a/src/webview/page-image-gallery.test.ts
+++ b/src/webview/page-image-gallery.test.ts
@@ -24,7 +24,9 @@ describe('Coding Moments time-range filter', () => {
     const { IMAGE_TIME_RANGES } = await import('./page-image-gallery');
     const labels = IMAGE_TIME_RANGES.map(r => r.label);
     expect(labels).toContain('Last 7 days');
-    expect(labels).toContain('Last 30 days');
+    expect(labels).toContain('Last 4 weeks');
+    expect(labels).toContain('Last 3 months');
+    expect(labels).toContain('Last 6 months');
     expect(labels).toContain('All time');
     // "All time" is represented by days === 0.
     expect(IMAGE_TIME_RANGES.find(r => r.label === 'All time')?.days).toBe(0);

--- a/src/webview/page-image-gallery.ts
+++ b/src/webview/page-image-gallery.ts
@@ -88,10 +88,10 @@ export interface ImageTimeRange {
 
 /** Range options shown in the toolbar. Mirrors the Output tab pattern. */
 export const IMAGE_TIME_RANGES: ImageTimeRange[] = [
-  { days: 1, label: 'Last 24 hours' },
   { days: 7, label: 'Last 7 days' },
-  { days: 30, label: 'Last 30 days' },
+  { days: 28, label: 'Last 4 weeks' },
   { days: 90, label: 'Last 3 months' },
+  { days: 180, label: 'Last 6 months' },
   { days: 0, label: 'All time' },
 ];
 
@@ -195,8 +195,13 @@ export async function renderImageGallery(container: HTMLElement, currentFilter: 
   }
 
   /** Moments within the active time range (workspace filter not applied). */
+  let cachedRangeDays: number | null = null;
+  let cachedInRange: ImageMoment[] = rankedMoments;
   function timeFilteredMoments(): ImageMoment[] {
-    return filterMomentsByRange(rankedMoments, activeRangeDays);
+    if (cachedRangeDays === activeRangeDays) return cachedInRange;
+    cachedRangeDays = activeRangeDays;
+    cachedInRange = filterMomentsByRange(rankedMoments, activeRangeDays);
+    return cachedInRange;
   }
 
   function getFilterBase(): ImageMoment[] {

--- a/src/webview/page-image-gallery.ts
+++ b/src/webview/page-image-gallery.ts
@@ -78,6 +78,42 @@ function rankMomentsForGallery(moments: ImageMoment[]): ImageMoment[] {
   return scored.map(x => x.moment);
 }
 
+/* ── Time-range filter ───────────────────────────────────────── */
+
+export interface ImageTimeRange {
+  /** Window length in days; 0 means "All time" (no lower bound). */
+  days: number;
+  label: string;
+}
+
+/** Range options shown in the toolbar. Mirrors the Output tab pattern. */
+export const IMAGE_TIME_RANGES: ImageTimeRange[] = [
+  { days: 1, label: 'Last 24 hours' },
+  { days: 7, label: 'Last 7 days' },
+  { days: 30, label: 'Last 30 days' },
+  { days: 90, label: 'Last 3 months' },
+  { days: 0, label: 'All time' },
+];
+
+/** Lower-bound timestamp (ms) for a range. 0 days ("All time") returns 0. */
+export function rangeStartTimestamp(days: number, now: number = Date.now()): number {
+  return days <= 0 ? 0 : now - days * 86_400_000;
+}
+
+/** Keep only moments captured within the selected range. */
+export function filterMomentsByRange<T extends { timestamp: number }>(
+  moments: T[],
+  days: number,
+  now: number = Date.now(),
+): T[] {
+  const start = rangeStartTimestamp(days, now);
+  return start === 0 ? moments : moments.filter(m => m.timestamp >= start);
+}
+
+// Selected range in days (0 = all time). Module-level so the choice persists
+// across re-renders and navigation for the lifetime of the session.
+let activeRangeDays = 0;
+
 /* ── Render entry ────────────────────────────────────────────── */
 
 const PAGE_SIZE = 30;
@@ -146,20 +182,28 @@ export async function renderImageGallery(container: HTMLElement, currentFilter: 
 
   /** Returns stories filtered to only include moments with confirmed images */
   function getConfirmedStories(): ImageStory[] {
+    const start = rangeStartTimestamp(activeRangeDays);
     return pickTopStories(data.stories, 8)
-      .map(s => ({
-        ...s,
-        moments: s.moments.filter(m => confirmedImageSet.has(m.id)),
-        totalImages: s.moments.filter(m => confirmedImageSet.has(m.id)).length,
-      }))
+      .map(s => {
+        const moments = s.moments.filter(
+          m => confirmedImageSet.has(m.id) && (start === 0 || m.timestamp >= start),
+        );
+        return { ...s, moments, totalImages: moments.length };
+      })
       .filter(s => s.moments.length >= 2)
       .slice(0, 5);
   }
 
+  /** Moments within the active time range (workspace filter not applied). */
+  function timeFilteredMoments(): ImageMoment[] {
+    return filterMomentsByRange(rankedMoments, activeRangeDays);
+  }
+
   function getFilterBase(): ImageMoment[] {
+    const base = timeFilteredMoments();
     return galleryFilter === 'all'
-      ? rankedMoments
-      : rankedMoments.filter(m => m.workspace === galleryFilter);
+      ? base
+      : base.filter(m => m.workspace === galleryFilter);
   }
 
   function hasUndiscoveredImages(base: ImageMoment[]): boolean {
@@ -208,15 +252,33 @@ export async function renderImageGallery(container: HTMLElement, currentFilter: 
     return confirmedCount > visibleCount || hasUndiscoveredImages(base);
   }
 
+  function renderRangeBar(): ComponentChildren {
+    const count = getFilterBase().length;
+    return html`
+      <div class="cons-range-bar img-range-bar" id="img-range">
+        ${IMAGE_TIME_RANGES.map(r => html`
+          <button class=${`cons-range-btn${activeRangeDays === r.days ? ' active' : ''}`}
+                  onClick=${() => {
+                    if (activeRangeDays === r.days) return;
+                    activeRangeDays = r.days;
+                    visibleCount = PAGE_SIZE;
+                    void loadMoreAndRender(true);
+                  }}>${r.label}</button>`)}
+        <span class="img-range-count">${count} ${count === 1 ? 'moment' : 'moments'}</span>
+      </div>`;
+  }
+
   function rerenderPage(): void {
     const filtered = getFiltered();
-    const workspaces = [...new Set(rankedMoments.map(m => m.workspace))];
+    const inRange = timeFilteredMoments();
+    const workspaces = [...new Set(inRange.map(m => m.workspace))];
 
     render(html`
       <div class="img-gallery-page">
         ${renderHeader(data)}
+        ${renderRangeBar()}
         ${renderStoryReels(getConfirmedStories(), (s: ImageStory) => { openStoryPlayer(s); })}
-        ${renderWorkspaceFilter(workspaces, galleryFilter, rankedMoments, workspacesWithImages, (f: string) => { galleryFilter = f; visibleCount = PAGE_SIZE; void loadMoreAndRender(true); })}
+        ${renderWorkspaceFilter(workspaces, galleryFilter, inRange, workspacesWithImages, (f: string) => { galleryFilter = f; visibleCount = PAGE_SIZE; void loadMoreAndRender(true); })}
         <div class="img-grid" id="img-grid">
           ${filtered.map(m => renderMomentCard(m, (mm: ImageMoment) => {
             const story = storyBySession.get(mm.sessionId);
@@ -226,7 +288,12 @@ export async function renderImageGallery(container: HTMLElement, currentFilter: 
             }
           }))}
         </div>
-        ${filtered.length === 0 && !canLoadMore() ? html`
+        ${inRange.length === 0 ? html`
+          <div class="page-empty">
+            <h2>No Coding Moments In This Range</h2>
+            <p class="text-muted">No screenshots were captured in the selected time range. Try a wider range.</p>
+          </div>`
+        : filtered.length === 0 && !canLoadMore() ? html`
           <div class="page-empty">
             <h2>No Loadable Images Found</h2>
             <p class="text-muted">These sessions referenced images, but the raw screenshots could not be loaded.</p>

--- a/src/webview/styles-pages.css
+++ b/src/webview/styles-pages.css
@@ -1378,6 +1378,7 @@
 .img-range-bar {
   display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
   margin-bottom: 14px;
+  width: 100%;
 }
 .img-range-count {
   margin-left: auto; font-size: 11px; color: var(--text-muted);

--- a/src/webview/styles-pages.css
+++ b/src/webview/styles-pages.css
@@ -1374,6 +1374,16 @@
 .img-stat-chip.accent .img-stat-val { color: var(--accent-purple); font-size: 12px; }
 .img-stat-label { font-size: 9px; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.6px; }
 
+/* Time-range filter bar */
+.img-range-bar {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+  margin-bottom: 14px;
+}
+.img-range-count {
+  margin-left: auto; font-size: 11px; color: var(--text-muted);
+  white-space: nowrap;
+}
+
 /* Tabs */
 .img-tabs {
   display: flex; gap: 2px;


### PR DESCRIPTION
Adds a time-range filter bar (Last 7 days / 4 weeks / 3 months / 6 months / All time) to the Coding Moments image gallery, matching the Output tab pattern.

- New exported pure helpers: IMAGE_TIME_RANGES, rangeStartTimestamp, filterMomentsByRange (easy to unit-test, no DOM dependency)
- Range options aligned with the Output tab (7 days / 4 weeks / 3 months / 6 months / All time)
- Module-level activeRangeDays persists the selection for the session
- Range filter applied to moments, story reels and workspace pill counts; timeFilteredMoments() is memoized to avoid re-filtering on every call
- Empty state message when no moments match the selected range
- Live result count displayed next to the range buttons, right-aligned within the bar
- CSS for the bar reuses cons-range-btn from the Output tab
- 4 unit tests in page-image-gallery.test.ts