### PR TITLE
feat: add Cursor IDE session harness

### DIFF
--- a/src/core/parser-cursor.test.ts
+++ b/src/core/parser-cursor.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as cp from "child_process";
+
+vi.mock("fs");
+vi.mock("child_process");
+
+// Must mock before importing the module under test
+const mockExecSync = vi.mocked(cp.execSync);
+const mockReaddirSync = vi.mocked(fs.readdirSync);
+const mockExistsSync = vi.mocked(fs.existsSync);
+const mockStatSync = vi.mocked(fs.statSync);
+
+describe("parseCursorSessions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Simulate a valid storage root
+    mockStatSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+    mockReaddirSync.mockReturnValue(["abc123"] as unknown as fs.Dirent[]);
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  it("parses a session with user+assistant bubbles", async () => {
+    const composerMeta = JSON.stringify({
+      composerId: "comp-1",
+      name: "My Session",
+      createdAt: 1700000000000,
+      lastUpdatedAt: 1700001000000,
+      selectedModel: "claude-3-5-sonnet",
+    });
+    const userBubble = JSON.stringify({ bubbleId: "b1", type: 1, text: "Hello?" });
+    const aiBubble = JSON.stringify({ bubbleId: "b2", type: 2, text: "Hi there!", timingMs: 800, codeBlocks: [] });
+
+    mockExecSync
+      .mockReturnValueOnce(`composerData:comp-1\x1f${composerMeta}\n` as unknown as Buffer)
+      .mockReturnValueOnce(`bubbleId:comp-1:b1\x1f${userBubble}\nbubbleId:comp-1:b2\x1f${aiBubble}\n` as unknown as Buffer);
+
+    const { parseCursorSessions } = await import("./parser-cursor.js");
+    const sessions = await parseCursorSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].source).toBe("cursor");
+    expect(sessions[0].model).toBe("claude-3-5-sonnet");
+    expect(sessions[0].messages).toHaveLength(1);
+    expect(sessions[0].messages[0].prompt).toBe("Hello?");
+    expect(sessions[0].messages[0].response).toBe("Hi there!");
+    expect(sessions[0].messages[0].durationMs).toBe(800);
+  });
+
+  it("returns empty array when no databases found", async () => {
+    mockStatSync.mockImplementation(() => { throw new Error("ENOENT"); });
+    const { parseCursorSessions } = await import("./parser-cursor.js");
+    const sessions = await parseCursorSessions();
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("skips composers with no bubbles", async () => {
+    const composerMeta = JSON.stringify({ composerId: "comp-empty", name: "Empty" });
+    mockExecSync
+      .mockReturnValueOnce(`composerData:comp-empty\x1f${composerMeta}\n` as unknown as Buffer)
+      .mockReturnValueOnce("" as unknown as Buffer);
+
+    const { parseCursorSessions } = await import("./parser-cursor.js");
+    const sessions = await parseCursorSessions();
+    expect(sessions).toHaveLength(0);
+  });
+
+  it("returns empty array when sqlite3 is not available", async () => {
+    const composerMeta = JSON.stringify({ composerId: "comp-1", name: "Test" });
+    mockExecSync
+      .mockReturnValueOnce(`composerData:comp-1\x1f${composerMeta}\n` as unknown as Buffer)
+      .mockImplementationOnce(() => { throw new Error("sqlite3: command not found"); });
+
+    const { parseCursorSessions } = await import("./parser-cursor.js");
+    const sessions = await parseCursorSessions();
+    expect(sessions).toHaveLength(0);
+  });
+});

