### PR TITLE
feat: standalone CLI (aicoach) — all harnesses in one terminal report

### DIFF
--- a/esbuild-cli.mjs
+++ b/esbuild-cli.mjs
@@ -1,0 +1,21 @@
+import esbuild from 'esbuild';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Standalone CLI bundle (dist/cli.js). Kept separate from esbuild.mjs so the
+// extension build pipeline stays untouched.
+await esbuild.build({
+  entryPoints: [path.join(__dirname, 'src', 'cli.ts')],
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  outfile: path.join(__dirname, 'dist', 'cli.js'),
+  format: 'cjs',
+  sourcemap: false,
+  minify: false,
+});
+
+console.log('CLI build complete: dist/cli.js');

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "entry": [
     "src/extension.ts",
+    "src/cli.ts",
     "src/canvas/host.ts",
     "src/webview/app.ts",
     "src/core/warm-up-worker.ts",

--- a/package.json
+++ b/package.json
@@ -290,9 +290,15 @@
       }
     ]
   },
+  "bin": {
+    "aicoach": "./dist/cli.js",
+    "ai-engineer-coach": "./dist/cli.js"
+  },
   "scripts": {
     "vscode:prepublish": "npm run build",
     "build": "node esbuild.mjs",
+    "build:cli": "node esbuild-cli.mjs",
+    "cli": "node dist/cli.js",
     "watch": "node esbuild.mjs --watch",
     "lint": "eslint src/",
     "bench": "vitest bench",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Standalone CLI for AI Engineer Coach.
+ *
+ * Runs the same parsing/analysis pipeline as the VS Code extension against
+ * every supported harness (VS Code/Copilot, Claude Code, Codex, OpenCode)
+ * and renders reports to the terminal or to md/json/html files — no editor
+ * required. Build with `npm run build:cli`; entry point is `dist/cli.js`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { Analyzer } from './core/analyzer';
+import { findLogsDirs, parseAllLogsViaWorker } from './core/parser';
+import { loadAllRuleLayersAsync, loadAllMetricLayers } from './core/rule-loader';
+import { TrustGate } from './core/rule-trust';
+
+import {
+  buildSummaryExportFromAnalyzer,
+  renderSummaryJson,
+  renderSummaryMarkdown,
+  getSummaryExportFilenames,
+} from './core/summary-export';
+
+import {
+  formatSummary,
+  formatActivity,
+  formatCredits,
+  formatCodeProduction,
+  formatFlow,
+  formatPatterns,
+  formatInsights,
+  formatWellbeing,
+  formatWorkflows,
+  formatHarnessComparison,
+  formatSessions,
+  formatContextHealth,
+} from './mcp/formatters';
+
+import {
+  CliOptions,
+  HELP_TEXT,
+  ReportFormat,
+  getBool,
+  getFilter,
+  getNumber,
+  getString,
+  normalizeReportFormats,
+  parseArgs,
+} from './cli/args';
+import { ReportPayload, buildReportPayload, extractSection } from './cli/report-payload';
+import { renderAntiPatternsMarkdown, renderContextHealthMarkdown, renderProductMarkdown } from './cli/render-markdown';
+import { markdownToHtml } from './cli/render-html';
+import { renderTerminalDashboard, stripAnsi } from './cli/render-terminal';
+
+function normalizeLogsDirs(opts: CliOptions): string[] {
+  const explicit = opts['logs-dir'];
+
+  if (Array.isArray(explicit) && explicit.length > 0) {
+    return explicit.map(p => path.resolve(p));
+  }
+
+  return findLogsDirs();
+}
+
+function buildBlockingTrustGate(blockedLocalFiles: string[]): TrustGate {
+  return {
+    isAllowed() {
+      return false;
+    },
+    onBlocked(entry) {
+      blockedLocalFiles.push(entry.filePath);
+    },
+  };
+}
+
+async function createAnalyzer(opts: CliOptions): Promise<Analyzer> {
+  const logsDirs = normalizeLogsDirs(opts);
+
+  if (logsDirs.length === 0) {
+    throw new Error('No log directories found. Run `aicoach dirs` or pass --logs-dir <path>.');
+  }
+
+  const projectRoot = path.resolve(getString(opts, 'project-root') ?? process.cwd());
+  const showProgress = getBool(opts, 'verbose') && !getBool(opts, 'quiet');
+  const blockedLocalFiles: string[] = [];
+
+  // Local rules/metrics execute arbitrary logic, so they stay blocked unless
+  // the user explicitly opts in — the CLI has no interactive approval UI.
+  const trustGate = getBool(opts, 'allow-local-rules') ? undefined : buildBlockingTrustGate(blockedLocalFiles);
+
+  await loadAllRuleLayersAsync(projectRoot, trustGate);
+  loadAllMetricLayers(projectRoot, trustGate);
+
+  if (blockedLocalFiles.length > 0 && !getBool(opts, 'quiet')) {
+    console.error(`Local rules/metrics blocked for safety: ${blockedLocalFiles.length}`);
+    console.error('Pass --allow-local-rules if you trust these files.');
+  }
+
+  const parsed = await parseAllLogsViaWorker(logsDirs, progress => {
+    if (!showProgress) return;
+
+    const pct = String(progress.pct).padStart(3, ' ');
+    const detail = progress.detail ? ` ${progress.detail}` : '';
+    process.stderr.write(`\r${pct}%${detail}`);
+  });
+
+  if (showProgress) {
+    process.stderr.write('\n');
+  }
+
+  const analyzer = new Analyzer(parsed.sessions, parsed.editLocIndex, parsed.workspaces);
+
+  if (!getBool(opts, 'no-warmup')) {
+    await analyzer.warmUp((_phase: number, detail: string, pct: number) => {
+      if (!showProgress) return;
+      process.stderr.write(`\r${pct}% ${detail}`);
+    });
+
+    if (showProgress) {
+      process.stderr.write('\n');
+    }
+  }
+
+  return analyzer;
+}
+
+function writeOrPrint(content: string, outputPath?: string): void {
+  const normalized = content.endsWith('\n') ? content : `${content}\n`;
+
+  if (!outputPath) {
+    process.stdout.write(normalized);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, normalized, 'utf8');
+  console.log(outputPath);
+}
+
+function writeReport(payload: ReportPayload, opts: CliOptions): void {
+  const formats = normalizeReportFormats(getString(opts, 'format'));
+  const outDir = getString(opts, 'out');
+
+  const terminal = outDir ? stripAnsi(renderTerminalDashboard(payload)) : renderTerminalDashboard(payload);
+  const markdown = renderProductMarkdown(payload);
+
+  const contentByFormat: Record<ReportFormat, string> = {
+    terminal,
+    md: markdown,
+    json: JSON.stringify(payload, null, 2),
+    html: markdownToHtml(markdown),
+  };
+
+  if (!outDir && formats.length === 1) {
+    writeOrPrint(contentByFormat[formats[0]]);
+    return;
+  }
+
+  const targetDir = path.resolve(outDir ?? './reports');
+  const extByFormat: Record<ReportFormat, string> = { terminal: 'txt', md: 'md', json: 'json', html: 'html' };
+
+  for (const format of formats) {
+    writeOrPrint(contentByFormat[format], path.join(targetDir, `aicoach-report.${extByFormat[format]}`));
+  }
+}
+
+function commandDirs(opts: CliOptions): void {
+  console.log(JSON.stringify({ logsDirs: normalizeLogsDirs(opts) }, null, 2));
+}
+
+async function commandSummary(opts: CliOptions): Promise<void> {
+  const analyzer = await createAnalyzer(opts);
+  const report = buildSummaryExportFromAnalyzer(analyzer, getFilter(opts));
+
+  const format = getString(opts, 'format') ?? 'md';
+  const outDir = getString(opts, 'out');
+
+  if (outDir) {
+    const filenames = getSummaryExportFilenames(report.generatedAt);
+    const absOut = path.resolve(outDir);
+
+    if (format === 'json' || format === 'both') {
+      writeOrPrint(renderSummaryJson(report), path.join(absOut, filenames.json));
+    }
+
+    if (format === 'md' || format === 'both') {
+      writeOrPrint(renderSummaryMarkdown(report), path.join(absOut, filenames.markdown));
+    }
+
+    return;
+  }
+
+  writeOrPrint(format === 'json' ? renderSummaryJson(report) : renderSummaryMarkdown(report));
+}
+
+async function commandReport(opts: CliOptions): Promise<void> {
+  const analyzer = await createAnalyzer(opts);
+  const filter = getFilter(opts);
+  const top = getNumber(opts, 'top') ?? 8;
+
+  const summaryExport = buildSummaryExportFromAnalyzer(analyzer, filter);
+  const baseMarkdown = renderSummaryMarkdown(summaryExport);
+  const patternsData = formatPatterns(analyzer, filter);
+  const contextData = formatContextHealth(analyzer, filter);
+
+  writeReport(buildReportPayload(baseMarkdown, patternsData, contextData, top), opts);
+}
+
+async function commandJson(opts: CliOptions): Promise<void> {
+  const kind = opts._[1] ?? 'summary';
+  const analyzer = await createAnalyzer(opts);
+  const filter = getFilter(opts);
+
+  const map: Record<string, unknown> = {
+    summary: formatSummary(analyzer, filter),
+    activity: formatActivity(analyzer, filter),
+    credits: formatCredits(analyzer, filter),
+    production: formatCodeProduction(analyzer, filter),
+    flow: formatFlow(analyzer, filter),
+    patterns: formatPatterns(analyzer, filter),
+    insights: formatInsights(analyzer, filter),
+    wellbeing: formatWellbeing(analyzer, filter),
+    workflows: formatWorkflows(analyzer, filter),
+    compare: formatHarnessComparison(analyzer, filter),
+    context: formatContextHealth(analyzer, filter),
+  };
+
+  if (!(kind in map)) {
+    throw new Error(`Invalid json kind: ${kind}`);
+  }
+
+  console.log(JSON.stringify(map[kind], null, 2));
+}
+
+async function commandSessions(opts: CliOptions): Promise<void> {
+  const analyzer = await createAnalyzer(opts);
+
+  const data = formatSessions(
+    analyzer,
+    {
+      page: getNumber(opts, 'page') ?? 1,
+      pageSize: getNumber(opts, 'page-size') ?? 20,
+      search: getString(opts, 'search'),
+    },
+    getFilter(opts),
+  );
+
+  console.log(JSON.stringify(data, null, 2));
+}
+
+async function commandSession(opts: CliOptions): Promise<void> {
+  const sessionId = getString(opts, 'session-id');
+
+  if (!sessionId) {
+    throw new Error('Usage: aicoach session --session-id <id>');
+  }
+
+  const analyzer = await createAnalyzer(opts);
+  const data = formatSessions(analyzer, { sessionId }, getFilter(opts));
+
+  console.log(JSON.stringify(data, null, 2));
+}
+
+async function commandObserve(opts: CliOptions): Promise<void> {
+  const subcommand = opts._[1] ?? 'summary';
+
+  if (subcommand !== 'summary') {
+    throw new Error(`Invalid observe subcommand: ${subcommand}`);
+  }
+
+  opts.format = getString(opts, 'format') ?? 'md';
+  return commandReport(opts);
+}
+
+async function commandMeasure(opts: CliOptions): Promise<void> {
+  const subcommand = opts._[1] ?? 'output';
+
+  if (subcommand !== 'output') {
+    throw new Error(`Invalid measure subcommand: ${subcommand}`);
+  }
+
+  const analyzer = await createAnalyzer(opts);
+  const report = buildSummaryExportFromAnalyzer(analyzer, getFilter(opts));
+  const markdown = renderSummaryMarkdown(report);
+
+  const totals = extractSection(markdown, '## Totals');
+  const topLanguages = extractSection(markdown, '## Top Languages');
+
+  console.log('# Code Output\n');
+  console.log(totals || 'No totals found.');
+  console.log('');
+  console.log(topLanguages || 'No language output found.');
+}
+
+async function commandImprove(opts: CliOptions): Promise<void> {
+  const subcommand = opts._[1] ?? 'anti-patterns';
+  const analyzer = await createAnalyzer(opts);
+  const filter = getFilter(opts);
+  const top = getNumber(opts, 'top') ?? 8;
+
+  if (subcommand === 'anti-patterns' || subcommand === 'patterns') {
+    console.log(renderAntiPatternsMarkdown(formatPatterns(analyzer, filter), top));
+    return;
+  }
+
+  if (subcommand === 'context-health' || subcommand === 'context') {
+    console.log(renderContextHealthMarkdown(formatContextHealth(analyzer, filter)));
+    return;
+  }
+
+  throw new Error(`Invalid improve subcommand: ${subcommand}`);
+}
+
+function routeDiagnosticsToStderr(quiet: boolean): void {
+  // Core helpers (infoCore/debugCore) log via console.info/console.debug,
+  // which write to stdout. The CLI reserves stdout for command output so it
+  // stays pipeable; diagnostics go to stderr (or are dropped with --quiet).
+  const sink = quiet ? () => undefined : (...args: unknown[]) => console.error(...args);
+  console.info = sink;
+  console.debug = sink;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const command = opts._[0] ?? 'help';
+
+  routeDiagnosticsToStderr(getBool(opts, 'quiet'));
+
+  if (command === 'help' || getBool(opts, 'help')) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (command === 'dirs') return commandDirs(opts);
+  if (command === 'summary') return commandSummary(opts);
+  if (command === 'report') return commandReport(opts);
+  if (command === 'json') return commandJson(opts);
+  if (command === 'sessions') return commandSessions(opts);
+  if (command === 'session') return commandSession(opts);
+  if (command === 'observe') return commandObserve(opts);
+  if (command === 'measure') return commandMeasure(opts);
+  if (command === 'improve') return commandImprove(opts);
+
+  throw new Error(`Invalid command: ${command}. Run \`aicoach help\`.`);
+}
+
+main().catch((error: unknown) => {
+  console.error('');
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* CLI argument parsing and shared option helpers. */
+
+import { DateFilter } from '../core/types';
+
+export type CliOptions = Record<string, string | boolean | string[]> & {
+  _: string[];
+};
+
+export type ReportFormat = 'terminal' | 'md' | 'json' | 'html';
+
+export function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { _: [] };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (!arg.startsWith('--')) {
+      opts._.push(arg);
+      continue;
+    }
+
+    const eq = arg.indexOf('=');
+    const key = eq >= 0 ? arg.slice(2, eq) : arg.slice(2);
+    const inlineValue = eq >= 0 ? arg.slice(eq + 1) : undefined;
+
+    let value: string | boolean = true;
+
+    if (inlineValue !== undefined) {
+      value = inlineValue;
+    } else if (argv[i + 1] && !argv[i + 1].startsWith('--')) {
+      value = argv[i + 1];
+      i++;
+    }
+
+    // --logs-dir may repeat; collect every occurrence.
+    if (key === 'logs-dir') {
+      const current = opts[key];
+      opts[key] = Array.isArray(current) ? [...current, String(value)] : [String(value)];
+    } else {
+      opts[key] = value;
+    }
+  }
+
+  return opts;
+}
+
+export function getString(opts: CliOptions, key: string): string | undefined {
+  const value = opts[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function getBool(opts: CliOptions, key: string): boolean {
+  return opts[key] === true || opts[key] === 'true';
+}
+
+export function getNumber(opts: CliOptions, key: string): number | undefined {
+  const value = getString(opts, key);
+  if (!value) return undefined;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function getFilter(opts: CliOptions): DateFilter | undefined {
+  const filter: DateFilter = {};
+
+  const fromDate = getString(opts, 'from');
+  const toDate = getString(opts, 'to');
+  const workspaceId = getString(opts, 'workspace');
+  const harness = getString(opts, 'harness');
+
+  if (fromDate) filter.fromDate = fromDate;
+  if (toDate) filter.toDate = toDate;
+  if (workspaceId) filter.workspaceId = workspaceId;
+  if (harness) filter.harness = harness;
+
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
+export function normalizeReportFormats(format: string | undefined): ReportFormat[] {
+  if (!format || format === 'terminal') return ['terminal'];
+  if (format === 'md') return ['md'];
+  if (format === 'json') return ['json'];
+  if (format === 'html') return ['html'];
+  if (format === 'both') return ['md', 'json'];
+  if (format === 'all') return ['terminal', 'md', 'json', 'html'];
+
+  throw new Error(`Invalid format: ${format}`);
+}
+
+export const HELP_TEXT = `
+AI Engineer Coach CLI
+
+Main usage:
+  aicoach report [--format terminal|md|json|html|both|all] [--out ./reports]
+  aicoach dirs
+
+Product areas:
+  aicoach observe summary
+  aicoach measure output
+  aicoach improve anti-patterns [--top 5]
+  aicoach improve context-health
+
+Technical commands:
+  aicoach summary [--format md|json|both] [--out ./reports]
+  aicoach json <summary|activity|patterns|flow|insights|workflows|context|production|credits|wellbeing|compare>
+  aicoach sessions [--page 1] [--page-size 20] [--search term]
+  aicoach session --session-id <id>
+
+Filters:
+  --from YYYY-MM-DD
+  --to YYYY-MM-DD
+  --workspace <id-or-name>
+  --harness <name>            e.g. Claude, Codex, OpenCode, "VS Code"
+
+Options:
+  --logs-dir <path>        May repeat
+  --project-root <path>    Default: current directory
+  --out <dir>              Write report files to a directory
+  --format terminal|md|json|html|both|all
+  --top <n>                Number of items in rankings
+  --allow-local-rules      Admit local rules/metrics files
+  --no-warmup              Skip the analyzer warm-up
+  --quiet                  Reduce stderr logging
+  --verbose                Show parsing/warm-up progress
+
+Examples:
+  aicoach report
+  aicoach report --format all --out ./reports
+  aicoach improve anti-patterns --top 5
+  aicoach measure output --from 2026-06-01
+  aicoach sessions --harness OpenCode
+`;

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Tests for the CLI helpers: argument parsing, payload extraction, and renderers. */
+
+import { describe, it, expect } from 'vitest';
+import { getFilter, normalizeReportFormats, parseArgs } from './args';
+import { buildNextActions, extractBulletMap, extractBullets, extractSection } from './report-payload';
+import { escapeHtml, markdownToHtml } from './render-html';
+import { stripAnsi } from './render-terminal';
+
+describe('parseArgs', () => {
+  it('collects positionals, boolean flags, and space/equals values', () => {
+    const opts = parseArgs(['report', '--quiet', '--format', 'md', '--top=5']);
+
+    expect(opts._).toEqual(['report']);
+    expect(opts['quiet']).toBe(true);
+    expect(opts['format']).toBe('md');
+    expect(opts['top']).toBe('5');
+  });
+
+  it('accumulates repeated --logs-dir flags into an array', () => {
+    const opts = parseArgs(['dirs', '--logs-dir', '/a', '--logs-dir=/b']);
+
+    expect(opts['logs-dir']).toEqual(['/a', '/b']);
+  });
+});
+
+describe('getFilter', () => {
+  it('returns undefined when no filter flags are present', () => {
+    expect(getFilter(parseArgs(['report']))).toBeUndefined();
+  });
+
+  it('maps from/to/workspace/harness flags onto a DateFilter', () => {
+    const filter = getFilter(parseArgs(['report', '--from', '2026-06-01', '--harness', 'OpenCode']));
+
+    expect(filter).toEqual({ fromDate: '2026-06-01', harness: 'OpenCode' });
+  });
+});
+
+describe('normalizeReportFormats', () => {
+  it('defaults to terminal and expands both/all aliases', () => {
+    expect(normalizeReportFormats(undefined)).toEqual(['terminal']);
+    expect(normalizeReportFormats('both')).toEqual(['md', 'json']);
+    expect(normalizeReportFormats('all')).toEqual(['terminal', 'md', 'json', 'html']);
+  });
+
+  it('rejects unknown formats', () => {
+    expect(() => normalizeReportFormats('pdf')).toThrow(/Invalid format/);
+  });
+});
+
+const SAMPLE_MARKDOWN = [
+  '## Totals',
+  '- Sessions: 10',
+  '- Requests: 42',
+  '',
+  '## Top Languages',
+  '- typescript: 100 AI LoC',
+  '- python: 50 AI LoC',
+  '',
+  '## Flow',
+  '- Overall flow score: 61',
+].join('\n');
+
+describe('markdown extraction helpers', () => {
+  it('extracts a section up to the next heading', () => {
+    const section = extractSection(SAMPLE_MARKDOWN, '## Totals');
+
+    expect(section).toContain('- Sessions: 10');
+    expect(section).not.toContain('typescript');
+  });
+
+  it('returns an empty string for a missing section', () => {
+    expect(extractSection(SAMPLE_MARKDOWN, '## Missing')).toBe('');
+  });
+
+  it('parses bullet maps and bullet lists', () => {
+    expect(extractBulletMap(SAMPLE_MARKDOWN, '## Totals')).toEqual({ Sessions: '10', Requests: '42' });
+    expect(extractBullets(SAMPLE_MARKDOWN, '## Top Languages')).toEqual([
+      'typescript: 100 AI LoC',
+      'python: 50 AI LoC',
+    ]);
+  });
+});
+
+describe('buildNextActions', () => {
+  it('prioritizes the first high-severity suggestion and deduplicates', () => {
+    const actions = buildNextActions({
+      topAntiPatterns: [
+        { name: 'A', severity: 'medium', group: 'g', occurrences: 5, suggestion: 'Medium tip' },
+        { name: 'B', severity: 'high', group: 'g', occurrences: 3, suggestion: 'High tip' },
+      ],
+      contextHealth: {
+        missingSignals: [{ label: 'Hooks', detail: 'No hooks configured' }],
+        workspaceSummary: [{ workspace: 'w', suggestions: ['High tip'] }],
+      },
+    });
+
+    expect(actions[0]).toBe('High tip');
+    expect(actions).toContain('Fix: Hooks. No hooks configured');
+    expect(actions.filter(a => a === 'High tip')).toHaveLength(1);
+  });
+});
+
+describe('markdownToHtml', () => {
+  it('escapes HTML in every rendered construct', () => {
+    const html = markdownToHtml('# <script>\n- "quoted" & <b>\n1. it\'s');
+
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&quot;quoted&quot; &amp; &lt;b&gt;');
+    expect(html).toContain('it&#39;s');
+  });
+
+  it('renders headings, lists, and ordered lists', () => {
+    const html = markdownToHtml('## Section\n- item\n\n1. first');
+
+    expect(html).toContain('<h2>Section</h2>');
+    expect(html).toContain('<ul>\n<li>item</li>\n</ul>');
+    expect(html).toContain('<ol>\n<li>first</li>\n</ol>');
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes all five sensitive characters', () => {
+    expect(escapeHtml(`&<>"'`)).toBe('&amp;&lt;&gt;&quot;&#39;');
+  });
+});
+
+describe('stripAnsi', () => {
+  it('removes color codes but keeps text', () => {
+    expect(stripAnsi('\x1b[31mred\x1b[0m plain')).toBe('red plain');
+  });
+});

--- a/src/cli/render-html.ts
+++ b/src/cli/render-html.ts
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Minimal markdown-to-HTML renderer for the self-contained CLI report page. */
+
+export function escapeHtml(input: string): string {
+  return input
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+const PAGE_STYLE = `
+  :root {
+    color-scheme: light dark;
+    --bg: #0f172a;
+    --card: #111827;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --border: #374151;
+    --accent: #60a5fa;
+  }
+
+  body {
+    margin: 0;
+    padding: 40px;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+  }
+
+  main {
+    max-width: 980px;
+    margin: 0 auto;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 20px;
+    padding: 32px;
+    box-shadow: 0 24px 80px rgba(0,0,0,.25);
+  }
+
+  h1 {
+    font-size: 38px;
+    letter-spacing: -0.04em;
+    margin: 0 0 16px;
+  }
+
+  h2 {
+    margin-top: 36px;
+    padding-top: 24px;
+    border-top: 1px solid var(--border);
+    font-size: 24px;
+  }
+
+  h3 {
+    margin-top: 24px;
+    color: var(--accent);
+  }
+
+  p {
+    color: var(--muted);
+  }
+
+  li {
+    margin: 6px 0;
+  }
+
+  ol, ul {
+    padding-left: 24px;
+  }
+`;
+
+interface ListState {
+  inList: boolean;
+  inOrderedList: boolean;
+}
+
+function closeLists(state: ListState, body: string[]): void {
+  if (state.inList) {
+    body.push('</ul>');
+    state.inList = false;
+  }
+
+  if (state.inOrderedList) {
+    body.push('</ol>');
+    state.inOrderedList = false;
+  }
+}
+
+function renderLine(line: string, state: ListState, body: string[]): void {
+  if (line.startsWith('### ')) {
+    closeLists(state, body);
+    body.push(`<h3>${escapeHtml(line.slice(4))}</h3>`);
+    return;
+  }
+
+  if (line.startsWith('## ')) {
+    closeLists(state, body);
+    body.push(`<h2>${escapeHtml(line.slice(3))}</h2>`);
+    return;
+  }
+
+  if (line.startsWith('# ')) {
+    closeLists(state, body);
+    body.push(`<h1>${escapeHtml(line.slice(2))}</h1>`);
+    return;
+  }
+
+  if (line.startsWith('- ')) {
+    if (!state.inList) {
+      closeLists(state, body);
+      body.push('<ul>');
+      state.inList = true;
+    }
+
+    body.push(`<li>${escapeHtml(line.slice(2))}</li>`);
+    return;
+  }
+
+  if (/^\d+\.\s+/.test(line)) {
+    if (!state.inOrderedList) {
+      closeLists(state, body);
+      body.push('<ol>');
+      state.inOrderedList = true;
+    }
+
+    body.push(`<li>${escapeHtml(line.replace(/^\d+\.\s+/, ''))}</li>`);
+    return;
+  }
+
+  closeLists(state, body);
+  body.push(`<p>${escapeHtml(line)}</p>`);
+}
+
+export function markdownToHtml(markdown: string): string {
+  const body: string[] = [];
+  const state: ListState = { inList: false, inOrderedList: false };
+
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.trimEnd();
+
+    if (!line.trim()) {
+      closeLists(state, body);
+      continue;
+    }
+
+    renderLine(line, state, body);
+  }
+
+  closeLists(state, body);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AI Engineer Coach Report</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>${PAGE_STYLE}</style>
+</head>
+<body>
+<main>
+${body.join('\n')}
+</main>
+</body>
+</html>
+`;
+}

--- a/src/cli/render-markdown.ts
+++ b/src/cli/render-markdown.ts
@@ -1,0 +1,224 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Markdown renderers for the CLI report and the improve subcommands. */
+
+import { ContextHealthData, PatternsData, ReportAntiPattern, ReportPayload } from './report-payload';
+
+function renderExecutiveSummary(payload: ReportPayload): string[] {
+  return [
+    '## Executive Summary',
+    '',
+    `- Sessions: ${payload.totals['Sessions'] ?? 'n/a'}`,
+    `- Requests: ${payload.totals['Requests'] ?? 'n/a'}`,
+    `- Workspaces: ${payload.totals['Workspaces'] ?? 'n/a'}`,
+    `- AI-generated LoC: ${payload.totals['AI-generated LoC'] ?? 'n/a'}`,
+    `- Flow score: ${payload.flow['Overall flow score'] ?? 'n/a'}`,
+    `- Context health: ${payload.contextHealth.overallScore ?? 'n/a'}`,
+    `- Agentic readiness: ${payload.contextHealth.agenticReadinessScore ?? 'n/a'}`,
+    '',
+  ];
+}
+
+function renderTopLanguages(payload: ReportPayload): string[] {
+  const lines = ['## Top Languages', ''];
+
+  if (payload.topLanguages.length === 0) {
+    lines.push('- No language data found.');
+  } else {
+    for (const item of payload.topLanguages) lines.push(`- ${item}`);
+  }
+
+  lines.push('');
+  return lines;
+}
+
+function renderAntiPatternItems(patterns: ReportAntiPattern[]): string[] {
+  const lines: string[] = [];
+
+  for (const [index, item] of patterns.entries()) {
+    lines.push(`${index + 1}. ${item.name} (${item.severity}, ${item.occurrences} occurrences)`);
+    lines.push(`   - Group: ${item.group}`);
+    lines.push(`   - Action: ${item.suggestion}`);
+    if (item.trend) lines.push(`   - Trend: ${item.trend}`);
+  }
+
+  return lines;
+}
+
+function renderTopAntiPatterns(payload: ReportPayload): string[] {
+  const lines = ['## Top Anti-Patterns', ''];
+
+  if (payload.topAntiPatterns.length === 0) {
+    lines.push('- No anti-patterns found.');
+  } else {
+    lines.push(...renderAntiPatternItems(payload.topAntiPatterns));
+  }
+
+  lines.push('');
+  return lines;
+}
+
+function renderGroupScores(payload: ReportPayload): string[] {
+  const lines = ['## Group Scores', ''];
+
+  if (payload.groupScores.length === 0) {
+    lines.push('- No group scores found.');
+  } else {
+    for (const item of payload.groupScores) {
+      lines.push(`- ${item.group}: ${item.score}/100`);
+      if (item.topIssue) lines.push(`  - Main issue: ${item.topIssue}`);
+      for (const improvement of item.improvements ?? []) {
+        lines.push(`  - Improvement: ${improvement}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines;
+}
+
+function renderContextHealthSection(payload: ReportPayload): string[] {
+  const lines = [
+    '## Context Health',
+    '',
+    `- Overall score: ${payload.contextHealth.overallScore ?? 'n/a'}`,
+    `- Agentic readiness: ${payload.contextHealth.agenticReadinessScore ?? 'n/a'}`,
+    '',
+    '### Missing Signals',
+    '',
+  ];
+
+  if (payload.contextHealth.missingSignals.length === 0) {
+    lines.push('- No missing signals found.');
+  } else {
+    for (const item of payload.contextHealth.missingSignals) {
+      lines.push(`- ${item.label}: ${item.detail}`);
+    }
+  }
+
+  lines.push('', '### Workspace Context', '');
+
+  if (payload.contextHealth.workspaceSummary.length === 0) {
+    lines.push('- No workspace data found.');
+  } else {
+    for (const item of payload.contextHealth.workspaceSummary) {
+      lines.push(`- ${item.workspace}: ${item.qualityScore ?? 'n/a'}/100`);
+      lines.push(`  - Instructions: ${item.hasInstructions ? 'yes' : 'no'}`);
+      lines.push(`  - Prompts: ${item.hasPrompts ? 'yes' : 'no'}`);
+      lines.push(`  - Agents: ${item.hasAgents ? 'yes' : 'no'}`);
+      lines.push(`  - Stale context: ${item.staleContext ? 'yes' : 'no'}`);
+
+      for (const suggestion of item.suggestions ?? []) {
+        lines.push(`  - Suggestion: ${suggestion}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines;
+}
+
+function renderNextActions(payload: ReportPayload): string[] {
+  const lines = ['## Next Actions', ''];
+
+  if (payload.nextActions.length === 0) {
+    lines.push('- No immediate actions found.');
+  } else {
+    for (const [index, action] of payload.nextActions.entries()) {
+      lines.push(`${index + 1}. ${action}`);
+    }
+  }
+
+  lines.push('');
+  return lines;
+}
+
+export function renderProductMarkdown(payload: ReportPayload): string {
+  return [
+    '# AI Engineer Coach Report',
+    '',
+    `Generated: ${payload.generatedAt}`,
+    '',
+    ...renderExecutiveSummary(payload),
+    ...renderTopLanguages(payload),
+    ...renderTopAntiPatterns(payload),
+    ...renderGroupScores(payload),
+    ...renderContextHealthSection(payload),
+    ...renderNextActions(payload),
+  ].join('\n');
+}
+
+export function renderAntiPatternsMarkdown(data: PatternsData, top: number): string {
+  const lines: string[] = ['# Anti-Patterns', ''];
+
+  if (data.groupScores.length > 0) {
+    lines.push('## Group Scores', '');
+
+    for (const group of data.groupScores) {
+      lines.push(`- ${group.group}: ${group.score}/100`);
+      if (group.topIssue) lines.push(`  - Main issue: ${group.topIssue}`);
+    }
+
+    lines.push('');
+  }
+
+  const patterns = data.antiPatterns.patterns.slice(0, top);
+
+  lines.push('## Top Issues', '');
+
+  if (patterns.length === 0) {
+    lines.push('- No anti-patterns found.');
+  } else {
+    lines.push(...renderAntiPatternItems(patterns));
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function renderContextHealthMarkdown(data: ContextHealthData): string {
+  const lines: string[] = [
+    '# Context Health',
+    '',
+    `Overall score: ${data.configHealth.overallScore ?? 'n/a'}`,
+    `Agentic readiness: ${data.configHealth.agenticReadiness.score ?? 'n/a'}`,
+    '',
+    '## Missing Signals',
+    '',
+  ];
+
+  const missingSignals = data.configHealth.agenticReadiness.missingSignals;
+
+  if (missingSignals.length === 0) {
+    lines.push('- No missing signals found.');
+  } else {
+    for (const signal of missingSignals) {
+      lines.push(`- ${signal.label}: ${signal.detail}`);
+    }
+  }
+
+  lines.push('', '## Workspaces', '');
+
+  const workspaces = data.configHealth.workspaceSummary;
+
+  if (workspaces.length === 0) {
+    lines.push('- No workspace context data found.');
+  } else {
+    for (const workspace of workspaces) {
+      lines.push(`- ${workspace.workspace}: ${workspace.qualityScore ?? 'n/a'}/100`);
+      lines.push(`  - Instructions: ${workspace.hasInstructions ? 'yes' : 'no'}`);
+      lines.push(`  - Prompts: ${workspace.hasPrompts ? 'yes' : 'no'}`);
+      lines.push(`  - Agents: ${workspace.hasAgents ? 'yes' : 'no'}`);
+
+      for (const suggestion of workspace.suggestions) {
+        lines.push(`  - Suggestion: ${suggestion}`);
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/src/cli/render-terminal.ts
+++ b/src/cli/render-terminal.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* ANSI terminal dashboard renderer for `aicoach report`. */
+
+import { ReportPayload } from './report-payload';
+
+const ANSI = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  green: '\x1b[32m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+};
+
+function useAnsi(): boolean {
+  return Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+}
+
+function paint(text: string, code: string): string {
+  if (!useAnsi()) return text;
+  return `${code}${text}${ANSI.reset}`;
+}
+
+function truncateText(input: string, max = 96): string {
+  if (input.length <= max) return input;
+  return `${input.slice(0, max - 1)}…`;
+}
+
+function scoreBar(score: number | undefined, width = 12): string {
+  const value = Math.max(0, Math.min(100, Number(score ?? 0)));
+  const filled = Math.round((value / 100) * width);
+  const empty = width - filled;
+
+  let color = ANSI.red;
+  if (value >= 75) color = ANSI.green;
+  else if (value >= 55) color = ANSI.yellow;
+
+  return `${paint('█'.repeat(filled), color)}${paint('░'.repeat(empty), ANSI.gray)} ${value}/100`;
+}
+
+function severityBadge(severity: string): string {
+  const label = severity.toUpperCase();
+
+  if (severity === 'high') return paint(label, ANSI.red + ANSI.bold);
+  if (severity === 'medium') return paint(label, ANSI.yellow + ANSI.bold);
+  if (severity === 'low') return paint(label, ANSI.green + ANSI.bold);
+
+  return label;
+}
+
+function statusIcon(score: number | undefined): string {
+  const value = Number(score ?? 0);
+
+  if (value >= 80) return paint('●', ANSI.green);
+  if (value >= 60) return paint('●', ANSI.yellow);
+  return paint('●', ANSI.red);
+}
+
+function renderScoreLine(label: string, score: number | undefined): string {
+  return `${statusIcon(score)} ${label.padEnd(18)} ${scoreBar(score)}`;
+}
+
+function renderHeader(payload: ReportPayload): string[] {
+  const sessions = payload.totals['Sessions'] ?? 'n/a';
+  const requests = payload.totals['Requests'] ?? 'n/a';
+  const workspaces = payload.totals['Workspaces'] ?? 'n/a';
+  const aiLoc = payload.totals['AI-generated LoC'] ?? 'n/a';
+  const flow = payload.flow['Overall flow score'] ?? 'n/a';
+
+  return [
+    '',
+    paint('AI Engineer Coach', ANSI.bold + ANSI.cyan),
+    paint('────────────────────────────────────────────', ANSI.cyan),
+    `${paint('Summary', ANSI.bold)} ${sessions} sessions · ${requests} requests · ${workspaces} workspaces`,
+    `${paint('Output', ANSI.bold)}  ${aiLoc} AI LoC · Flow ${flow}/100`,
+    '',
+  ];
+}
+
+function renderScores(payload: ReportPayload): string[] {
+  const lines = [paint('Scores', ANSI.bold)];
+
+  lines.push(renderScoreLine('Context health', payload.contextHealth.overallScore));
+  lines.push(renderScoreLine('Agentic readiness', payload.contextHealth.agenticReadinessScore));
+
+  for (const group of payload.groupScores.slice(0, 4)) {
+    lines.push(renderScoreLine(group.group, group.score));
+  }
+
+  return lines;
+}
+
+function renderPriorities(payload: ReportPayload): string[] {
+  const lines = ['', paint('Priorities', ANSI.bold)];
+  const topRisks = payload.topAntiPatterns.slice(0, 3);
+
+  if (topRisks.length === 0) {
+    lines.push(`${paint('✓', ANSI.green)} No top risks found.`);
+    return lines;
+  }
+
+  for (const [index, item] of topRisks.entries()) {
+    lines.push(`${index + 1}. ${severityBadge(item.severity)} ${paint(item.name, ANSI.bold)} ${paint(`(${item.occurrences})`, ANSI.gray)}`);
+    lines.push(`   ${truncateText(item.suggestion, 86)}`);
+  }
+
+  return lines;
+}
+
+function renderContext(payload: ReportPayload): string[] {
+  const lines = ['', paint('Context', ANSI.bold)];
+  const missing = payload.contextHealth.missingSignals.map(item => item.label);
+
+  if (missing.length === 0) {
+    lines.push(`${paint('✓', ANSI.green)} Readiness complete.`);
+  } else {
+    lines.push(`${paint('Missing:', ANSI.yellow)} ${missing.join(' · ')}`);
+  }
+
+  const topWorkspace = payload.contextHealth.workspaceSummary[0];
+
+  if (topWorkspace) {
+    lines.push(`${paint('Workspace:', ANSI.gray)} ${topWorkspace.workspace} · score ${topWorkspace.qualityScore ?? 'n/a'}/100`);
+  }
+
+  return lines;
+}
+
+function renderActions(payload: ReportPayload): string[] {
+  const lines = ['', paint('Next 3 actions', ANSI.bold)];
+
+  const actions = payload.nextActions
+    .map(action => truncateText(action, 86))
+    .filter(Boolean)
+    .slice(0, 3);
+
+  if (actions.length === 0) {
+    lines.push('1. No immediate actions detected.');
+  } else {
+    for (const [index, action] of actions.entries()) {
+      lines.push(`${index + 1}. ${action}`);
+    }
+  }
+
+  return lines;
+}
+
+export function renderTerminalDashboard(payload: ReportPayload): string {
+  return [
+    ...renderHeader(payload),
+    ...renderScores(payload),
+    ...renderPriorities(payload),
+    ...renderContext(payload),
+    ...renderActions(payload),
+    '',
+    paint('Full report:', ANSI.gray) + ' aicoach report --format all --out ./reports',
+    '',
+  ].join('\n');
+}
+
+export function stripAnsi(input: string): string {
+  // eslint-disable-next-line no-control-regex
+  return input.replaceAll(/\x1b\[[0-9;]*m/g, '');
+}

--- a/src/cli/report-payload.ts
+++ b/src/cli/report-payload.ts
@@ -1,0 +1,188 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Builds the consolidated report payload consumed by every CLI renderer. */
+
+import { formatPatterns, formatContextHealth } from '../mcp/formatters';
+
+export type PatternsData = ReturnType<typeof formatPatterns>;
+export type ContextHealthData = ReturnType<typeof formatContextHealth>;
+
+export interface ReportAntiPattern {
+  name: string;
+  severity: string;
+  group: string;
+  occurrences: number;
+  suggestion: string;
+  trend?: string;
+}
+
+export interface ReportGroupScore {
+  group: string;
+  score: number;
+  topIssue?: string;
+  improvements?: string[];
+}
+
+export interface ReportMissingSignal {
+  label: string;
+  detail: string;
+}
+
+export interface ReportWorkspaceSummary {
+  workspace: string;
+  qualityScore?: number;
+  hasInstructions?: boolean;
+  hasPrompts?: boolean;
+  hasAgents?: boolean;
+  staleContext?: boolean;
+  suggestions?: string[];
+}
+
+export interface ReportPayload {
+  generatedAt: string;
+  filter: string;
+  totals: Record<string, string>;
+  flow: Record<string, string>;
+  topLanguages: string[];
+  topAntiPatterns: ReportAntiPattern[];
+  groupScores: ReportGroupScore[];
+  contextHealth: {
+    overallScore?: number;
+    agenticReadinessScore?: number;
+    missingSignals: ReportMissingSignal[];
+    workspaceSummary: ReportWorkspaceSummary[];
+  };
+  nextActions: string[];
+}
+
+/** Returns the markdown block starting at `heading` up to the next `## ` heading. */
+export function extractSection(markdown: string, heading: string): string {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex(line => line.trim() === heading);
+
+  if (start === -1) return '';
+
+  let end = lines.length;
+
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('## ') && lines[i].trim() !== heading) {
+      end = i;
+      break;
+    }
+  }
+
+  return lines.slice(start, end).join('\n').trim();
+}
+
+export function extractBulletMap(markdown: string, sectionHeading: string): Record<string, string> {
+  const section = extractSection(markdown, sectionHeading);
+  const result: Record<string, string> = {};
+
+  for (const line of section.split('\n')) {
+    const match = line.match(/^- ([^:]+):\s*(.+)$/);
+    if (match) {
+      result[match[1].trim()] = match[2].trim();
+    }
+  }
+
+  return result;
+}
+
+export function extractBullets(markdown: string, sectionHeading: string): string[] {
+  const section = extractSection(markdown, sectionHeading);
+
+  return section
+    .split('\n')
+    .filter(line => line.trim().startsWith('- '))
+    .map(line => line.replace(/^- /, '').trim());
+}
+
+export function buildNextActions(payload: {
+  topAntiPatterns: ReportAntiPattern[];
+  contextHealth: ReportPayload['contextHealth'];
+}): string[] {
+  const actions: string[] = [];
+
+  const firstHigh = payload.topAntiPatterns.find(item => item.severity === 'high');
+
+  if (firstHigh?.suggestion) {
+    actions.push(firstHigh.suggestion);
+  }
+
+  for (const signal of payload.contextHealth.missingSignals.slice(0, 2)) {
+    actions.push(`Fix: ${signal.label}. ${signal.detail}`);
+  }
+
+  const workspaceSuggestion = payload.contextHealth.workspaceSummary
+    .flatMap(w => w.suggestions ?? [])
+    .find(Boolean);
+
+  if (workspaceSuggestion) actions.push(workspaceSuggestion);
+
+  return [...new Set(actions)].slice(0, 5);
+}
+
+function toAntiPatterns(patternsData: PatternsData, top: number): ReportAntiPattern[] {
+  return patternsData.antiPatterns.patterns.slice(0, top).map(item => ({
+    name: item.name,
+    severity: item.severity,
+    group: item.group,
+    occurrences: item.occurrences,
+    suggestion: item.suggestion,
+    trend: item.trend,
+  }));
+}
+
+function toGroupScores(patternsData: PatternsData): ReportGroupScore[] {
+  return patternsData.groupScores.map(item => ({
+    group: item.group,
+    score: item.score,
+    topIssue: item.topIssue ?? undefined,
+    improvements: item.improvements,
+  }));
+}
+
+function toWorkspaceSummary(contextData: ContextHealthData, top: number): ReportWorkspaceSummary[] {
+  return contextData.configHealth.workspaceSummary.slice(0, top).map(item => ({
+    workspace: item.workspace,
+    qualityScore: item.qualityScore,
+    hasInstructions: item.hasInstructions,
+    hasPrompts: item.hasPrompts,
+    hasAgents: item.hasAgents,
+    staleContext: item.staleContext,
+    suggestions: item.suggestions,
+  }));
+}
+
+export function buildReportPayload(
+  baseMarkdown: string,
+  patternsData: PatternsData,
+  contextData: ContextHealthData,
+  top: number,
+): ReportPayload {
+  const totals = extractBulletMap(baseMarkdown, '## Totals');
+
+  const payloadWithoutActions = {
+    generatedAt: new Date().toISOString(),
+    filter: totals['Filter'] ?? 'All data',
+    totals,
+    flow: extractBulletMap(baseMarkdown, '## Flow'),
+    topLanguages: extractBullets(baseMarkdown, '## Top Languages').slice(0, top),
+    topAntiPatterns: toAntiPatterns(patternsData, top),
+    groupScores: toGroupScores(patternsData),
+    contextHealth: {
+      overallScore: contextData.configHealth.overallScore,
+      agenticReadinessScore: contextData.configHealth.agenticReadiness.score,
+      missingSignals: contextData.configHealth.agenticReadiness.missingSignals,
+      workspaceSummary: toWorkspaceSummary(contextData, top),
+    },
+  };
+
+  return {
+    ...payloadWithoutActions,
+    nextActions: buildNextActions(payloadWithoutActions),
+  };
+}


### PR DESCRIPTION
## Description

Adds a standalone CLI (`aicoach`) that runs the same read-only parsing/analysis pipeline as the extension and renders reports in a terminal — no VS Code required. This makes the coach usable from a plain shell, over SSH, and in CI/cron for people who work primarily in terminal harnesses (Claude Code, Codex, OpenCode).

**Commands**

- `aicoach report` — ANSI terminal dashboard (scores, priorities, context, next actions); `--format md|json|html|both|all` + `--out` writes self-contained report files
- `aicoach summary` — existing summary-export renderers (md/json)
- `aicoach json <summary|activity|patterns|flow|insights|workflows|context|production|credits|wellbeing|compare>` — raw payloads from the MCP formatters
- `aicoach sessions` / `aicoach session --session-id <id>` — paged listing and detail
- `aicoach observe summary`, `aicoach measure output`, `aicoach improve anti-patterns|context-health`
- All commands accept `--from/--to/--workspace/--harness` filters plus `--logs-dir` overrides
- `--verbose` progress goes to stderr; stdout carries only command output, so `aicoach json … | jq` works. Core `console.info`/`console.debug` diagnostics are routed to stderr for the same reason.

**Safety:** local rules/metrics stay blocked by default via a blocking `TrustGate` (the CLI has no interactive approval UI); `--allow-local-rules` opts in explicitly, and blocked files are reported on stderr.

**Build:** separate `esbuild-cli.mjs` → `dist/cli.js` (`npm run build:cli`); the extension pipeline in `esbuild.mjs` is untouched. `package.json` gains two `bin` aliases (`aicoach`, `ai-engineer-coach`) and two scripts; `src/cli.ts` is registered as a knip entry.

## Related Issues

Relates to #46 — "would be extremely useful to collect all the information from various tools in one dashboard": the CLI surfaces every supported harness (VS Code/Copilot, Claude Code, Codex, OpenCode) in one report from the terminal. OpenCode parsing on current OpenCode versions additionally needs #170 (SQLite storage).

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests) — 1227 tests, `tsc --noEmit` clean, ESLint 0 errors (0 new warnings), cspell 0 issues, knip clean
- [x] Changes are covered by tests (`src/cli/cli.test.ts`: arg parsing, filters, payload extraction, next-action dedup, HTML escaping, ANSI stripping)
- [x] Documentation updated (CLI help text; module header comments)

## Verification against real data

Audited on a machine with 6,086 real sessions across 67 workspaces (with #170 applied locally for OpenCode):

- `sessions --harness Claude` → 4,343 · `Codex` → 466 · `OpenCode` → 1,143
- `report --format all --out` produces consistent txt/md/json/html; JSON parses and matches the dashboard totals
- `json compare` breaks down per harness; `measure output --from` filters correctly
- Invalid commands/formats exit 1 with a one-line error
