### PR TITLE
ci: ship a verifiable VSIX to releases and add gated Marketplace/Open VSX publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # create the release and upload its assets
+      id-token: write # sign the build provenance attestation
+      attestations: write
 
     steps:
       - name: Checkout
@@ -45,6 +50,9 @@ jobs:
       - name: Package VSIX
         run: npm run package
 
+      - name: Check bundle size
+        run: npm run check-size
+
       - name: Capture VSIX path
         id: vsix
         run: |
@@ -53,14 +61,44 @@ jobs:
             echo "No VSIX package was produced"
             exit 1
           fi
+          VSIX_NAME="$(basename "$VSIX_PATH")"
+          sha256sum "$VSIX_NAME" > "$VSIX_NAME.sha256"
           echo "path=$VSIX_PATH" >> "$GITHUB_OUTPUT"
+          echo "checksum=$VSIX_NAME.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ${{ steps.vsix.outputs.path }}
 
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          files: ${{ steps.vsix.outputs.path }}
+          files: |
+            ${{ steps.vsix.outputs.path }}
+            ${{ steps.vsix.outputs.checksum }}
           generate_release_notes: true
+
+      # Marketplace publishing stays inert until a maintainer registers the publisher and sets
+      # the PUBLISH_MARKETPLACE repository variable plus the VSCE_PAT secret. The exact bytes
+      # attached to the release are the bytes published, so the checksum and attestation hold.
+      - name: Publish to VS Code Marketplace
+        if: startsWith(github.ref, 'refs/tags/') && vars.PUBLISH_MARKETPLACE == 'true'
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSIX_PATH: ${{ steps.vsix.outputs.path }}
+        run: npx vsce publish --packagePath "$VSIX_PATH" --skip-duplicate
+
+      # Open VSX serves VS Code OSS builds (VSCodium, Antigravity and friends), which cannot
+      # reach the Microsoft Marketplace. Gated the same way, on PUBLISH_OPENVSX and OVSX_PAT.
+      - name: Publish to Open VSX
+        if: startsWith(github.ref, 'refs/tags/') && vars.PUBLISH_OPENVSX == 'true'
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          VSIX_PATH: ${{ steps.vsix.outputs.path }}
+        run: npx --yes ovsx@1.1.1 publish "$VSIX_PATH" --skip-duplicate
 
       - name: Upload VSIX artifact
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -25,6 +25,16 @@ dist/**/*.map
 # Docs scaffolding (only publish README + LICENSE + dist)
 README.github.md
 SECURITY.md
+AGENTS.md
+
+# Screenshots belong to the GitHub README and the store listing, not to every install.
+# assets/icon.png stays — it is the extension icon and the chat participant icon.
+assets/screen-*.png
+assets/icon.svg
+
+# Repo-authoring context for agents working on this codebase — nothing reads it at runtime
+skills/**
+.claude/**
 
 # Dev-only config & tooling — not needed at runtime
 .husky/**


### PR DESCRIPTION
Towards #92. Also unblocks the duplicate cluster #123, #130 and #140 once a tag is pushed.

## What I found

The automation for "Option 1 — prebuilt VSIX via GH releases" already exists. `release.yml` builds, tests, packages and attaches the `.vsix` on any `v*.*.*` tag. It has simply never run: the repo has **zero tags**, and the file has only ever been touched by Dependabot since the initial commit. So the gap is not a missing pipeline — it is (a) no tag has been cut, (b) nothing publishes to a marketplace, and (c) nothing about the artifact is verifiable, which is what the issue's enterprise angle actually asks for.

This PR closes (b) and (c), and tightens the artifact before the first publish makes it permanent. It deliberately does **not** touch the README — advertising a release that does not exist yet is exactly the bug reported in #123. That doc flip belongs in the PR that lands alongside the first tag.

## Changes

**`.github/workflows/release.yml`**

- Emit a `.sha256` beside the VSIX and attach both to the release.
- Attest build provenance (`actions/attest-build-provenance`, SHA-pinned), so anyone can run `gh attestation verify ai-engineer-coach-<version>.vsix --repo microsoft/AI-Engineering-Coach` on the download.
- Run `check-size` in the release job, not only in CI, so an oversized VSIX cannot reach a release.
- Publish to the VS Code Marketplace and to Open VSX with `--packagePath`, so the bytes on the release, on the Marketplace and on Open VSX are byte-identical and the checksum/attestation cover all three. Open VSX matters for VS Code OSS builds (VSCodium, Antigravity), which cannot reach the Microsoft Marketplace — see #41.
- Both publish steps are gated on `vars.PUBLISH_MARKETPLACE` / `vars.PUBLISH_OPENVSX`, so this merges inert and stays a no-op until maintainers opt in. Secrets are passed through `env:` rather than interpolated into `run:`.
- Workflow-level permissions narrowed to `contents: read`, elevated only on the release job.

**`.vscodeignore`**

The package was carrying 2.5 MB of README screenshots plus `AGENTS.md`, `skills/` and `.claude/`, none of which are read at runtime. `assets/icon.png` stays — it is both the extension icon and the chat participant icon (`src/chat/participant.ts`).

## Verification

`npm ci && npm run package && npm run check-size` locally:

| | before | after |
|---|---|---|
| VSIX size | 3.35 MB | **1.04 MB** |
| files | 94 | **73** |

`dist/` and `assets/icon.png` are intact; `check-size` passes both budgets. The workflow YAML parses clean.

## What still needs a maintainer

1. **Push a tag.** `git tag v0.1.0 && git push origin v0.1.0` produces the first release on its own, even with zero further changes. That alone resolves #123/#130/#140.
2. **Register the publisher.** `package.json` claims `publisher: "ai-engineer-coach"`, which has to exist on the Marketplace and be owned by the org. This sets the permanent extension ID, so it is worth deciding before the first publish.
3. **Pick an auth method.** The pinned `@vscode/vsce` (3.9.2) supports `VSCE_PAT` and `--azure-credential` (Entra ID), but not `--oidc` — trusted publishing only exists on `vsce` main / the 3.9.3 prereleases. Note Azure DevOps retires global PATs on 2026-12-01, so `VSCE_PAT` is a stopgap and `--azure-credential` is the durable path. Happy to switch the step over if that is the preference.

## One thing worth flagging separately

`engines.vscode` is `^1.125.0`, while the README badge says 1.115+, `README.extension.md` says 1.85+ and `skills/package-extension.md` says ^1.120.0. Once this is on the Marketplace, `engines` becomes load-bearing: everyone below 1.125 gets "not compatible", which reproduces #41 for the published artifact. Settling on a real minimum needs an API-usage audit, so I left it alone rather than guessing.
