### PR TITLE
Update burndown e2e tests and mocks for feature flag handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ local/
 test_output.txt
 scripts/verify-counts.ts
 marketing/
+
+# Playwright test results
+test-results/

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -124,4 +124,8 @@ export const CONTEXT_GROWING_SESSION_GROWTH_RATE = 0.8;   // 80%+ sequential inc
 export const TOKEN_DATA_AVAILABLE_FROM = '2026-04-01';
 
 /* ---- Feature flags ---- */
+// When flipping this back to `true`, also update the burndown e2e tests, which
+// are skipped while it is off and contain stale assertions + an incomplete mock:
+// tests/e2e/burndown.spec.ts and the getAiCreditBurndown mock in
+// tests/e2e/harness.html (see the TODO(FF_TOKEN_REPORTING_ENABLED) notes there).
 export const FF_TOKEN_REPORTING_ENABLED = false;

--- a/tests/e2e/burndown.spec.ts
+++ b/tests/e2e/burndown.spec.ts
@@ -2,12 +2,15 @@ import { test, expect, Page } from '@playwright/test';
 
 const HARNESS_URL = 'http://localhost:3999/tests/e2e/harness.html';
 
-async function navigateToBurndown(page: Page) {
+async function bootHarness(page: Page) {
   await page.goto(HARNESS_URL);
   await page.waitForFunction(() => {
     const content = document.getElementById('content');
     return content && content.innerHTML.length > 200 && !content.querySelector('.loading-spinner') && !content.querySelector('.error-boundary');
   }, { timeout: 10000 });
+}
+
+async function navigateToBurndown(page: Page) {
   await page.locator('[data-page="burndown"]').first().click();
   await page.waitForFunction(() => {
     const content = document.getElementById('content');
@@ -15,8 +18,29 @@ async function navigateToBurndown(page: Page) {
   }, { timeout: 10000 });
 }
 
+// TODO(FF_TOKEN_REPORTING_ENABLED): These tests are SKIPPED while the burndown
+// feature flag is off (see beforeEach). When the flag is switched back on, two
+// things below are known to be stale and MUST be fixed before they will pass:
+//   1. The value assertions in this file still expect the OLD getBurndown mock
+//      (budget 1500 / consumed 248 / projected 2480). The page now reads
+//      getAiCreditBurndown (budget 300 / consumed 42.5 / projected 425). Either
+//      update these to the new numbers, or switch to structural checks
+//      (presence of "Budget" / "Consumed:" / "Projected:" / "All Models").
+//   2. The getAiCreditBurndown mock in tests/e2e/harness.html is incomplete
+//      (missing byModel/missingPct/countedRequests/partialRequests/
+//      pendingRequests/noDataRequests/finalizableRequests/coverageByDay, etc.),
+//      so the status section never renders. Fill it out to match the real
+//      AiCreditBurndownData shape in src/core/analyzer-consumption.ts.
 test.describe('Burndown', () => {
   test.beforeEach(async ({ page }) => {
+    await bootHarness(page);
+    // When FF_TOKEN_REPORTING_ENABLED is off, app.ts removes the Burndown nav
+    // link at runtime (and the page renders only a "disabled" notice). The link
+    // removal runs synchronously on app.js load, so by the time the harness has
+    // booted it is already gone. Skip gracefully instead of timing out on a
+    // click target that no longer exists.
+    const hasBurndown = (await page.locator('[data-page="burndown"]').count()) > 0;
+    test.skip(!hasBurndown, 'Burndown is gated by FF_TOKEN_REPORTING_ENABLED');
     await navigateToBurndown(page);
   });
 

--- a/tests/e2e/harness.html
+++ b/tests/e2e/harness.html
@@ -327,6 +327,14 @@ function getMockData(method, params) {
       budgetLine: Array.from({ length: 31 }, () => 300),
       status: 'warning',
       recommendation: 'At current pace you will exceed your credit budget.'
+      // TODO(FF_TOKEN_REPORTING_ENABLED): This mock is INCOMPLETE. The real
+      // getAiCreditBurndown (src/core/analyzer-consumption.ts) also returns
+      // byModel, missingPct, countedRequests, partialRequests, pendingRequests,
+      // noDataRequests, finalizableRequests, delegatedRequests, coverageByDay,
+      // daysUntilExhaustion, safeDailyBudget, projectedOverage and totalRequests.
+      // Without them page-burndown.ts cannot render the status section. When the
+      // burndown feature flag is re-enabled, fill these in so tests/e2e/
+      // burndown.spec.ts can exercise the page (those tests are skipped today).
     }),
 
     getWorkflowOptimization: () => ({


### PR DESCRIPTION
## Summary

Fixes #109. The burndown e2e tests were failing because `FF_TOKEN_REPORTING_ENABLED` is off, so `app.ts` removes the `[data-page="burndown"]` nav link at runtime. The tests still tried to click that (now-missing) link, timing out for 30s × 5 tests in `beforeEach`.

Since burndown won't be re-enabled in the near future, this PR makes the tests **skip gracefully** instead of failing, and adds `TODO` notes so the stale assertions and incomplete mock get fixed when the flag is flipped back on.

## Changes

- **`tests/e2e/burndown.spec.ts`**
  - Split the `navigateToBurndown` helper into `bootHarness` (load + wait for render) and the nav-click step.
  - In `beforeEach`, after the harness boots, check whether `[data-page="burndown"]` still exists. The flag-gating removal runs synchronously on `app.js` load, so the link is already gone by boot time → `test.skip(...)` fires before any click, avoiding the timeout.
  - Added a `TODO(FF_TOKEN_REPORTING_ENABLED)` block documenting the stale value assertions (old `getBurndown` `1500 / 248 / 2480` vs new `getAiCreditBurndown` `300 / 42.5 / 425`).
- **`tests/e2e/harness.html`** — Added a `TODO(FF_TOKEN_REPORTING_ENABLED)` note on the `getAiCreditBurndown` mock listing the missing fields (`byModel`, `missingPct`, `countedRequests`, `partialRequests`, `pendingRequests`, `noDataRequests`, `finalizableRequests`, `delegatedRequests`, `coverageByDay`, `daysUntilExhaustion`, `safeDailyBudget`, `projectedOverage`, `totalRequests`) that block the status section from rendering; points to the real shape in `src/core/analyzer-consumption.ts`.
- **`src/core/constants.ts`** — Added a comment at the `FF_TOKEN_REPORTING_ENABLED` definition reminding whoever re-enables it to update the two test files above.

All three notes share the searchable tag `TODO(FF_TOKEN_REPORTING_ENABLED)` — a single grep surfaces every spot to fix.

## Testing

`npx playwright test tests/e2e/burndown.spec.ts`

Before:

```
Running 5 tests using 1 worker
  5 failed   (locator.click: Test timeout of 30000ms exceeded — waiting for locator('[data-page="burndown"]'))
```

After:

```
Running 5 tests using 1 worker
  5 skipped
```

Exits 0.

