### PR TITLE
fix(learning): reset quiz choice state when advancing to next question

### DIFF
--- a/src/webview/page-learning-templates.test.ts
+++ b/src/webview/page-learning-templates.test.ts
@@ -85,4 +85,12 @@ describe('page-learning-templates', () => {
     expect(result).toContain('data-choice="3"');
     expect(result).toContain('learn-quiz-skip');
   });
+
+  it('keys quiz cards by question index to avoid stale DOM reuse', () => {
+    const vnode = templates.renderQuiz([
+      { question: 'Q1', choices: ['A', 'B'], correctIndex: 0, explanation: '', difficulty: 'easy', topic: 'x' },
+    ] as never, 0) as { key?: unknown };
+
+    expect(vnode.key).toBe(0);
+  });
 });

--- a/src/webview/page-learning-templates.ts
+++ b/src/webview/page-learning-templates.ts
@@ -91,7 +91,7 @@ export function renderQuiz(questions: QuizQuestion[], index: number): ComponentC
 
   const question = questions[index];
   return html`
-    <div class="learn-quiz-card" data-index=${String(index)}>
+    <div class="learn-quiz-card" key=${index} data-index=${String(index)}>
       <div class="learn-quiz-meta">
         <span class=${`learn-quiz-diff learn-quiz-diff-${question.difficulty}`}>${question.difficulty}</span>
         <span class="learn-quiz-topic">${question.topic}</span>


### PR DESCRIPTION
## Problem

`renderQuiz()` re-renders the same Preact container on every question
change, but the `.learn-quiz-choice` `<button>` elements have no `key`:

```ts
// page-learning-templates.ts
<div class="learn-quiz-card" data-index=${String(index)}>
  ...
  ${question.choices.map((choice, i) =>
    html`<button class="learn-quiz-choice" data-choice=${String(i)}>${choice}</button>`)}
```

After answering, `wireQuizHandlers` mutates those buttons imperatively
(outside Preact's vnode diffing):

```ts
// page-learning.ts
for (const b of quizContainer.querySelectorAll<HTMLButtonElement>('.learn-quiz-choice')) {
  b.disabled = true;
  if (...) b.classList.add('learn-quiz-choice-correct');
  if (...) b.classList.add('learn-quiz-choice-wrong');
}
```

Since the choices have no `key` and the template's `class`/`disabled`
attributes never change between renders, Preact reuses the same DOM nodes
on the next `render(renderQuiz(questions, nextIndex), quizContainer)` call
and never resets them. The next question shows up already disabled with a
leftover correct/wrong highlight.

## Fix

```diff
- <div class="learn-quiz-card" data-index=${String(index)}>
+ <div class="learn-quiz-card" key=${index} data-index=${String(index)}>
```

Giving the card a `key` tied to the question index makes Preact treat each
question as a distinct node identity, so it discards the old DOM subtree and
mounts a fresh one — no imperative reset code needed.

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [x] Changes are covered by tests (if applicable)
- [ ] Documentation updated — not applicable