### PR TITLE
fix: use gpt-5-nano for Agentic Triage workflow

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"a7295b1927adf4de6ef08dbcf46f3d23f59f29859c680fb87e611397c71d1ef6","body_hash":"ceff08f68a4f21ad22bd52e3532bf794f733481c8a877c06718802dbe8e63407","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"small"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"af49137cf9739c2f874247280dcaa863c3bc8f3428ce3964ce86fc0cfe08ca20","body_hash":"ceff08f68a4f21ad22bd52e3532bf794f733481c8a877c06718802dbe8e63407","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"gpt-5-nano"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -107,7 +107,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: "small"
+          GH_AW_INFO_MODEL: "gpt-5-nano"
           GH_AW_INFO_VERSION: "1.0.55"
           GH_AW_INFO_AGENT_VERSION: "1.0.55"
           GH_AW_INFO_CLI_VERSION: "v0.77.5"
@@ -220,20 +220,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_bb3f4d6a632529c4_EOF'
+          cat << 'GH_AW_PROMPT_163eff9ff9ce06df_EOF'
           <system>
-          GH_AW_PROMPT_bb3f4d6a632529c4_EOF
+          GH_AW_PROMPT_163eff9ff9ce06df_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bb3f4d6a632529c4_EOF'
+          cat << 'GH_AW_PROMPT_163eff9ff9ce06df_EOF'
           <safe-output-tools>
           Tools: add_comment, close_issue, add_labels(max:5), set_issue_type, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_bb3f4d6a632529c4_EOF
+          GH_AW_PROMPT_163eff9ff9ce06df_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_bb3f4d6a632529c4_EOF'
+          cat << 'GH_AW_PROMPT_163eff9ff9ce06df_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -262,12 +262,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_bb3f4d6a632529c4_EOF
+          GH_AW_PROMPT_163eff9ff9ce06df_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bb3f4d6a632529c4_EOF'
+          cat << 'GH_AW_PROMPT_163eff9ff9ce06df_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_bb3f4d6a632529c4_EOF
+          GH_AW_PROMPT_163eff9ff9ce06df_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -474,9 +474,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8b623120d1e092aa_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2aa7fc261351a8c6_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":5},"close_issue":{"max":1,"state_reason":"not_planned","target":"triggering"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"set_issue_type":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8b623120d1e092aa_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2aa7fc261351a8c6_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -724,7 +724,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6d99630a4b6db290_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e83e0165897a44b4_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -768,7 +768,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6d99630a4b6db290_EOF
+          GH_AW_MCP_CONFIG_e83e0165897a44b4_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -826,7 +826,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: small
+          COPILOT_MODEL: gpt-5-nano
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1329,7 +1329,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_DUMMY_BYOK: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: small
+          COPILOT_MODEL: gpt-5-nano
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: v0.77.5
@@ -1406,7 +1406,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: "small"
+      GH_AW_ENGINE_MODEL: "gpt-5-nano"
       GH_AW_ENGINE_VERSION: "1.0.55"
       GH_AW_WORKFLOW_ID: "issue-triage"
       GH_AW_WORKFLOW_NAME: "Agentic Triage"

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -20,7 +20,7 @@ network: defaults
 
 # This workflow runs often, so use a small model to keep costs down.
 engine:
-  model: small
+  model: gpt-5-nano
 
 safe-outputs:
   add-labels:


### PR DESCRIPTION
## Summary

Fixes #124.

The Agentic Triage workflow was configured with `engine.model: small`, which could be routed through token steering to an incompatible GPT-5 mini variant that is not accessible via the `/chat/completions` endpoint.

This change updates the workflow to use `gpt-5-nano` directly and regenerates the workflow lock file using the repository-pinned `gh-aw v0.77.5` compiler.

## Validation

* Verified workflow compilation using `gh-aw v0.77.5`
* Regenerated lock file with the pinned compiler version
* Confirmed model routing no longer depends on the `gpt-5-mini` wildcard path
* Verified clean workflow diff