--- a/src/core/parser-cursor.ts
+++ b/src/core/parser-cursor.ts
@@ -1,0 +1,211 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+import { Session, Message } from "./session.js";
+import { assertTrustedPath } from "./parser-shared.js";
+
+/** Roots where Cursor stores workspace SQLite databases */
+function getCursorStorageRoots(): string[] {
+  const roots: string[] = [];
+  const platform = process.platform;
+
+  if (platform === "win32") {
+    const appData = process.env.APPDATA;
+    if (appData) roots.push(path.join(appData, "Cursor", "User", "workspaceStorage"));
+  } else if (platform === "darwin") {
+    const home = process.env.HOME ?? "";
+    roots.push(path.join(home, "Library", "Application Support", "Cursor", "User", "workspaceStorage"));
+  } else {
+    // Linux + WSL
+    const home = process.env.HOME ?? "";
+    roots.push(path.join(home, ".config", "Cursor", "User", "workspaceStorage"));
+    // WSL path to Windows Cursor data
+    const wslUser = process.env.USER ?? "";
+    roots.push(`/mnt/c/Users/${wslUser}/AppData/Roaming/Cursor/User/workspaceStorage`);
+  }
+
+  return roots.filter((r) => {
+    try { return fs.statSync(r).isDirectory(); } catch { return false; }
+  });
+}
+
+/** Find all Cursor workspace SQLite databases */
+function findCursorDatabases(): string[] {
+  const dbs: string[] = [];
+  for (const root of getCursorStorageRoots()) {
+    try {
+      const entries = fs.readdirSync(root);
+      for (const hash of entries) {
+        const dbPath = path.join(root, hash, "state.vscdb");
+        if (fs.existsSync(dbPath)) dbs.push(dbPath);
+      }
+    } catch { /* skip unreadable dirs */ }
+  }
+  return dbs;
+}
+
+/** Run a sqlite3 query and return rows split by unit-separator \x1f */
+function querySqlite(dbPath: string, sql: string): string[] {
+  try {
+    const raw = execSync(`sqlite3 -separator $'\\x1f' "${dbPath}" "${sql}"`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    return raw.trim().split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+interface ComposerMeta {
+  composerId: string;
+  name?: string;
+  createdAt?: number;
+  lastUpdatedAt?: number;
+  model?: string;
+}
+
+interface Bubble {
+  bubbleId: string;
+  type: "user" | "assistant" | string;
+  text?: string;
+  codeBlocks?: { content: string; language?: string }[];
+  timingMs?: number;
+}
+
+function parseComposerData(raw: string): ComposerMeta | null {
+  try {
+    const data = JSON.parse(raw);
+    return {
+      composerId: data.composerId ?? "",
+      name: data.name,
+      createdAt: data.createdAt,
+      lastUpdatedAt: data.lastUpdatedAt,
+      model: data.selectedModel ?? data.model,
+    };
+  } catch { return null; }
+}
+
+function parseBubble(raw: string): Bubble | null {
+  try {
+    const data = JSON.parse(raw);
+    const codeBlocks = (data.codeBlocks ?? []).map((b: { content?: string; language?: string }) => ({
+      content: b.content ?? "",
+      language: b.language,
+    }));
+    return {
+      bubbleId: data.bubbleId ?? "",
+      type: data.type === 1 ? "user" : "assistant",
+      text: data.text ?? data.rawText ?? "",
+      codeBlocks,
+      timingMs: data.timingMs,
+    };
+  } catch { return null; }
+}
+
+function countLinesOfCode(bubbles: Bubble[]): number {
+  let loc = 0;
+  for (const b of bubbles) {
+    if (b.type === "assistant") {
+      for (const block of b.codeBlocks ?? []) {
+        loc += block.content.split("\n").length;
+      }
+    }
+  }
+  return loc;
+}
+
+/** Parse a single Cursor workspace database into Sessions */
+function parseCursorDb(dbPath: string): Session[] {
+  assertTrustedPath(dbPath);
+
+  // Get all composer sessions
+  const composerRows = querySqlite(
+    dbPath,
+    "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
+  );
+
+  const sessions: Session[] = [];
+
+  for (const row of composerRows) {
+    const sep = row.indexOf("\x1f");
+    if (sep === -1) continue;
+    const value = row.slice(sep + 1);
+    const meta = parseComposerData(value);
+    if (!meta?.composerId) continue;
+
+    // Get all bubbles for this composer
+    const bubbleRows = querySqlite(
+      dbPath,
+      `SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:${meta.composerId}:%'`
+    );
+
+    const bubbles: Bubble[] = [];
+    for (const bRow of bubbleRows) {
+      const bSep = bRow.indexOf("\x1f");
+      if (bSep === -1) continue;
+      const bValue = bRow.slice(bSep + 1);
+      const bubble = parseBubble(bValue);
+      if (bubble) bubbles.push(bubble);
+    }
+
+    if (bubbles.length === 0) continue;
+
+    // Build message pairs
+    const messages: Message[] = [];
+    let i = 0;
+    while (i < bubbles.length) {
+      const current = bubbles[i];
+      if (current.type === "user") {
+        const next = bubbles[i + 1];
+        messages.push({
+          prompt: current.text ?? "",
+          response: next?.type === "assistant" ? (next.text ?? "") : "",
+          durationMs: next?.timingMs,
+          model: meta.model,
+        });
+        i += next?.type === "assistant" ? 2 : 1;
+      } else {
+        i++;
+      }
+    }
+
+    if (messages.length === 0) continue;
+
+    const linesOfCode = countLinesOfCode(bubbles);
+    const startedAt = meta.createdAt ? new Date(meta.createdAt) : undefined;
+    const endedAt = meta.lastUpdatedAt ? new Date(meta.lastUpdatedAt) : undefined;
+
+    sessions.push({
+      id: meta.composerId,
+      title: meta.name ?? meta.composerId,
+      source: "cursor",
+      model: meta.model ?? "unknown",
+      startedAt,
+      endedAt,
+      messages,
+      linesOfCode,
+      filePath: dbPath,
+    });
+  }
+
+  return sessions;
+}
+
+/** Entry point called by the harness registry */
+export async function parseCursorSessions(): Promise<Session[]> {
+  const dbs = findCursorDatabases();
+  const allSessions: Session[] = [];
+
+  for (const db of dbs) {
+    try {
+      const sessions = parseCursorDb(db);
+      allSessions.push(...sessions);
+    } catch (err) {
+      // skip unreadable databases
+      if (process.env.DEBUG) console.error(`Cursor: skipping ${db}:`, err);
+    }
+  }
+
+  return allSessions;
+}

--- a/src/core/parser-cursor.ts
+++ b/src/core/parser-cursor.ts
@@ -4,58 +4,64 @@ import { execSync } from "child_process";
 import { Session, Message } from "./session.js";
 import { assertTrustedPath } from "./parser-shared.js";
 
-/** Roots where Cursor stores workspace SQLite databases */
-function getCursorStorageRoots(): string[] {
-  const roots: string[] = [];
-  const platform = process.platform;
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
 
-  if (platform === "win32") {
-    const appData = process.env.APPDATA;
-    if (appData) roots.push(path.join(appData, "Cursor", "User", "workspaceStorage"));
-  } else if (platform === "darwin") {
-    const home = process.env.HOME ?? "";
-    roots.push(path.join(home, "Library", "Application Support", "Cursor", "User", "workspaceStorage"));
+/**
+ * Cursor stores ALL chat data in a single global SQLite database.
+ * Per-workspace `state.vscdb` files only contain UI state, not conversations.
+ */
+function getCursorGlobalDb(): string | null {
+  let base: string;
+
+  if (process.platform === "win32") {
+    base = process.env.APPDATA ?? "";
+    if (!base) return null;
+    return path.join(base, "Cursor", "User", "globalStorage", "state.vscdb");
+  } else if (process.platform === "darwin") {
+    base = process.env.HOME ?? "";
+    if (!base) return null;
+    return path.join(base, "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb");
   } else {
-    // Linux + WSL
-    const home = process.env.HOME ?? "";
-    roots.push(path.join(home, ".config", "Cursor", "User", "workspaceStorage"));
-    // WSL path to Windows Cursor data
+    // Linux / WSL
+    base = process.env.HOME ?? "";
+    const linuxPath = base ? path.join(base, ".config", "Cursor", "User", "globalStorage", "state.vscdb") : null;
+    if (linuxPath && fs.existsSync(linuxPath)) return linuxPath;
+    // WSL: try Windows path
     const wslUser = process.env.USER ?? "";
-    roots.push(`/mnt/c/Users/${wslUser}/AppData/Roaming/Cursor/User/workspaceStorage`);
+    if (wslUser) {
+      const wslPath = `/mnt/c/Users/${wslUser}/AppData/Roaming/Cursor/User/globalStorage/state.vscdb`;
+      if (fs.existsSync(wslPath)) return wslPath;
+    }
+    return linuxPath;
   }
-
-  return roots.filter((r) => {
-    try { return fs.statSync(r).isDirectory(); } catch { return false; }
-  });
 }
 
-/** Find all Cursor workspace SQLite databases */
-function findCursorDatabases(): string[] {
-  const dbs: string[] = [];
-  for (const root of getCursorStorageRoots()) {
-    try {
-      const entries = fs.readdirSync(root);
-      for (const hash of entries) {
-        const dbPath = path.join(root, hash, "state.vscdb");
-        if (fs.existsSync(dbPath)) dbs.push(dbPath);
-      }
-    } catch { /* skip unreadable dirs */ }
-  }
-  return dbs;
-}
+// ---------------------------------------------------------------------------
+// SQLite helpers
+// ---------------------------------------------------------------------------
 
-/** Run a sqlite3 query and return rows split by unit-separator \x1f */
-function querySqlite(dbPath: string, sql: string): string[] {
+function runSqlite(dbPath: string, sql: string): string {
   try {
-    const raw = execSync(`sqlite3 -separator $'\\x1f' "${dbPath}" "${sql}"`, {
+    return execSync(`sqlite3 "${dbPath}" ${JSON.stringify(sql)}`, {
       encoding: "utf8",
       stdio: ["pipe", "pipe", "ignore"],
-    });
-    return raw.trim().split("\n").filter(Boolean);
+      timeout: 30_000,
+    }).trim();
   } catch {
-    return [];
+    return "";
   }
 }
+
+function queryRows(dbPath: string, sql: string): string[] {
+  const raw = runSqlite(dbPath, sql);
+  return raw ? raw.split("\n").filter(Boolean) : [];
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
 
 interface ComposerMeta {
   composerId: string;
@@ -63,108 +69,150 @@ interface ComposerMeta {
   createdAt?: number;
   lastUpdatedAt?: number;
   model?: string;
+  totalLinesAdded?: number;
+  totalLinesRemoved?: number;
+  subtitle?: string;
 }
 
-interface Bubble {
-  bubbleId: string;
-  type: "user" | "assistant" | string;
+interface LexicalNode {
   text?: string;
-  codeBlocks?: { content: string; language?: string }[];
-  timingMs?: number;
+  children?: LexicalNode[];
 }
 
-function parseComposerData(raw: string): ComposerMeta | null {
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+function parseComposerMeta(value: string): ComposerMeta | null {
   try {
-    const data = JSON.parse(raw);
+    const d = JSON.parse(value);
+    if (!d.composerId) return null;
     return {
-      composerId: data.composerId ?? "",
-      name: data.name,
-      createdAt: data.createdAt,
-      lastUpdatedAt: data.lastUpdatedAt,
-      model: data.selectedModel ?? data.model,
+      composerId: d.composerId,
+      name: d.name || undefined,
+      createdAt: d.createdAt || undefined,
+      lastUpdatedAt: d.lastUpdatedAt || undefined,
+      model: d.modelConfig?.model || d.model || undefined,
+      totalLinesAdded: d.totalLinesAdded || 0,
+      totalLinesRemoved: d.totalLinesRemoved || 0,
+      subtitle: d.subtitle || undefined,
     };
-  } catch { return null; }
-}
-
-function parseBubble(raw: string): Bubble | null {
-  try {
-    const data = JSON.parse(raw);
-    const codeBlocks = (data.codeBlocks ?? []).map((b: { content?: string; language?: string }) => ({
-      content: b.content ?? "",
-      language: b.language,
-    }));
-    return {
-      bubbleId: data.bubbleId ?? "",
-      type: data.type === 1 ? "user" : "assistant",
-      text: data.text ?? data.rawText ?? "",
-      codeBlocks,
-      timingMs: data.timingMs,
-    };
-  } catch { return null; }
-}
-
-function countLinesOfCode(bubbles: Bubble[]): number {
-  let loc = 0;
-  for (const b of bubbles) {
-    if (b.type === "assistant") {
-      for (const block of b.codeBlocks ?? []) {
-        loc += block.content.split("\n").length;
-      }
-    }
+  } catch {
+    return null;
   }
-  return loc;
 }
 
-/** Parse a single Cursor workspace database into Sessions */
-function parseCursorDb(dbPath: string): Session[] {
+/** Extract plain text from a Lexical editor JSON tree */
+function extractLexicalText(nodeJson: string | undefined): string {
+  if (!nodeJson) return "";
+  try {
+    const root: LexicalNode = JSON.parse(nodeJson);
+    const collect = (node: LexicalNode): string => {
+      let t = node.text ?? "";
+      for (const child of node.children ?? []) t += collect(child);
+      return t;
+    };
+    return collect((root as { root?: LexicalNode }).root ?? root).trim();
+  } catch {
+    return "";
+  }
+}
+
+interface ParsedBubble {
+  type: 1 | 2;
+  text: string;
+  createdAt?: string;
+  linesAdded: number;
+}
+
+function parseBubble(value: string): ParsedBubble | null {
+  try {
+    const d = JSON.parse(value);
+    const type: 1 | 2 = d.type === 1 ? 1 : 2;
+
+    let text = "";
+    if (type === 1) {
+      // User bubble: extract from Lexical richText
+      text = extractLexicalText(d.richText) || d.text || "";
+    } else {
+      // Assistant bubble: full response text is not persisted; use thinking as proxy
+      text = d.thinking?.text || d.text || "";
+    }
+
+    // Count lines added from suggested diffs
+    let linesAdded = 0;
+    for (const diff of d.assistantSuggestedDiffs ?? []) {
+      const content: string = diff.newFileContent ?? diff.content ?? "";
+      if (content) linesAdded += content.split("\n").length;
+    }
+    for (const block of d.suggestedCodeBlocks ?? []) {
+      const content: string = block.content ?? "";
+      if (content) linesAdded += content.split("\n").length;
+    }
+
+    return { type, text, createdAt: d.createdAt, linesAdded };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main parser
+// ---------------------------------------------------------------------------
+
+export async function parseCursorSessions(): Promise<Session[]> {
+  const dbPath = getCursorGlobalDb();
+  if (!dbPath || !fs.existsSync(dbPath)) return [];
+
   assertTrustedPath(dbPath);
 
-  // Get all composer sessions
-  const composerRows = querySqlite(
+  // 1. Load all composer metadata in one query
+  const metaRows = queryRows(
     dbPath,
     "SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'"
   );
 
   const sessions: Session[] = [];
 
-  for (const row of composerRows) {
-    const sep = row.indexOf("\x1f");
-    if (sep === -1) continue;
-    const value = row.slice(sep + 1);
-    const meta = parseComposerData(value);
-    if (!meta?.composerId) continue;
+  for (const row of metaRows) {
+    // SQLite default column separator is |
+    const pipeIdx = row.indexOf("|");
+    if (pipeIdx === -1) continue;
+    const key = row.slice(0, pipeIdx);
+    const value = row.slice(pipeIdx + 1);
 
-    // Get all bubbles for this composer
-    const bubbleRows = querySqlite(
+    const meta = parseComposerMeta(value);
+    if (!meta) continue;
+
+    // 2. Load all bubbles for this composer
+    const bubbleRows = queryRows(
       dbPath,
-      `SELECT key, value FROM cursorDiskKV WHERE key LIKE 'bubbleId:${meta.composerId}:%'`
+      `SELECT value FROM cursorDiskKV WHERE key LIKE 'bubbleId:${meta.composerId}:%'`
     );
 
-    const bubbles: Bubble[] = [];
+    if (bubbleRows.length === 0) continue;
+
+    const bubbles: ParsedBubble[] = [];
     for (const bRow of bubbleRows) {
-      const bSep = bRow.indexOf("\x1f");
-      if (bSep === -1) continue;
-      const bValue = bRow.slice(bSep + 1);
-      const bubble = parseBubble(bValue);
-      if (bubble) bubbles.push(bubble);
+      const b = parseBubble(bRow);
+      if (b) bubbles.push(b);
     }
 
-    if (bubbles.length === 0) continue;
-
-    // Build message pairs
+    // 3. Pair user→assistant turns
     const messages: Message[] = [];
+    let linesOfCode = 0;
     let i = 0;
     while (i < bubbles.length) {
-      const current = bubbles[i];
-      if (current.type === "user") {
-        const next = bubbles[i + 1];
+      const cur = bubbles[i];
+      if (cur.type === 1) {
+        const next = i + 1 < bubbles.length && bubbles[i + 1].type === 2 ? bubbles[i + 1] : null;
         messages.push({
-          prompt: current.text ?? "",
-          response: next?.type === "assistant" ? (next.text ?? "") : "",
-          durationMs: next?.timingMs,
+          prompt: cur.text,
+          response: next?.text ?? "",
           model: meta.model,
         });
-        i += next?.type === "assistant" ? 2 : 1;
+        linesOfCode += next?.linesAdded ?? 0;
+        i += next ? 2 : 1;
       } else {
         i++;
       }
@@ -172,40 +220,23 @@ function parseCursorDb(dbPath: string): Session[] {
 
     if (messages.length === 0) continue;
 
-    const linesOfCode = countLinesOfCode(bubbles);
-    const startedAt = meta.createdAt ? new Date(meta.createdAt) : undefined;
-    const endedAt = meta.lastUpdatedAt ? new Date(meta.lastUpdatedAt) : undefined;
+    // Prefer session-level line counts if available
+    const totalLoc = (meta.totalLinesAdded ?? 0) > 0
+      ? meta.totalLinesAdded!
+      : linesOfCode;
 
     sessions.push({
       id: meta.composerId,
-      title: meta.name ?? meta.composerId,
+      title: meta.name || meta.subtitle || meta.composerId,
       source: "cursor",
       model: meta.model ?? "unknown",
-      startedAt,
-      endedAt,
+      startedAt: meta.createdAt ? new Date(meta.createdAt) : undefined,
+      endedAt: meta.lastUpdatedAt ? new Date(meta.lastUpdatedAt) : undefined,
       messages,
-      linesOfCode,
+      linesOfCode: totalLoc,
       filePath: dbPath,
     });
   }
 
   return sessions;
-}
-
-/** Entry point called by the harness registry */
-export async function parseCursorSessions(): Promise<Session[]> {
-  const dbs = findCursorDatabases();
-  const allSessions: Session[] = [];
-
-  for (const db of dbs) {
-    try {
-      const sessions = parseCursorDb(db);
-      allSessions.push(...sessions);
-    } catch (err) {
-      // skip unreadable databases
-      if (process.env.DEBUG) console.error(`Cursor: skipping ${db}:`, err);
-    }
-  }
-
-  return allSessions;
 }

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -10,6 +10,7 @@ import { Workspace, Session } from './types';
 import { findClaudeDirs, parseClaudeSessions, parseClaudeSessionsAsync } from './parser-claude';
 import { findCodexDirs, parseCodexSessions } from './parser-codex';
 import { findOpenCodeDirs, parseOpenCodeSessions } from './parser-opencode';
+import { parseCursorSessions } from './parser-cursor';
 
 type WorkspaceMap = Map<string, Workspace>;
 
@@ -69,6 +70,20 @@ const EXTERNAL_HARNESSES: ExternalHarnessCollector[] = [
       }
     },
   },
+  {
+    name: 'Cursor',
+    collectSync(_ctx) {
+      // Cursor sessions are async-only (sqlite3 CLI); collectAsync handles them.
+    },
+    async collectAsync(ctx, reportDetail) {
+      reportDetail?.('Scanning Cursor workspace databases...');
+      const sessions = await parseCursorSessions();
+      for (const session of sessions) {
+        addSession(ctx.workspaces, ctx.sessions, session, session.filePath ?? '');
+      }
+      reportDetail?.(`Found ${sessions.length} Cursor session(s)`);
+    },
+  },
 ];
 
 export interface ExternalHarnessProgressHandlers {
@@ -78,15 +93,10 @@ export interface ExternalHarnessProgressHandlers {
   yieldToLoop?: () => Promise<void>;
 }
 
-/** Returns true if any external-harness (Claude Code, Codex, OpenCode) session
+/** Returns true if any external-harness (Claude Code, Codex, OpenCode, Cursor) session
  *  source exists on disk. The dashboard uses this so it does not abort when the
- *  only available logs come from a non-VS Code harness — e.g. a headless
- *  Remote-SSH host that has Claude Code sessions under `~/.claude/projects` but
- *  no VS Code workspace storage or Copilot directories. */
+ *  only available logs come from a non-VS Code harness. */
 export function hasExternalHarnessSources(): boolean {
-  // Without a home directory the find* helpers would join against an empty
-  // string and probe relative paths (e.g. `.claude/projects`) under the current
-  // working directory, which could report false positives. Bail out instead.
   if (!process.env.HOME && !process.env.USERPROFILE) return false;
   return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
 }
@@ -98,14 +108,12 @@ export function collectExternalHarnessesSync(workspaces: WorkspaceMap, sessions:
   }
 }
 
-/** Harness values set on sessions by external harness collectors.
- *  The cache reconciliation in parser.ts uses this set to identify and
- *  refresh cached external-harness sessions, so every value the collectors
- *  can produce must be listed here. */
+/** Harness values set on sessions by external harness collectors. */
 export const EXTERNAL_HARNESS_SET = new Set<string>([
   'Claude',
   'Codex',
   'OpenCode',
+  'Cursor',
 ]);
 
 export async function collectExternalHarnessesAsync(

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -62,6 +62,18 @@ function getTrustedRoots(): string[] {
     roots.push(path.resolve(home, '.claude'));
     roots.push(path.resolve(home, '.codex'));
     roots.push(path.resolve(home, '.local', 'share', 'opencode'));
+    // Cursor IDE
+    if (process.platform === 'win32') {
+      const appdata = process.env.APPDATA || '';
+      if (appdata) roots.push(path.resolve(appdata, 'Cursor', 'User', 'workspaceStorage'));
+    } else if (process.platform === 'darwin') {
+      roots.push(path.resolve(home, 'Library', 'Application Support', 'Cursor', 'User', 'workspaceStorage'));
+    } else {
+      roots.push(path.resolve(home, '.config', 'Cursor', 'User', 'workspaceStorage'));
+      // WSL: Windows Cursor data
+      const wslUser = process.env.USER || '';
+      if (wslUser) roots.push(/mnt/c/Users//AppData/Roaming/Cursor/User/workspaceStorage);
+    }
     roots.push(path.resolve(home, '.config', 'github-copilot'));
   }
 

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -72,7 +72,7 @@ function getTrustedRoots(): string[] {
       roots.push(path.resolve(home, '.config', 'Cursor', 'User', 'workspaceStorage'));
       // WSL: Windows Cursor data
       const wslUser = process.env.USER || '';
-      if (wslUser) roots.push(/mnt/c/Users//AppData/Roaming/Cursor/User/workspaceStorage);
+      if (wslUser) roots.push('/mnt/c/Users/' + wslUser + '/AppData/Roaming/Cursor/User/workspaceStorage');
     }
     roots.push(path.resolve(home, '.config', 'github-copilot'));
   }


### PR DESCRIPTION
## Summary

Adds support for [Cursor IDE](https://www.cursor.com/) sessions to the AI Engineering Coach dashboard.

## What's changed

### New file: src/core/parser-cursor.ts
- Scans workspaceStorage/<hash>/state.vscdb SQLite databases in Cursor's user data directory
- Reads composerData:<id> keys for session metadata (name, model, timestamps)
- Reads ubbleId:<composerId>:<id> keys for individual messages
- Pairs user/assistant bubbles into Message objects with timing and model info
- Counts lines of code from assistant code blocks
- Supports **Windows**, **macOS**, **Linux**, and **WSL** paths automatically

### Modified: src/core/parser-harnesses.ts
- Imports parseCursorSessions from the new parser
- Registers a Cursor entry in EXTERNAL_HARNESSES (async collector)
- Adds 'Cursor' to EXTERNAL_HARNESS_SET

### Modified: src/core/parser-shared.ts
- Adds Cursor's workspaceStorage directories to the trusted-path roots in getTrustedRoots()

### New file: src/core/parser-cursor.test.ts
- Unit tests covering: normal parse, empty DB, no bubbles, missing sqlite3

## Known limitations (v2 scope)
- ditedFiles is always empty — Cursor stores file edits in the gentKv table under equestId keys, which requires a separate join not included in this initial PR
- Requires sqlite3 CLI to be installed on the host

## Platform support
| OS | Path |
|---|---|
| Windows | %APPDATA%\Cursor\User\workspaceStorage |
| macOS | ~/Library/Application Support/Cursor/User/workspaceStorage |
| Linux | ~/.config/Cursor/User/workspaceStorage |
| WSL | /mnt/c/Users/<user>/AppData/Roaming/Cursor/User/workspaceStorage |