### PR TITLE
feat: implement filtering for harness-injected context in workflow an…

### DIFF
--- a/src/core/analyzer-workflows.test.ts
+++ b/src/core/analyzer-workflows.test.ts
@@ -101,6 +101,21 @@ describe('WorkflowAnalyzer', () => {
       expect(result.clusters).toEqual([]);
     });
 
+    it('filters harness-injected AGENTS.md context as noise', () => {
+      const now = Date.now();
+      const injected = '# AGENTS.md instructions for /home/me/project\n\n<INSTRUCTIONS>\nfollow repo conventions\n</INSTRUCTIONS>';
+      const sessions = Array.from({ length: 5 }, (_, i) =>
+        makeSession({
+          sessionId: `inj-${i}`,
+          requests: [makeRequest({ messageText: injected, timestamp: now + i * 1000 })],
+          lastMessageDate: now + i * 1000,
+        })
+      );
+      const analyzer = createAnalyzer(sessions);
+      const result = analyzer.getWorkflowOptimization();
+      expect(result.clusters).toEqual([]);
+    });
+
     it('clusters repeated similar prompts', () => {
       const now = Date.now();
       // Need at least 3 occurrences with same fingerprint

--- a/src/core/analyzer-workflows.ts
+++ b/src/core/analyzer-workflows.ts
@@ -7,7 +7,7 @@
 
 import { DateFilter, WorkflowCluster, WorkflowOptimizationData } from './types';
 import { AnalyzerBase } from './analyzer-base';
-import { toDateStr } from './helpers';
+import { isHarnessInjectedContext, toDateStr } from './helpers';
 
 /** Minimum prompt length to consider for clustering (skip trivial messages) */
 const MIN_PROMPT_LEN = 15;
@@ -53,6 +53,8 @@ function normalizePrompt(raw: string): string {
 /** Check if text is likely a system/bot message or noise rather than a user prompt */
 function isNoise(text: string): boolean {
   const t = text.trim();
+  // Harness-injected session-start context (e.g. Codex AGENTS.md / environment context)
+  if (isHarnessInjectedContext(t)) return true;
   // Decorative separators/borders
   if (/^[═─━=\-_*]{10,}/.test(t)) return true;
   // System auth/notification messages

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -294,3 +294,25 @@ export function classifyWorkType(msg: string): WorkType {
   }
   return 'other';
 }
+
+/**
+ * Harness-injected session-start payloads that are recorded as `user` messages
+ * but are not real user prompts (e.g. Codex injects the repo `AGENTS.md` and
+ * environment/instruction context at session start). These should be treated as
+ * noise so they don't get clustered into workflow/skill recommendations.
+ *
+ * Matches a small set of known leading markers only — deliberately NOT a generic
+ * `#` markdown header or `<tag>` rule, both of which would suppress legitimate
+ * user prompts.
+ */
+const HARNESS_INJECTED_MARKERS: RegExp[] = [
+  /^# AGENTS\.md instructions\b/,
+  /^<environment_context\b/,
+  /^<INSTRUCTIONS\b/,
+  /^<user_instructions\b/,
+];
+
+export function isHarnessInjectedContext(text: string): boolean {
+  const t = text.trimStart();
+  return HARNESS_INJECTED_MARKERS.some(re => re.test(t));
+}

--- a/src/core/parser-codex.test.ts
+++ b/src/core/parser-codex.test.ts
@@ -186,6 +186,29 @@ describe('parseCodexSessions skillsUsed extraction', () => {
       expect(sessions[0].requests[0].skillsUsed).toEqual(['pdf']);
     });
   });
+
+  it('ignores harness-injected AGENTS.md context and captures the real prompt', () => {
+    withCodexFile([
+      { type: 'session_meta', payload: { id: 'sess-inject-1', cwd: '/Users/me/proj' } },
+      { type: 'turn_context', payload: { model: 'gpt-5.3-codex' } },
+      // Session-start injected context recorded as a user response_item.
+      { type: 'response_item', timestamp: '2025-06-15T10:00:00Z',
+        payload: { type: 'message', role: 'user', content: [
+          { type: 'input_text', text: '# AGENTS.md instructions for /Users/me/proj\n\nfollow repo conventions' },
+          { type: 'input_text', text: '<environment_context>\n  <cwd>/Users/me/proj</cwd>\n</environment_context>' },
+        ] } },
+      // The actual user prompt.
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:05Z', payload: { type: 'user_message', message: 'what is this repo about?' } },
+      { type: 'event_msg', timestamp: '2025-06-15T10:00:06Z', payload: { type: 'assistant_message', content: 'a coach' } },
+    ], (sessionsDir) => {
+      const sessions = parseCodexSessions(sessionsDir);
+      expect(sessions).toHaveLength(1);
+      const texts = sessions[0].requests.map(r => r.messageText);
+      // The injected AGENTS.md / environment context must not be captured as a prompt.
+      expect(texts.some(t => t.startsWith('# AGENTS.md instructions'))).toBe(false);
+      expect(texts).toContain('what is this repo about?');
+    });
+  });
 });
 
 describe('findCodexDirs', () => {

--- a/src/core/parser-codex.ts
+++ b/src/core/parser-codex.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 import { StringDecoder } from 'string_decoder';
 import { ModelUsage, Session, SessionRequest } from './types';
 import { assertTrustedPath, createRequest, createSession, detectDevcontainerFromRequests, extractSkillNameFromPath, extractSkillPathsFromText } from './parser-shared';
-import { canonicalizeReasoningEffort, extractReasoningEffortFromModelId } from './helpers';
+import { canonicalizeReasoningEffort, extractReasoningEffortFromModelId, isHarnessInjectedContext } from './helpers';
 
 interface CodexLine {
   type: string;
@@ -268,6 +268,9 @@ function extractFilePath(args: Record<string, unknown> | null | undefined): stri
 
 function handleUserMessageEvent(payload: Record<string, unknown>, state: CodexParseState, ts: number | null, defaultModel: string): void {
   const newMessage = stringValue(payload.message) || stringValue(payload.text);
+  // Harness-injected session-start context is recorded as a user message but is
+  // not a real prompt; ignore it before flushing or mutating turn state.
+  if (isHarnessInjectedContext(newMessage)) return;
   if (state.currentUserMessage && state.currentUserMessage === newMessage && isTurnEmpty(state)) {
     if (state.turnStartTs == null) state.turnStartTs = ts;
     return;
@@ -342,7 +345,7 @@ function handleTurnContext(payload: Record<string, unknown>, state: CodexParseSt
 
 function handleUserResponseItem(payload: Record<string, unknown>, state: CodexParseState, ts: number | null, defaultModel: string): void {
   for (const item of extractContentItems(payload.content)) {
-    if (item.type !== 'input_text' || !item.text || item.text.startsWith('<')) continue;
+    if (item.type !== 'input_text' || !item.text || item.text.startsWith('<') || isHarnessInjectedContext(item.text)) continue;
     if (!state.currentUserMessage) {
       flushCodexTurn(state, defaultModel);
       state.currentUserMessage = item.text;


### PR DESCRIPTION
This pull request improves the handling of harness-injected context messages (such as AGENTS.md instructions and environment context) in workflow analysis and session parsing. These injected messages, which are not real user prompts, are now filtered out to prevent them from being clustered or recorded as user activity, ensuring more accurate workflow and skill extraction.

**Filtering of harness-injected context:**

* Added the `isHarnessInjectedContext` utility in `helpers.ts`, which detects known harness-injected markers to identify and filter out these messages.
* Updated `analyzer-workflows.ts` to call `isHarnessInjectedContext` in the noise filter, ensuring such messages are excluded from workflow clustering. [[1]](diffhunk://#diff-0aca165399fc555fb45c3ced504f4e493ecd1714202962657b8c92acb466b32dL10-R10) [[2]](diffhunk://#diff-0aca165399fc555fb45c3ced504f4e493ecd1714202962657b8c92acb466b32dR56-R57)
* Modified `parser-codex.ts` to skip harness-injected context in both user response items and user message events, preventing these from being treated as real user prompts. [[1]](diffhunk://#diff-145088457d763f0d742ac27e5b189b699d6511883eb59927743c6f769009ec59L25-R25) [[2]](diffhunk://#diff-145088457d763f0d742ac27e5b189b699d6511883eb59927743c6f769009ec59R271-R273) [[3]](diffhunk://#diff-145088457d763f0d742ac27e5b189b699d6511883eb59927743c6f769009ec59L345-R348)

**Test coverage:**

* Added tests in `analyzer-workflows.test.ts` and `parser-codex.test.ts` to verify that harness-injected AGENTS.md and environment context are ignored and do not affect workflow clustering or prompt extraction. [[1]](diffhunk://#diff-f256b81421517ea000e117d02e16f01057b63b11e6ef972867b4062a6238f09bR104-R118) [[2]](diffhunk://#diff-ff5ea46417cfeb863391e790114770422e4e7b061c0c186b645220f9d0e1be69R189-R211)…alysis and parsing

## Description

<!-- What does this PR do? -->

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## Checklist

- [ ] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [ ] Changes are covered by tests (if applicable)
- [ ] Documentation updated (if applicable)
