### PR TITLE
ci: request maintainer reviews on new pull requests

### DIFF
--- a/.github/workflows/request-pull-request-reviews.yml
+++ b/.github/workflows/request-pull-request-reviews.yml
@@ -1,0 +1,31 @@
+name: Request pull request reviews
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request maintainer reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          reviewers=()
+          for reviewer in san360 aymenfurter TamasBoncz; do
+            if [[ "${reviewer,,}" != "${PR_AUTHOR,,}" ]]; then
+              reviewers+=(-f "reviewers[]=$reviewer")
+            fi
+          done
+
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/requested_reviewers" \
+            "${reviewers[@]}"


### PR DESCRIPTION
## Description

Automatically request reviews from `san360`, `aymenfurter`, and `TamasBoncz` when a pull request is opened. The workflow excludes the pull request author because GitHub does not permit self-review.

The workflow uses `pull_request_target` with only `pull-requests: write` permission and does not check out or execute pull request code.

## Related Issues

N/A

## Checklist

- [x] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [x] Changes are covered by tests (if applicable)
- [x] Documentation updated (if applicable)