### PR TITLE
feat: add Cursor Agent harness support

### DIFF
--- a/README.extension.md
+++ b/README.extension.md
@@ -1,7 +1,7 @@
 <h1 align="center">AI Engineer Coach</h1>
 
 <p align="center">
-Analyze your AI coding assistant usage across VS Code, GitHub Copilot for Xcode, Claude, Codex, OpenCode, and GitHub Copilot CLI.
+Analyze your AI coding assistant usage across VS Code, GitHub Copilot for Xcode, Claude, Codex, OpenCode, Cursor, and GitHub Copilot CLI.
 </p>
 
 <p align="center">
@@ -61,6 +61,7 @@ The extension is organized into three sections: **Observe**, **Measure**, and **
 | **Claude** | macOS/Linux: `~/.claude/projects/`<br>Windows: `%USERPROFILE%\.claude\projects\` |
 | **Codex** | macOS/Linux: `~/.codex/sessions/`<br>Windows: `%USERPROFILE%\.codex\sessions\` |
 | **OpenCode** | macOS/Linux: `~/.local/share/opencode/`<br>Windows: `%USERPROFILE%\.local\share\opencode\` |
+| **Cursor** | macOS/Linux: `~/.cursor/projects/`<br>Windows: `%USERPROFILE%\.cursor\projects\` |
 | **GitHub Copilot CLI** | `~/.copilot/session-state/` and `~/.copilot/history-session-state/` |
 
 ### Chat

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -18,6 +18,7 @@ AI Engineer Coach reads logs from multiple AI coding tools:
 | **Claude** | Session files from Anthropic's CLI-based coding assistant |
 | **Codex** | Session history from OpenAI's terminal agent |
 | **OpenCode** | Session logs from the open-source terminal coding tool |
+| **Cursor** | Cursor Agent transcripts under `~/.cursor/projects/**/agent-transcripts/` |
 | **GitHub Copilot CLI** | Session state and history from the Copilot CLI terminal agent |
 
 ## How It Works

--- a/docs/content/getting-started/supported-tools.md
+++ b/docs/content/getting-started/supported-tools.md
@@ -34,6 +34,16 @@ Reads session history from OpenAI's Codex terminal agent. Captures prompts, comp
 
 Parses session logs from the open-source OpenCode terminal tool that supports multiple LLM backends.
 
+## Cursor Agent
+
+Parses Cursor Agent transcripts from the local Cursor projects directory. Each chat session under `agent-transcripts/` becomes a session; user turns wrapped in `<user_query>` become requests. Tool calls (Read, Write, Glob, Shell, and others) are mapped into the shared analytics model. Subagent transcripts under `subagents/` are merged into the parent session.
+
+Token and model usage are not present in Cursor Agent transcripts, so those metrics stay unavailable for this harness (same honest `no-data` approach used for sources without usage fields).
+
+**Default location:**
+- macOS/Linux: `~/.cursor/projects/`
+- Windows: `%USERPROFILE%\.cursor\projects\`
+
 ## GitHub Copilot for Xcode
 
 Reads Copilot Chat conversation logs from Apple's Xcode IDE. Sessions are parsed from SQLite databases stored in the GitHub Copilot configuration directory.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-engineer-coach",
   "displayName": "AI Engineer Coach",
-  "description": "Analyze your AI coding assistant usage across VS Code, Xcode, Claude, Codex, and OpenCode. Read-only, zero telemetry.",
+  "description": "Analyze your AI coding assistant usage across VS Code, Xcode, Claude, Codex, OpenCode, and Cursor. Read-only, zero telemetry.",
   "version": "0.1.0",
   "publisher": "ai-engineer-coach",
   "author": {
@@ -30,6 +30,7 @@
     "claude",
     "codex",
     "opencode",
+    "cursor",
     "productivity",
     "github"
   ],

--- a/src/core/parser-cursor.test.ts
+++ b/src/core/parser-cursor.test.ts
@@ -1,0 +1,623 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Tests for the Cursor Agent JSONL parser. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, it, expect } from 'vitest';
+import {
+  clearCursorResolveCache,
+  findCursorDirs,
+  inferWorkspaceRootFromPaths,
+  parseCursorSessions,
+  parseCursorTimestamp,
+  projectNameFromCursorEncoded,
+  resolveCursorEncodedPath,
+} from './parser-cursor';
+import { EXTERNAL_HARNESS_SET } from './parser-harnesses';
+
+function writeJsonl(filePath: string, lines: object[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, lines.map(l => JSON.stringify(l)).join('\n') + '\n', 'utf-8');
+}
+
+function makeUser(query: string, tsLabel = 'Thursday, Aug 13, 2026, 11:42 AM (UTC-3)'): object {
+  return {
+    role: 'user',
+    message: {
+      content: [{
+        type: 'text',
+        text: `<timestamp>${tsLabel}</timestamp>\n<user_query>\n${query}\n</user_query>`,
+      }],
+    },
+  };
+}
+
+function makeIncompleteUser(partialQuery: string): object {
+  return {
+    role: 'user',
+    message: {
+      content: [{
+        type: 'text',
+        text: `<timestamp>Thursday, Aug 13, 2026, 11:42 AM (UTC-3)</timestamp>\n<user_query>\n${partialQuery}`,
+      }],
+    },
+  };
+}
+
+function makeAssistant(text: string, tools: Array<{ name: string; input: Record<string, unknown> }> = []): object {
+  const content: object[] = [];
+  if (text) content.push({ type: 'text', text });
+  for (const t of tools) content.push({ type: 'tool_use', name: t.name, input: t.input });
+  return { role: 'assistant', message: { content } };
+}
+
+function makeTurnEnded(status: 'success' | 'error' = 'success'): object {
+  return { type: 'turn_ended', status };
+}
+
+/** Create a Cursor projects layout under a temp dir and return projectsDir. */
+function setupProject(
+  home: string,
+  projectSlug: string,
+  sessions: Array<{
+    id: string;
+    lines: object[];
+    subagents?: Array<{ id: string; lines: object[] }>;
+  }>,
+): string {
+  const projectsDir = path.join(home, '.cursor', 'projects');
+  for (const session of sessions) {
+    const sessionDir = path.join(projectsDir, projectSlug, 'agent-transcripts', session.id);
+    writeJsonl(path.join(sessionDir, `${session.id}.jsonl`), session.lines);
+    for (const sub of session.subagents ?? []) {
+      writeJsonl(path.join(sessionDir, 'subagents', `${sub.id}.jsonl`), sub.lines);
+    }
+  }
+  return projectsDir;
+}
+
+afterEach(() => {
+  clearCursorResolveCache();
+});
+
+describe('parseCursorTimestamp', () => {
+  it('parses Cursor timestamp tags to epoch ms', () => {
+    const ms = parseCursorTimestamp('<timestamp>Thursday, Aug 13, 2026, 11:42 AM (UTC-3)</timestamp>');
+    expect(ms).toBeTypeOf('number');
+    expect(ms).toBeGreaterThan(0);
+  });
+
+  it('returns null when no timestamp tag is present', () => {
+    expect(parseCursorTimestamp('plain text')).toBeNull();
+  });
+});
+
+describe('resolveCursorEncodedPath / projectNameFromCursorEncoded', () => {
+  it('uses the encoded slug when the path cannot be fully decoded', () => {
+    expect(resolveCursorEncodedPath('fixture-demo-workspace')).toBeUndefined();
+    expect(projectNameFromCursorEncoded('fixture-demo-workspace')).toBe('fixture-demo-workspace');
+  });
+
+  it('does not invent a Windows drive root when the drive is unavailable', () => {
+    // On Linux/WSL this typically cannot list E:\ — must not claim a live root.
+    expect(resolveCursorEncodedPath('e-projects-demo-app')).toBeUndefined();
+    expect(projectNameFromCursorEncoded('e-projects-demo-app')).toBe('e-projects-demo-app');
+  });
+
+  it('resolves a real Unix path tree to the folder basename', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-decode-'));
+    try {
+      const project = path.join(root, 'projects', 'demo-app');
+      fs.mkdirSync(project, { recursive: true });
+      const encoded = project.replaceAll('\\', '/').replace(/^\//, '').replaceAll('/', '-');
+      clearCursorResolveCache();
+      const resolved = resolveCursorEncodedPath(encoded);
+      expect(resolved).toBe(project);
+      expect(projectNameFromCursorEncoded(encoded, resolved)).toBe('demo-app');
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses partial matches that would collapse to an existing shallow path', () => {
+    // Matching only `/home` for `home-user-projects-demo-app` would be wrong.
+    expect(resolveCursorEncodedPath('home-user-projects-demo-app')).toBeUndefined();
+  });
+});
+
+describe('inferWorkspaceRootFromPaths', () => {
+  it('finds the common ancestor of Unix directories', () => {
+    expect(inferWorkspaceRootFromPaths([
+      '/home/user/projects/demo-app/src',
+      '/home/user/projects/demo-app/lib',
+    ])).toBe('/home/user/projects/demo-app');
+  });
+
+  it('finds the common ancestor of Windows paths with spaces', () => {
+    expect(inferWorkspaceRootFromPaths([
+      'E:\\projects\\Demo Workspace\\src',
+      'E:\\projects\\Demo Workspace\\docs',
+    ])).toBe('E:\\projects\\Demo Workspace');
+  });
+
+  it('returns the single directory when only one candidate is present', () => {
+    expect(inferWorkspaceRootFromPaths(['/home/user/projects/demo-app/src'])).toBe(
+      '/home/user/projects/demo-app/src',
+    );
+  });
+
+  it('returns undefined for drive or filesystem root only', () => {
+    expect(inferWorkspaceRootFromPaths(['/', '/tmp'])).toBeUndefined();
+    expect(inferWorkspaceRootFromPaths(['E:\\', 'E:\\projects'])).toBeUndefined();
+  });
+
+  it('ignores relative paths', () => {
+    expect(inferWorkspaceRootFromPaths(['src/main.ts', 'lib/util.ts'])).toBeUndefined();
+  });
+});
+
+describe('findCursorDirs', () => {
+  it('returns empty when .cursor/projects is missing', () => {
+    const prevHome = process.env.HOME;
+    const prevUser = process.env.USERPROFILE;
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-home-missing-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    try {
+      expect(findCursorDirs()).toEqual([]);
+    } finally {
+      process.env.HOME = prevHome;
+      process.env.USERPROFILE = prevUser;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('finds ~/.cursor/projects when present', () => {
+    const prevHome = process.env.HOME;
+    const prevUser = process.env.USERPROFILE;
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-home-present-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    try {
+      fs.mkdirSync(path.join(home, '.cursor', 'projects'), { recursive: true });
+      expect(findCursorDirs()).toEqual([path.join(home, '.cursor', 'projects')]);
+    } finally {
+      process.env.HOME = prevHome;
+      process.env.USERPROFILE = prevUser;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseCursorSessions', () => {
+  it('parses a simple single-request session with harness Cursor', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-simple-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-1',
+        lines: [
+          makeUser('hello world'),
+          makeAssistant('hi there'),
+          makeTurnEnded(),
+        ],
+      }]);
+
+      const result = parseCursorSessions(projectsDir);
+      expect(result).toHaveLength(1);
+      expect(result[0].workspaceId).toBe('cursor-fixture-demo-workspace');
+      expect(result[0].workspaceName).toBe('fixture-demo-workspace');
+      expect(result[0].sessions).toHaveLength(1);
+
+      const session = result[0].sessions[0];
+      expect(session.harness).toBe('Cursor');
+      expect(EXTERNAL_HARNESS_SET.has(session.harness)).toBe(true);
+      expect(session.sessionId).toBe('sess-1');
+      expect(session.requestCount).toBe(1);
+      expect(session.requests[0].messageText).toContain('hello world');
+      expect(session.requests[0].responseText).toContain('hi there');
+      expect(session.requests[0].promptTokens).toBeNull();
+      expect(session.requests[0].completionTokens).toBeNull();
+      expect(session.requests[0].endState).toBe('no-data');
+      expect(session.requests[0].timestamp).toBeTypeOf('number');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('counts multiple user_query turns as separate requests', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-multi-req-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-2',
+        lines: [
+          makeUser('first', 'Thursday, Aug 13, 2026, 10:00 AM (UTC-3)'),
+          makeAssistant('reply 1'),
+          makeTurnEnded(),
+          makeUser('second', 'Thursday, Aug 13, 2026, 10:05 AM (UTC-3)'),
+          makeAssistant('reply 2'),
+          makeTurnEnded(),
+        ],
+      }]);
+
+      const session = parseCursorSessions(projectsDir)[0].sessions[0];
+      expect(session.requestCount).toBe(2);
+      expect(session.requests[0].messageText).toContain('first');
+      expect(session.requests[1].messageText).toContain('second');
+      expect(session.requests[0].timestamp).toBeLessThan(session.requests[1].timestamp!);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('aggregates multiple assistant messages and tools before turn_ended', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-multi-asst-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-multi-asst',
+        lines: [
+          makeUser('explore'),
+          makeAssistant('step 1', [{ name: 'Glob', input: { glob_pattern: '**/*', target_directory: '/tmp/demo' } }]),
+          makeAssistant('step 2', [{ name: 'Read', input: { path: '/tmp/demo/a.ts' } }]),
+          makeTurnEnded(),
+        ],
+      }]);
+
+      const req = parseCursorSessions(projectsDir)[0].sessions[0].requests[0];
+      expect(req.responseText).toContain('step 1');
+      expect(req.responseText).toContain('step 2');
+      expect(req.toolsUsed).toEqual(expect.arrayContaining(['Glob', 'Read']));
+      expect(req.endState).toBe('no-data');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('marks in-flight turns without turn_ended as pending', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-pending-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-pending',
+        lines: [
+          makeUser('still running'),
+          makeAssistant('working…'),
+        ],
+      }]);
+      expect(parseCursorSessions(projectsDir)[0].sessions[0].requests[0].endState).toBe('pending');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts an incomplete open user_query for incremental transcripts', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-incomplete-uq-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-inc-uq',
+        lines: [
+          makeIncompleteUser('partial question still being typed'),
+          makeAssistant('ack'),
+        ],
+      }]);
+      const session = parseCursorSessions(projectsDir)[0].sessions[0];
+      expect(session.requestCount).toBe(1);
+      expect(session.requests[0].messageText).toContain('partial question');
+      expect(session.requests[0].endState).toBe('pending');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('does not treat role=user without user_query as a request', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-no-uq-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-no-uq',
+        lines: [
+          {
+            role: 'user',
+            message: { content: [{ type: 'text', text: '<timestamp>Thursday, Aug 13, 2026, 11:42 AM (UTC-3)</timestamp>\nnot a query' }] },
+          },
+          makeAssistant('should be ignored'),
+          makeTurnEnded(),
+        ],
+      }]);
+      expect(parseCursorSessions(projectsDir)).toEqual([]);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('captures tool calls and prefers tool LCP when decoded path is absent', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-tools-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-tools',
+        lines: [
+          makeUser('edit the file'),
+          makeAssistant('working', [
+            { name: 'Glob', input: { glob_pattern: '**/*', target_directory: '/home/user/projects/demo-app' } },
+            { name: 'Read', input: { path: '/home/user/projects/demo-app/src/main.ts' } },
+            {
+              name: 'Write',
+              input: {
+                path: '/home/user/projects/demo-app/src/main.ts',
+                contents: 'export const x = 1;\nexport const y = 2;\n',
+              },
+            },
+            {
+              name: 'StrReplace',
+              input: {
+                path: '/home/user/projects/demo-app/src/main.ts',
+                old_string: 'x = 1',
+                new_string: 'x = 3',
+              },
+            },
+          ]),
+          makeTurnEnded(),
+        ],
+      }]);
+
+      const parsed = parseCursorSessions(projectsDir)[0].sessions[0];
+      const req = parsed.requests[0];
+      expect(req.toolsUsed).toEqual(expect.arrayContaining(['Glob', 'Read', 'Write', 'StrReplace']));
+      expect(req.referencedFiles).toEqual(expect.arrayContaining([
+        '/home/user/projects/demo-app',
+        '/home/user/projects/demo-app/src/main.ts',
+      ]));
+      expect(req.editedFiles).toEqual(expect.arrayContaining([
+        '/home/user/projects/demo-app/src/main.ts',
+      ]));
+      expect(req.aiCode.some(b => b.loc >= 2)).toBe(true);
+      expect(parsed.workspaceRootPath).toBe('/home/user/projects/demo-app');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('prefers an existing decoded project path over tool LCP', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-prefer-decoded-'));
+    try {
+      const project = path.join(root, 'demo-proj');
+      fs.mkdirSync(project, { recursive: true });
+      const encoded = project.replaceAll('\\', '/').replace(/^\//, '').replaceAll('/', '-');
+      clearCursorResolveCache();
+
+      const projectsDir = setupProject(root, encoded, [{
+        id: 'sess-pref',
+        lines: [
+          makeUser('edit'),
+          makeAssistant('ok', [
+            { name: 'Read', input: { path: path.join(project, 'src', 'a.ts') } },
+          ]),
+          makeTurnEnded(),
+        ],
+      }]);
+
+      // setupProject nests under root/.cursor/projects — move to match encoded layout:
+      // We stored under root/.cursor/projects/<encoded>, and encoded resolves to `project`.
+      const session = parseCursorSessions(projectsDir)[0].sessions[0];
+      expect(session.workspaceRootPath).toBe(project);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('merges subagent files into the parent session preserving tools and timestamps', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-subagent-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'parent-sess',
+        lines: [
+          makeUser('main task', 'Thursday, Aug 13, 2026, 10:00 AM (UTC-3)'),
+          makeAssistant('parent reply'),
+          makeTurnEnded(),
+        ],
+        subagents: [{
+          id: 'sub-1',
+          lines: [
+            makeUser('subagent task', 'Thursday, Aug 13, 2026, 10:01 AM (UTC-3)'),
+            makeAssistant('subagent reply', [
+              { name: 'Write', input: { path: '/tmp/demo/out.ts', contents: 'x\n' } },
+            ]),
+            makeTurnEnded(),
+          ],
+        }],
+      }]);
+
+      const result = parseCursorSessions(projectsDir);
+      expect(result[0].sessions).toHaveLength(1);
+      const session = result[0].sessions[0];
+      expect(session.sessionId).toBe('parent-sess');
+      expect(session.harness).toBe('Cursor');
+      expect(session.requestCount).toBe(2);
+      expect(session.requests.map(r => r.messageText).join(' ')).toContain('subagent task');
+      expect(session.requests[0].timestamp!).toBeLessThan(session.requests[1].timestamp!);
+      expect(session.requests.some(r => r.editedFiles.includes('/tmp/demo/out.ts'))).toBe(true);
+      expect(session.creationDate).toBe(session.requests[0].timestamp);
+      expect(session.lastMessageDate).toBeGreaterThanOrEqual(session.requests[1].timestamp!);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('emits orphan subagent sessions when the parent transcript is missing', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-orphan-'));
+    try {
+      const projectsDir = path.join(home, '.cursor', 'projects');
+      const sessionDir = path.join(projectsDir, 'fixture-demo-workspace', 'agent-transcripts', 'orphan-sess');
+      writeJsonl(path.join(sessionDir, 'subagents', 'sub-only.jsonl'), [
+        makeUser('orphan work'),
+        makeAssistant('done'),
+        makeTurnEnded(),
+      ]);
+
+      const result = parseCursorSessions(projectsDir);
+      expect(result[0].sessions).toHaveLength(1);
+      expect(result[0].sessions[0].sessionId).toBe('orphan-sess');
+      expect(result[0].sessions[0].requestCount).toBe(1);
+      expect(result[0].sessions[0].harness).toBe('Cursor');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('parses multiple sessions under one workspace', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-multi-sess-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [
+        {
+          id: 'sess-a',
+          lines: [makeUser('a'), makeAssistant('A'), makeTurnEnded()],
+        },
+        {
+          id: 'sess-b',
+          lines: [makeUser('b'), makeAssistant('B'), makeTurnEnded()],
+        },
+      ]);
+
+      const sessions = parseCursorSessions(projectsDir)[0].sessions;
+      expect(sessions).toHaveLength(2);
+      expect(sessions.map(s => s.sessionId).sort()).toEqual(['sess-a', 'sess-b']);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores empty and corrupt JSONL lines', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-corrupt-'));
+    try {
+      const projectsDir = path.join(home, '.cursor', 'projects');
+      const sessionFile = path.join(
+        projectsDir, 'fixture-demo-workspace', 'agent-transcripts', 'sess-bad', 'sess-bad.jsonl',
+      );
+      fs.mkdirSync(path.dirname(sessionFile), { recursive: true });
+      fs.writeFileSync(
+        sessionFile,
+        [
+          '',
+          'not-json',
+          JSON.stringify(makeUser('ok')),
+          JSON.stringify(makeAssistant('reply')),
+          '{broken',
+          JSON.stringify(makeTurnEnded()),
+        ].join('\n'),
+        'utf-8',
+      );
+
+      const session = parseCursorSessions(projectsDir)[0].sessions[0];
+      expect(session.requestCount).toBe(1);
+      expect(session.requests[0].messageText).toContain('ok');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns no sessions when agent-transcripts is missing', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-no-transcripts-'));
+    try {
+      const projectsDir = path.join(home, '.cursor', 'projects');
+      fs.mkdirSync(path.join(projectsDir, '1783368199641', 'terminals'), { recursive: true });
+      expect(parseCursorSessions(projectsDir)).toEqual([]);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('returns no sessions for an empty projects directory', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-empty-projects-'));
+    try {
+      const projectsDir = path.join(home, '.cursor', 'projects');
+      fs.mkdirSync(projectsDir, { recursive: true });
+      expect(parseCursorSessions(projectsDir)).toEqual([]);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('does not duplicate a session when parent and matching id already exist', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-dedupe-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-dup',
+        lines: [makeUser('once'), makeAssistant('once'), makeTurnEnded()],
+        subagents: [{
+          id: 'sub-extra',
+          lines: [makeUser('extra'), makeAssistant('extra'), makeTurnEnded()],
+        }],
+      }]);
+
+      const sessions = parseCursorSessions(projectsDir)[0].sessions;
+      expect(sessions.filter(s => s.sessionId === 'sess-dup')).toHaveLength(1);
+      expect(sessions[0].requestCount).toBe(2);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('re-parses an incrementally updated transcript with more requests', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-incremental-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-inc',
+        lines: [
+          makeUser('first', 'Thursday, Aug 13, 2026, 10:00 AM (UTC-3)'),
+          makeAssistant('r1'),
+          makeTurnEnded(),
+        ],
+      }]);
+
+      expect(parseCursorSessions(projectsDir)[0].sessions[0].requestCount).toBe(1);
+
+      const sessionFile = path.join(
+        projectsDir, 'fixture-demo-workspace', 'agent-transcripts', 'sess-inc', 'sess-inc.jsonl',
+      );
+      writeJsonl(sessionFile, [
+        makeUser('first', 'Thursday, Aug 13, 2026, 10:00 AM (UTC-3)'),
+        makeAssistant('r1'),
+        makeTurnEnded(),
+        makeUser('second', 'Thursday, Aug 13, 2026, 10:10 AM (UTC-3)'),
+        makeAssistant('r2'),
+        makeTurnEnded(),
+      ]);
+
+      expect(parseCursorSessions(projectsDir)[0].sessions[0].requestCount).toBe(2);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores unexpected shapes such as turn_ended-only files', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-unexpected-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-meta',
+        lines: [makeTurnEnded(), { role: 'assistant', message: { content: [{ type: 'text', text: 'orphan' }] } }],
+      }]);
+      expect(parseCursorSessions(projectsDir)).toEqual([]);
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('marks errored turn_ended as endState errored', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cursor-error-'));
+    try {
+      const projectsDir = setupProject(home, 'fixture-demo-workspace', [{
+        id: 'sess-err',
+        lines: [
+          makeUser('fail please'),
+          makeAssistant('trying'),
+          makeTurnEnded('error'),
+        ],
+      }]);
+      expect(parseCursorSessions(projectsDir)[0].sessions[0].requests[0].endState).toBe('errored');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/core/parser-cursor.ts
+++ b/src/core/parser-cursor.ts
@@ -1,0 +1,741 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Cursor Agent session parser
+ *
+ * Data layout:
+ *   ~/.cursor/projects/<encoded-workspace>/agent-transcripts/<session-id>/<session-id>.jsonl
+ *   ~/.cursor/projects/<encoded-workspace>/agent-transcripts/<session-id>/subagents/<id>.jsonl
+ *
+ * Each JSONL line is typically:
+ *   { "role": "user"|"assistant", "message": { "content": [ { type, text?, name?, input? } ] } }
+ * or a meta marker:
+ *   { "type": "turn_ended", "status": "success"|"error"|... }
+ *
+ * User text usually wraps the prompt as:
+ *   <timestamp>...</timestamp>\n<user_query>...</user_query>
+ *
+ * Tokens / model ids are not present in these transcripts — leave them null / no-data
+ * after a finalized turn (`turn_ended`). In-flight turns (assistant without turn_ended)
+ * stay `pending`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { Session, SessionRequest } from './types';
+import {
+  assertTrustedPath,
+  createRequest,
+  createSession,
+  detectDevcontainerFromRequests,
+  extractSkillNameFromPath,
+  readFileSafe,
+} from './parser-shared';
+import { warnCore } from './log';
+
+interface CursorContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+}
+
+interface CursorMessage {
+  content?: CursorContentBlock[] | string;
+}
+
+interface CursorLine {
+  role?: string;
+  type?: string;
+  status?: string;
+  message?: CursorMessage;
+}
+
+interface CursorAssistantData {
+  nextIndex: number;
+  lastTs: number | null;
+  assistantTexts: string[];
+  toolsUsed: string[];
+  editedFiles: string[];
+  referencedFiles: string[];
+  skillsUsed: string[];
+  /** Absolute directory candidates for workspace-root inference (tool-role classified). */
+  rootCandidates: string[];
+  assistantCount: number;
+  sawTurnEnded: boolean;
+  turnEndedError: boolean;
+}
+
+/** Path kind for workspace-root LCP: files contribute their dirname; dirs as-is. */
+type PathKind = 'file' | 'dir';
+
+const CURSOR_WRITE_TOOLS = new Set(['Write', 'StrReplace', 'SearchReplace', 'Edit', 'ApplyPatch']);
+const CURSOR_READ_FILE_TOOLS = new Set(['Read']);
+const CURSOR_READ_PATH_TOOLS = new Set(['Glob', 'Grep', 'SemanticSearch', 'LS', 'Find']);
+
+const TIMESTAMP_RE = /<timestamp>([\s\S]*?)<\/timestamp>/i;
+const USER_QUERY_RE = /<user_query>([\s\S]*?)<\/user_query>/i;
+const USER_QUERY_OPEN_RE = /<user_query>/i;
+
+/** Per-parse cache so slug resolution is not repeated for name + root. */
+const resolveCache = new Map<string, string | undefined>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isCursorContentBlock(value: unknown): value is CursorContentBlock {
+  if (!isRecord(value) || typeof value.type !== 'string') return false;
+  if (value.text !== undefined && typeof value.text !== 'string') return false;
+  if (value.name !== undefined && typeof value.name !== 'string') return false;
+  if (value.input !== undefined && value.input !== null && !isRecord(value.input)) return false;
+  return true;
+}
+
+function isCursorMessage(value: unknown): value is CursorMessage {
+  if (!isRecord(value)) return false;
+  if (value.content === undefined) return true;
+  const content = value.content;
+  if (typeof content === 'string') return true;
+  return Array.isArray(content) && content.every(isCursorContentBlock);
+}
+
+function isCursorLine(value: unknown): value is CursorLine {
+  if (!isRecord(value)) return false;
+  if (value.role !== undefined && typeof value.role !== 'string') return false;
+  if (value.type !== undefined && typeof value.type !== 'string') return false;
+  if (value.status !== undefined && typeof value.status !== 'string') return false;
+  if (value.message !== undefined && !isCursorMessage(value.message)) return false;
+  return true;
+}
+
+function parseCursorLine(rawLine: string): CursorLine | null {
+  try {
+    const parsed: unknown = JSON.parse(rawLine);
+    if (!isCursorLine(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function parseCursorLines(raw: string): CursorLine[] {
+  const lines: CursorLine[] = [];
+  for (const rawLine of raw.split('\n')) {
+    if (!rawLine.trim()) continue;
+    const parsed = parseCursorLine(rawLine);
+    if (parsed) lines.push(parsed);
+  }
+  return lines;
+}
+
+function toContentArray(content: CursorContentBlock[] | string | undefined): CursorContentBlock[] {
+  if (Array.isArray(content)) return content;
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  return [];
+}
+
+function getTextFromLine(line: CursorLine): string {
+  return toContentArray(line.message?.content)
+    .filter(block => block.type === 'text' && block.text)
+    .map(block => block.text || '')
+    .join('\n');
+}
+
+function extractUserQuery(text: string): string {
+  const match = USER_QUERY_RE.exec(text);
+  if (match) return match[1].trim();
+  // Incomplete mid-write: open tag without close — keep text after the open tag.
+  const open = USER_QUERY_OPEN_RE.exec(text);
+  if (open) {
+    return text.slice(open.index + open[0].length).replace(TIMESTAMP_RE, '').trim();
+  }
+  return text.replace(TIMESTAMP_RE, '').trim();
+}
+
+/** A user turn is a Coach request only when it carries a <user_query> marker
+ *  (closed or still-open for incrementally written transcripts). Arbitrary
+ *  role=user text is ignored — real Cursor Agent transcripts use this wrapper. */
+function userHasRequestText(line: CursorLine): boolean {
+  if (line.role !== 'user') return false;
+  const text = getTextFromLine(line).trim();
+  if (!text) return false;
+  return USER_QUERY_OPEN_RE.test(text);
+}
+
+/** Parse Cursor's human-readable timestamp tags into epoch ms. */
+export function parseCursorTimestamp(text: string | undefined): number | null {
+  if (!text) return null;
+  const match = TIMESTAMP_RE.exec(text);
+  if (!match) return null;
+  const raw = match[1].trim();
+  const ms = Date.parse(raw);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function getInputPath(input: Record<string, unknown> | undefined, key: string): string | null {
+  const value = input?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function isAbsoluteToolPath(p: string): boolean {
+  return path.isAbsolute(p) || /^[A-Za-z]:[\\/]/.test(p) || p.startsWith('\\\\') || p.startsWith('//');
+}
+
+function toRootCandidate(fileOrDir: string, kind: PathKind): string | undefined {
+  if (!isAbsoluteToolPath(fileOrDir)) return undefined;
+  const normalized = fileOrDir.replaceAll('\\', '/');
+  if (kind === 'file') {
+    const dir = path.posix.dirname(normalized);
+    return fileOrDir.includes('\\') ? dir.replaceAll('/', '\\') : dir;
+  }
+  return fileOrDir;
+}
+
+function applyCursorToolBlock(
+  block: CursorContentBlock,
+  data: Pick<CursorAssistantData, 'toolsUsed' | 'editedFiles' | 'referencedFiles' | 'skillsUsed' | 'rootCandidates'>,
+): void {
+  if (block.type !== 'tool_use' || !block.name) return;
+
+  data.toolsUsed.push(block.name);
+  const input = block.input;
+
+  if (CURSOR_WRITE_TOOLS.has(block.name)) {
+    const filePath = getInputPath(input, 'path') || getInputPath(input, 'file_path');
+    if (filePath) {
+      data.editedFiles.push(filePath);
+      const candidate = toRootCandidate(filePath, 'file');
+      if (candidate) data.rootCandidates.push(candidate);
+    }
+    return;
+  }
+
+  if (CURSOR_READ_FILE_TOOLS.has(block.name)) {
+    const filePath = getInputPath(input, 'path') || getInputPath(input, 'file_path');
+    if (filePath) {
+      data.referencedFiles.push(filePath);
+      const candidate = toRootCandidate(filePath, 'file');
+      if (candidate) data.rootCandidates.push(candidate);
+    }
+    return;
+  }
+
+  if (block.name === 'Grep') {
+    const filePath = getInputPath(input, 'path');
+    if (filePath) {
+      data.referencedFiles.push(filePath);
+      // Grep path may be a file or a directory; treat as dir candidate when no
+      // extension-looking basename, otherwise as file. Prefer dirname of files.
+      const base = path.posix.basename(filePath.replaceAll('\\', '/'));
+      const kind: PathKind = /\.[A-Za-z0-9]+$/.test(base) ? 'file' : 'dir';
+      const candidate = toRootCandidate(filePath, kind);
+      if (candidate) data.rootCandidates.push(candidate);
+    }
+    return;
+  }
+
+  if (CURSOR_READ_PATH_TOOLS.has(block.name)) {
+    const target =
+      getInputPath(input, 'target_directory') ||
+      getInputPath(input, 'path');
+    if (target) {
+      data.referencedFiles.push(target);
+      const candidate = toRootCandidate(target, 'dir');
+      if (candidate) data.rootCandidates.push(candidate);
+    }
+  }
+}
+
+function injectWriteToolCode(block: CursorContentBlock, assistantTexts: string[]): void {
+  if (block.type !== 'tool_use' || !block.name || !CURSOR_WRITE_TOOLS.has(block.name) || !block.input) return;
+  const filePath = getInputPath(block.input, 'path') || getInputPath(block.input, 'file_path');
+  const code =
+    typeof block.input.contents === 'string' ? block.input.contents
+      : typeof block.input.content === 'string' ? block.input.content
+        : typeof block.input.new_string === 'string' ? block.input.new_string
+          : typeof block.input.new_str === 'string' ? block.input.new_str
+            : null;
+  if (!code || !filePath) return;
+  const ext = filePath.split(/[/\\]/).pop()?.split('.').pop() || 'unknown';
+  assistantTexts.push(`\`\`\`${ext}\n${code}\n\`\`\``);
+}
+
+function collectCursorAssistantData(lines: CursorLine[], startIndex: number, lastTs: number | null): CursorAssistantData {
+  const data: CursorAssistantData = {
+    nextIndex: startIndex,
+    lastTs,
+    assistantTexts: [],
+    toolsUsed: [],
+    editedFiles: [],
+    referencedFiles: [],
+    skillsUsed: [],
+    rootCandidates: [],
+    assistantCount: 0,
+    sawTurnEnded: false,
+    turnEndedError: false,
+  };
+
+  let i = startIndex;
+  while (i < lines.length) {
+    const next = lines[i];
+    if (next.role === 'user' && userHasRequestText(next)) break;
+
+    if (next.type === 'turn_ended') {
+      data.sawTurnEnded = true;
+      if (next.status && next.status !== 'success') data.turnEndedError = true;
+      i++;
+      continue;
+    }
+
+    if (next.role === 'assistant') {
+      data.assistantCount++;
+      const text = getTextFromLine(next);
+      const assistantTs = parseCursorTimestamp(text);
+      if (assistantTs && (!data.lastTs || assistantTs > data.lastTs)) data.lastTs = assistantTs;
+
+      for (const block of toContentArray(next.message?.content)) {
+        if (block.type === 'text' && block.text) {
+          data.assistantTexts.push(block.text);
+          continue;
+        }
+        applyCursorToolBlock(block, data);
+        injectWriteToolCode(block, data.assistantTexts);
+      }
+    }
+    i++;
+  }
+
+  data.nextIndex = i;
+  return data;
+}
+
+function extractSkillsFromRefs(referencedFiles: string[]): string[] {
+  const skills = new Set<string>();
+  for (const ref of referencedFiles) {
+    const name = extractSkillNameFromPath(ref);
+    if (name) skills.add(name);
+  }
+  return [...skills];
+}
+
+function buildCursorRequest(
+  userText: string,
+  userTs: number | null,
+  assistantData: CursorAssistantData,
+  requestIndex: number,
+  sessionId: string,
+): SessionRequest {
+  const uniqueRefs = [...new Set(assistantData.referencedFiles)];
+  const skills = new Set(assistantData.skillsUsed);
+  for (const name of extractSkillsFromRefs(uniqueRefs)) skills.add(name);
+
+  // endState semantics (session-types / analyzer-consumption):
+  //   errored  — turn finalized with a non-success status
+  //   no-data  — turn finalized; Cursor JSONL never records tokens
+  //   pending  — still in-flight / truncated (no turn_ended yet)
+  let endState: 'pending' | 'errored' | 'no-data';
+  if (assistantData.turnEndedError) endState = 'errored';
+  else if (assistantData.sawTurnEnded) endState = 'no-data';
+  else endState = 'pending';
+
+  return createRequest({
+    requestId: `${sessionId}-${requestIndex}`,
+    timestamp: userTs,
+    messageText: extractUserQuery(userText),
+    responseText: assistantData.assistantTexts.join('\n'),
+    agentName: 'Cursor',
+    agentMode: 'agent',
+    modelId: '',
+    toolsUsed: assistantData.toolsUsed,
+    editedFiles: [...new Set(assistantData.editedFiles)],
+    referencedFiles: uniqueRefs,
+    skillsUsed: [...skills],
+    totalElapsed: userTs && assistantData.lastTs ? assistantData.lastTs - userTs : null,
+    promptTokens: null,
+    completionTokens: null,
+    endState,
+  });
+}
+
+function updateTimestampRange(
+  ts: number | null,
+  firstTs: number | null,
+  lastTs: number | null,
+): { firstTs: number | null; lastTs: number | null } {
+  if (!ts) return { firstTs, lastTs };
+  return {
+    firstTs: !firstTs || ts < firstTs ? ts : firstTs,
+    lastTs: !lastTs || ts > lastTs ? ts : lastTs,
+  };
+}
+
+/**
+ * Longest common ancestor of absolute directory candidates.
+ * Callers must pass directories (not files) — tool-role classification happens upstream.
+ * Exported for unit tests.
+ */
+export function inferWorkspaceRootFromPaths(dirs: string[]): string | undefined {
+  const abs = dirs.filter(isAbsoluteToolPath);
+  if (abs.length === 0) return undefined;
+
+  const normalized = abs.map(p => p.replaceAll('\\', '/'));
+
+  let common = normalized[0];
+  for (let i = 1; i < normalized.length; i++) {
+    while (common && !normalized[i].startsWith(common.endsWith('/') ? common : common + '/') && normalized[i] !== common) {
+      const parent = path.posix.dirname(common);
+      if (parent === common) {
+        common = '';
+        break;
+      }
+      common = parent;
+    }
+    if (!common) break;
+  }
+  if (!common || common === '/' || /^[A-Za-z]:\/?$/.test(common)) return undefined;
+
+  if (abs[0].includes('\\')) return common.replaceAll('/', '\\');
+  return common;
+}
+
+function encodeComponentForMatch(name: string): string {
+  return name.replace(/\s/g, '-');
+}
+
+/**
+ * Resolve a Cursor project directory slug back to a human workspace name.
+ *
+ * Cursor encoding is lossy (spaces, hyphens, and path separators all become `-`).
+ * We recover a display name via best-effort filesystem matching when possible;
+ * otherwise the encoded slug itself is used. Do not treat the result as a
+ * guaranteed live path — check existsSync before using as workspaceRootPath.
+ */
+export function projectNameFromCursorEncoded(encoded: string, resolved?: string): string {
+  const pathResolved = resolved !== undefined ? resolved : resolveCursorEncodedPath(encoded);
+  if (pathResolved) {
+    // Prefer basename only when the path exists (or is a confident full match).
+    // Invented partial tails still yield a basename that is often the last folder.
+    return path.basename(pathResolved);
+  }
+  return encoded;
+}
+
+/** Best-effort absolute path from a Cursor project slug. Results are cached per process. */
+export function resolveCursorEncodedPath(encoded: string): string | undefined {
+  if (resolveCache.has(encoded)) return resolveCache.get(encoded);
+
+  const resolved = resolveCursorEncodedPathUncached(encoded);
+  resolveCache.set(encoded, resolved);
+  return resolved;
+}
+
+/** Clear the slug-resolve cache (tests only). */
+export function clearCursorResolveCache(): void {
+  resolveCache.clear();
+}
+
+function resolveCursorEncodedPathUncached(encoded: string): string | undefined {
+  if (!encoded || /^\d+$/.test(encoded)) {
+    return undefined;
+  }
+
+  const segments = encoded.split('-');
+  let root: string;
+  let startIdx: number;
+
+  // Windows drive: "e-projects-..." → "E:\"
+  if (segments.length >= 2 && /^[a-zA-Z]$/.test(segments[0])) {
+    root = `${segments[0].toUpperCase()}:\\`;
+    startIdx = 1;
+  } else {
+    // Unix-style: "home-user-..." → "/home/user/..."
+    root = '/';
+    startIdx = 0;
+  }
+
+  const remaining = segments.slice(startIdx).join('-');
+  if (!remaining) return undefined;
+
+  let resolved = root;
+  let offset = 0;
+
+  while (offset < remaining.length) {
+    let dirEntries: { name: string; encoded: string }[];
+    try {
+      dirEntries = fs.readdirSync(resolved, { withFileTypes: true })
+        .filter(e => e.isDirectory() || e.isSymbolicLink())
+        .map(e => ({ name: e.name, encoded: encodeComponentForMatch(e.name) }))
+        .sort((a, b) => b.encoded.length - a.encoded.length);
+    } catch {
+      // Missing drive, permission denied, etc. — do not invent a path.
+      return undefined;
+    }
+
+    const rest = remaining.slice(offset);
+    let found = false;
+    for (const entry of dirEntries) {
+      if (rest === entry.encoded) {
+        resolved = path.join(resolved, entry.name);
+        offset = remaining.length;
+        found = true;
+        break;
+      }
+      if (rest.startsWith(entry.encoded + '-')) {
+        resolved = path.join(resolved, entry.name);
+        offset += entry.encoded.length + 1;
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      // Partial matches are ambiguous under a lossy encoding — refuse rather
+      // than return a too-shallow path (e.g. `/home`) that happens to exist.
+      return undefined;
+    }
+  }
+
+  return resolved;
+}
+
+export function findCursorDirs(): string[] {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  if (!home) return [];
+  const projectsDir = path.join(home, '.cursor', 'projects');
+  if (fs.existsSync(projectsDir)) return [projectsDir];
+  return [];
+}
+
+function pickWorkspaceRoot(decodedPath: string | undefined, toolCandidates: string[]): string | undefined {
+  if (decodedPath && fs.existsSync(decodedPath)) return decodedPath;
+  return inferWorkspaceRootFromPaths(toolCandidates);
+}
+
+function parseCursorSessionFile(
+  filePath: string,
+  wsId: string,
+  wsName: string,
+  decodedPath?: string,
+): Session | null {
+  assertTrustedPath(filePath);
+  let raw: string;
+  try {
+    const content = readFileSafe(filePath);
+    if (content === null) return null;
+    raw = content;
+  } catch {
+    return null;
+  }
+
+  const lines = parseCursorLines(raw);
+  if (lines.length === 0) return null;
+
+  const sessionId = path.basename(filePath, '.jsonl');
+  const requests: SessionRequest[] = [];
+  const rootCandidates: string[] = [];
+  let firstTs: number | null = null;
+  let lastTs: number | null = null;
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!userHasRequestText(line)) {
+      i++;
+      continue;
+    }
+
+    const userText = getTextFromLine(line);
+    const userTs = parseCursorTimestamp(userText);
+    ({ firstTs, lastTs } = updateTimestampRange(userTs, firstTs, lastTs));
+
+    const assistantData = collectCursorAssistantData(lines, i + 1, lastTs);
+    lastTs = assistantData.lastTs ?? lastTs;
+    for (const p of assistantData.rootCandidates) rootCandidates.push(p);
+
+    requests.push(buildCursorRequest(userText, userTs, assistantData, requests.length, sessionId));
+    i = assistantData.nextIndex;
+  }
+
+  if (requests.length === 0) return null;
+
+  const workspaceRootPath = pickWorkspaceRoot(decodedPath, rootCandidates);
+  return createSession({
+    sessionId,
+    workspaceId: wsId,
+    workspaceName: wsName,
+    location: 'panel',
+    harness: 'Cursor',
+    creationDate: firstTs,
+    lastMessageDate: lastTs,
+    requests,
+    hasDevcontainer: detectDevcontainerFromRequests(requests, workspaceRootPath),
+    workspaceRootPath,
+  });
+}
+
+function parseCursorProjectSessions(
+  projectsDir: string,
+  dirName: string,
+): { sessions: Session[]; workspaceId: string; workspaceName: string } | null {
+  const projPath = path.join(projectsDir, dirName);
+  const transcriptsRoot = path.join(projPath, 'agent-transcripts');
+  if (!fs.existsSync(transcriptsRoot)) return null;
+
+  const workspaceId = `cursor-${dirName}`;
+  const decodedPath = resolveCursorEncodedPath(dirName);
+  const workspaceName = projectNameFromCursorEncoded(dirName, decodedPath);
+
+  let sessionDirs: fs.Dirent[];
+  try {
+    sessionDirs = fs.readdirSync(transcriptsRoot, { withFileTypes: true }).filter(e => e.isDirectory());
+  } catch {
+    return null;
+  }
+
+  const sessionsById = new Map<string, Session>();
+  const sessions: Session[] = [];
+  const existingDecoded = decodedPath && fs.existsSync(decodedPath) ? decodedPath : undefined;
+
+  // Pass 1: parent session JSONL files
+  for (const entry of sessionDirs) {
+    const sessionFile = path.join(transcriptsRoot, entry.name, `${entry.name}.jsonl`);
+    if (!fs.existsSync(sessionFile)) continue;
+    const session = parseCursorSessionFile(sessionFile, workspaceId, workspaceName, existingDecoded);
+    if (!session) continue;
+    sessions.push(session);
+    sessionsById.set(session.sessionId, session);
+  }
+
+  // Pass 2: merge subagents into parents (or emit orphans) — Claude pattern
+  for (const entry of sessionDirs) {
+    const subagentDir = path.join(transcriptsRoot, entry.name, 'subagents');
+    let subagentEntries: fs.Dirent[];
+    try {
+      subagentEntries = fs.readdirSync(subagentDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    const parent = sessionsById.get(entry.name);
+    const orphanRequests: SessionRequest[] = [];
+    let orphanFirstTs: number | null = null;
+    let orphanLastTs: number | null = null;
+
+    for (const subEntry of subagentEntries) {
+      if (!subEntry.isFile() || !subEntry.name.endsWith('.jsonl')) continue;
+      const subSession = parseCursorSessionFile(
+        path.join(subagentDir, subEntry.name),
+        workspaceId,
+        workspaceName,
+        existingDecoded,
+      );
+      if (!subSession) continue;
+
+      if (parent) {
+        for (const r of subSession.requests) parent.requests.push(r);
+        if (subSession.lastMessageDate &&
+            (!parent.lastMessageDate || subSession.lastMessageDate > parent.lastMessageDate)) {
+          parent.lastMessageDate = subSession.lastMessageDate;
+        }
+        if (subSession.creationDate &&
+            (!parent.creationDate || subSession.creationDate < parent.creationDate)) {
+          parent.creationDate = subSession.creationDate;
+        }
+        if (!parent.workspaceRootPath && subSession.workspaceRootPath) {
+          parent.workspaceRootPath = subSession.workspaceRootPath;
+        }
+      } else {
+        for (const r of subSession.requests) orphanRequests.push(r);
+        if (subSession.creationDate &&
+            (!orphanFirstTs || subSession.creationDate < orphanFirstTs)) {
+          orphanFirstTs = subSession.creationDate;
+        }
+        if (subSession.lastMessageDate &&
+            (!orphanLastTs || subSession.lastMessageDate > orphanLastTs)) {
+          orphanLastTs = subSession.lastMessageDate;
+        }
+      }
+    }
+
+    if (parent) continue;
+
+    if (orphanRequests.length > 0) {
+      warnCore('parser-cursor', `subagent dir without parent session: ${entry.name}`, {
+        requestCount: orphanRequests.length,
+      });
+      orphanRequests.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+      const orphan = createSession({
+        sessionId: entry.name,
+        workspaceId,
+        workspaceName,
+        location: 'panel',
+        harness: 'Cursor',
+        creationDate: orphanFirstTs,
+        lastMessageDate: orphanLastTs,
+        requests: orphanRequests,
+        workspaceRootPath: existingDecoded,
+      });
+      sessions.push(orphan);
+    }
+  }
+
+  for (const session of sessions) {
+    if (session.requests.length > 1) {
+      session.requests.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
+    }
+    session.requestCount = session.requests.length;
+  }
+
+  return sessions.length > 0 ? { sessions, workspaceId, workspaceName } : null;
+}
+
+export function parseCursorSessions(projectsDir: string): { sessions: Session[]; workspaceId: string; workspaceName: string }[] {
+  const results: { sessions: Session[]; workspaceId: string; workspaceName: string }[] = [];
+
+  let projectDirs: fs.Dirent[];
+  try {
+    projectDirs = fs.readdirSync(projectsDir, { withFileTypes: true }).filter(e => e.isDirectory());
+  } catch {
+    return results;
+  }
+
+  for (const projDir of projectDirs) {
+    const result = parseCursorProjectSessions(projectsDir, projDir.name);
+    if (result) results.push(result);
+  }
+
+  return results;
+}
+
+export async function parseCursorSessionsAsync(
+  projectsDir: string,
+  onProject?: (idx: number, total: number, name: string) => void,
+): Promise<{ sessions: Session[]; workspaceId: string; workspaceName: string }[]> {
+  const results: { sessions: Session[]; workspaceId: string; workspaceName: string }[] = [];
+
+  let projectDirs: string[];
+  try {
+    projectDirs = (await fs.promises.readdir(projectsDir, { withFileTypes: true }))
+      .filter(e => e.isDirectory())
+      .map(e => e.name);
+  } catch {
+    return results;
+  }
+
+  for (let i = 0; i < projectDirs.length; i++) {
+    const dirName = projectDirs[i];
+    const decoded = resolveCursorEncodedPath(dirName);
+    const workspaceName = projectNameFromCursorEncoded(dirName, decoded);
+    if (onProject) onProject(i + 1, projectDirs.length, workspaceName);
+
+    const result = parseCursorProjectSessions(projectsDir, dirName);
+    if (result) results.push(result);
+
+    if (i % 5 === 0) await new Promise<void>(r => setTimeout(r, 0));
+  }
+
+  return results;
+}

--- a/src/core/parser-harnesses.test.ts
+++ b/src/core/parser-harnesses.test.ts
@@ -11,7 +11,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { describe, it, expect } from 'vitest';
-import { hasExternalHarnessSources } from './parser-harnesses';
+import { EXTERNAL_HARNESS_SET, hasExternalHarnessSources } from './parser-harnesses';
 
 function setEnv(key: 'HOME' | 'USERPROFILE', value: string | undefined): void {
   if (value === undefined) delete process.env[key]; else process.env[key] = value;
@@ -36,6 +36,12 @@ function withHome(setup: (home: string) => void, body: () => void): void {
   }
 }
 
+describe('EXTERNAL_HARNESS_SET', () => {
+  it('includes the canonical Cursor harness id', () => {
+    expect(EXTERNAL_HARNESS_SET.has('Cursor')).toBe(true);
+  });
+});
+
 describe('hasExternalHarnessSources', () => {
   it('returns false when no external-harness directories exist', () => {
     withHome(() => { /* empty home */ }, () => {
@@ -46,6 +52,14 @@ describe('hasExternalHarnessSources', () => {
   it('returns true when a Claude Code projects directory exists', () => {
     withHome(home => {
       fs.mkdirSync(path.join(home, '.claude', 'projects'), { recursive: true });
+    }, () => {
+      expect(hasExternalHarnessSources()).toBe(true);
+    });
+  });
+
+  it('returns true when a Cursor projects directory exists', () => {
+    withHome(home => {
+      fs.mkdirSync(path.join(home, '.cursor', 'projects'), { recursive: true });
     }, () => {
       expect(hasExternalHarnessSources()).toBe(true);
     });

--- a/src/core/parser-harnesses.ts
+++ b/src/core/parser-harnesses.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import { Workspace, Session } from './types';
 import { findClaudeDirs, parseClaudeSessions, parseClaudeSessionsAsync } from './parser-claude';
 import { findCodexDirs, parseCodexSessions } from './parser-codex';
+import { findCursorDirs, parseCursorSessions, parseCursorSessionsAsync } from './parser-cursor';
 import { findOpenCodeDirs, parseOpenCodeSessions } from './parser-opencode';
 
 type WorkspaceMap = Map<string, Workspace>;
@@ -69,6 +70,26 @@ const EXTERNAL_HARNESSES: ExternalHarnessCollector[] = [
       }
     },
   },
+  {
+    name: 'Cursor Agent',
+    collectSync(ctx) {
+      for (const cursorDir of findCursorDirs()) {
+        for (const { sessions } of parseCursorSessions(cursorDir)) {
+          for (const session of sessions) addSession(ctx.workspaces, ctx.sessions, session, cursorDir);
+        }
+      }
+    },
+    async collectAsync(ctx, reportDetail) {
+      for (const cursorDir of findCursorDirs()) {
+        const results = await parseCursorSessionsAsync(cursorDir, (idx, total, name) => {
+          reportDetail?.(`${idx}/${total}: ${name}`);
+        });
+        for (const { sessions } of results) {
+          for (const session of sessions) addSession(ctx.workspaces, ctx.sessions, session, cursorDir);
+        }
+      }
+    },
+  },
 ];
 
 export interface ExternalHarnessProgressHandlers {
@@ -78,17 +99,20 @@ export interface ExternalHarnessProgressHandlers {
   yieldToLoop?: () => Promise<void>;
 }
 
-/** Returns true if any external-harness (Claude Code, Codex, OpenCode) session
- *  source exists on disk. The dashboard uses this so it does not abort when the
- *  only available logs come from a non-VS Code harness — e.g. a headless
- *  Remote-SSH host that has Claude Code sessions under `~/.claude/projects` but
- *  no VS Code workspace storage or Copilot directories. */
+/** Returns true if any external-harness (Claude Code, Codex, OpenCode, Cursor)
+ *  session source exists on disk. The dashboard uses this so it does not abort
+ *  when the only available logs come from a non-VS Code harness — e.g. a
+ *  headless Remote-SSH host that has Claude Code sessions under
+ *  `~/.claude/projects` but no VS Code workspace storage or Copilot directories. */
 export function hasExternalHarnessSources(): boolean {
   // Without a home directory the find* helpers would join against an empty
   // string and probe relative paths (e.g. `.claude/projects`) under the current
   // working directory, which could report false positives. Bail out instead.
   if (!process.env.HOME && !process.env.USERPROFILE) return false;
-  return findClaudeDirs().length > 0 || findCodexDirs().length > 0 || findOpenCodeDirs().length > 0;
+  return findClaudeDirs().length > 0
+    || findCodexDirs().length > 0
+    || findOpenCodeDirs().length > 0
+    || findCursorDirs().length > 0;
 }
 
 export function collectExternalHarnessesSync(workspaces: WorkspaceMap, sessions: Session[]): void {
@@ -106,6 +130,7 @@ export const EXTERNAL_HARNESS_SET = new Set<string>([
   'Claude',
   'Codex',
   'OpenCode',
+  'Cursor',
 ]);
 
 export async function collectExternalHarnessesAsync(

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -61,6 +61,7 @@ function getTrustedRoots(): string[] {
     roots.push(path.resolve(home, '.copilot'));
     roots.push(path.resolve(home, '.claude'));
     roots.push(path.resolve(home, '.codex'));
+    roots.push(path.resolve(home, '.cursor'));
     roots.push(path.resolve(home, '.local', 'share', 'opencode'));
     roots.push(path.resolve(home, '.config', 'github-copilot'));
   }

--- a/src/webview/shared.ts
+++ b/src/webview/shared.ts
@@ -351,6 +351,7 @@ export const HARNESS_COLORS: Record<string, string> = {
 
   'Codex': '#10b981',
   'OpenCode': '#8b5cf6',
+  'Cursor': '#e11d48',
 };
 
 export function harnessColor(name: string, idx: number): string {


### PR DESCRIPTION
## Summary

Adds support for analyzing Cursor Agent usage in AI Engineering Coach.

The Cursor Agent stores session transcripts locally under:

`~/.cursor/projects/**/agent-transcripts/**/*.jsonl`

This change adds a dedicated Cursor harness parser that integrates with the existing session/request model and external harness pipeline.

## What's included

- Add Cursor Agent transcript discovery and parsing
- Add Cursor sessions and requests to the existing harness pipeline
- Parse assistant responses and tool usage
- Track referenced and edited files
- Support Cursor subagents and orphan subagents
- Infer workspace information from Cursor project paths and tool paths
- Add Cursor to harness filtering and dashboard display
- Add tests covering parsing, requests, subagents, workspace resolution and error cases
- Update supported harness documentation

## Limitations

Cursor Agent transcripts currently do not expose reliable token usage or model information, so these values are left unavailable rather than estimated.

Workspace resolution is necessarily conservative because Cursor's project directory names use a lossy encoding.

The implementation reads the local `agent-transcripts` files and does not depend on Cursor's internal `state.vscdb`.

## Testing

- Added unit tests for the Cursor parser and harness discovery
- Existing test suite remains unchanged for other harnesses
- Tested against Cursor Agent transcript structures