### PR TITLE
feat: support latest VS Code chat transcript sessions

### DIFF
--- a/docs/content/getting-started/supported-tools.md
+++ b/docs/content/getting-started/supported-tools.md
@@ -14,9 +14,11 @@ The primary harness. AI Engineer Coach parses the chat panel logs that GitHub Co
 
 When VS Code connects through Remote-WSL, Remote-SSH, or a Dev Container, the logs live on the remote host under `~/.vscode-server/data/User/workspaceStorage/` (or `~/.vscode-server-insiders/data/User/workspaceStorage/` for Insiders) and appear in the dashboard as `Local Agent (Server)` or `Local Agent (Server Insiders)`.
 
+Newer VS Code / Copilot Chat builds write sessions as `GitHub.copilot-chat/transcripts/*.jsonl` instead of `chatSessions/*.json`; both formats are read automatically. The transcript format has no `workspace.json` sidecar, so the workspace folder shown in the dashboard is inferred from the files those sessions edited — sessions that only read files (e.g. via a subagent) may show up under the raw workspace-storage id instead of the repo name.
+
 **What is tracked:**
 - Requests and responses with timestamps
-- Model selection (e.g., `claude-opus-4.6`, `gpt-5.4`, `auto`)
+- Model selection (e.g., `claude-opus-4.6`, `gpt-5.4`, `auto`) — not available for `transcripts/*.jsonl` sessions, which don't record model or token usage
 - Tool calls and slash commands used
 - File context references (`#file`, open editor tabs)
 - Terminal command execution

--- a/src/core/cache.test.ts
+++ b/src/core/cache.test.ts
@@ -167,6 +167,21 @@ describe('computeDirMetas', () => {
     expect(metas[wsDir].editCount).toBe(2);
   });
 
+  it('fingerprints GitHub.copilot-chat/transcripts (sync and async agree)', async () => {
+    const logsDir = makeTempDir();
+    const wsDir = path.join(logsDir, 'workspace1');
+    const transcriptsDir = path.join(wsDir, 'GitHub.copilot-chat', 'transcripts');
+    fs.mkdirSync(transcriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(transcriptsDir, 'sess1.jsonl'), '{}');
+    fs.writeFileSync(path.join(transcriptsDir, 'sess2.jsonl'), '{}');
+
+    const syncMetas = computeDirMetas([logsDir]);
+    const asyncMetas = await computeDirMetasAsync([logsDir]);
+
+    expect(syncMetas[wsDir].transcriptCount).toBe(2);
+    expect(asyncMetas[wsDir].transcriptCount).toBe(2);
+  });
+
   it('invalidates edit fingerprints when an existing state.json is rewritten', async () => {
     const logsDir = makeTempDir();
     const wsDir = path.join(logsDir, 'workspace1');
@@ -241,6 +256,18 @@ describe('findStaleDirs', () => {
     const { stale, removed } = findStaleDirs(current, cached);
     expect(stale.size).toBe(0);
     expect(removed.has('/ws2')).toBe(true);
+  });
+
+  it('detects stale dirs when only the transcripts fingerprint differs', () => {
+    const current: DirMetas = {
+      '/ws1': { chatCount: 0, chatMaxMtime: 0, editCount: 0, editMaxMtime: 0, transcriptCount: 2, transcriptMaxMtime: 500 },
+    };
+    const cached: DirMetas = {
+      '/ws1': { chatCount: 0, chatMaxMtime: 0, editCount: 0, editMaxMtime: 0, transcriptCount: 1, transcriptMaxMtime: 400 },
+    };
+
+    const { stale } = findStaleDirs(current, cached);
+    expect(stale.has('/ws1')).toBe(true);
   });
 
   it('marks new dirs as stale', () => {

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -18,6 +18,7 @@ import { EditLoc, EditLocIndex } from './edit-loc-diff';
 import { warnCore } from './log';
 import { parseSessionFile } from './parser-vscode';
 import { parseCLIEventsFile } from './parser-vscode-cli';
+import { parseTranscriptFile } from './parser-vscode-transcripts';
 import { stripSingleSession } from './parser-shared';
 
 export interface ParseResult {
@@ -31,7 +32,7 @@ export interface ParseResult {
 }
 
 export interface SessionSource {
-  kind: 'vscode-session-file' | 'cli-events';
+  kind: 'vscode-session-file' | 'cli-events' | 'vscode-transcript';
   filePath: string;
   workspaceId: string;
   workspaceName: string;
@@ -45,6 +46,10 @@ export interface DirMeta {
   chatMaxMtime: number;
   editCount: number;
   editMaxMtime: number;
+  /** Fingerprint of `GitHub.copilot-chat/transcripts` — the format that replaced `chatSessions`
+   *  in newer VS Code builds. Optional so existing cache entries/tests need no migration. */
+  transcriptCount?: number;
+  transcriptMaxMtime?: number;
 }
 
 export type DirMetas = Record<string, DirMeta>;
@@ -203,12 +208,15 @@ export function computeDirMetas(logsDirs: string[]): DirMetas {
         // A dir's mtime changes when files are added/removed/renamed inside it.
         const chat = dirFingerprint(path.join(wsPath, 'chatSessions'));
         const edit = dirFingerprint(path.join(wsPath, 'chatEditingSessions'), true);
+        const transcript = dirFingerprint(path.join(wsPath, 'GitHub.copilot-chat', 'transcripts'));
 
         metas[wsPath] = {
           chatCount: chat.count,
           chatMaxMtime: chat.mtime,
           editCount: edit.count,
           editMaxMtime: edit.mtime,
+          transcriptCount: transcript.count,
+          transcriptMaxMtime: transcript.mtime,
         };
       }
     } catch { /* cannot read logsDir */ }
@@ -244,11 +252,12 @@ export async function computeDirMetasAsync(logsDirs: string[]): Promise<DirMetas
     const batch = wsPaths.slice(i, i + CONCURRENCY);
     const results = await Promise.allSettled(
       batch.map(async wsPath => {
-        const [chat, edit] = await Promise.all([
+        const [chat, edit, transcript] = await Promise.all([
           dirFingerprintAsync(path.join(wsPath, 'chatSessions')),
           dirFingerprintAsync(path.join(wsPath, 'chatEditingSessions'), true),
+          dirFingerprintAsync(path.join(wsPath, 'GitHub.copilot-chat', 'transcripts')),
         ]);
-        return { wsPath, chat, edit };
+        return { wsPath, chat, edit, transcript };
       })
     );
     for (const r of results) {
@@ -258,6 +267,8 @@ export async function computeDirMetasAsync(logsDirs: string[]): Promise<DirMetas
           chatMaxMtime: r.value.chat.mtime,
           editCount: r.value.edit.count,
           editMaxMtime: r.value.edit.mtime,
+          transcriptCount: r.value.transcript.count,
+          transcriptMaxMtime: r.value.transcript.mtime,
         };
       }
     }
@@ -271,7 +282,9 @@ function dirMetaMatches(a: DirMeta, b: DirMeta): boolean {
   return a.chatCount === b.chatCount &&
     a.chatMaxMtime === b.chatMaxMtime &&
     a.editCount === b.editCount &&
-    a.editMaxMtime === b.editMaxMtime;
+    a.editMaxMtime === b.editMaxMtime &&
+    (a.transcriptCount ?? 0) === (b.transcriptCount ?? 0) &&
+    (a.transcriptMaxMtime ?? 0) === (b.transcriptMaxMtime ?? 0);
 }
 
 export function findStaleDirs(
@@ -461,6 +474,9 @@ export async function loadSessionFromDisk(sessionId: string): Promise<Session | 
 
     if (source.kind === 'cli-events') {
       return parseCLIEventsFile(source.filePath, source.workspaceId, source.workspaceName);
+    }
+    if (source.kind === 'vscode-transcript') {
+      return parseTranscriptFile(source.filePath, source.workspaceId, source.workspaceName, source.harness);
     }
     return parseSessionFile(source.filePath, source.workspaceId, source.workspaceName, source.harness);
   } catch {

--- a/src/core/parser-shared.ts
+++ b/src/core/parser-shared.ts
@@ -196,6 +196,8 @@ export interface ParseTiming {
   editMs: number;
   /** Cumulative ms spent parsing CLI events.jsonl files. */
   cliMs: number;
+  /** Cumulative ms spent parsing GitHub.copilot-chat/transcripts files. */
+  transcriptMs: number;
   /** Number of chat session files parsed. */
   chatFiles: number;
   /** Number of edit-state files parsed. */
@@ -204,12 +206,13 @@ export interface ParseTiming {
   forcedGc: number;
 }
 
-const parseTiming: ParseTiming = { chatMs: 0, editMs: 0, cliMs: 0, chatFiles: 0, editFiles: 0, forcedGc: 0 };
+const parseTiming: ParseTiming = { chatMs: 0, editMs: 0, cliMs: 0, transcriptMs: 0, chatFiles: 0, editFiles: 0, forcedGc: 0 };
 
 /** Accumulate elapsed time (ms) for a cold-parse sub-step. */
-export function addParseTiming(kind: 'chat' | 'edit' | 'cli', ms: number): void {
+export function addParseTiming(kind: 'chat' | 'edit' | 'cli' | 'transcript', ms: number): void {
   if (kind === 'chat') { parseTiming.chatMs += ms; parseTiming.chatFiles++; }
   else if (kind === 'edit') { parseTiming.editMs += ms; parseTiming.editFiles++; }
+  else if (kind === 'transcript') { parseTiming.transcriptMs += ms; }
   else parseTiming.cliMs += ms;
 }
 
@@ -218,6 +221,7 @@ export function resetParseTiming(): void {
   parseTiming.chatMs = 0;
   parseTiming.editMs = 0;
   parseTiming.cliMs = 0;
+  parseTiming.transcriptMs = 0;
   parseTiming.chatFiles = 0;
   parseTiming.editFiles = 0;
   parseTiming.forcedGc = 0;

--- a/src/core/parser-vscode-transcripts.test.ts
+++ b/src/core/parser-vscode-transcripts.test.ts
@@ -1,0 +1,157 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Tests for the GitHub Copilot Chat "transcripts" parser — the session storage format that
+ * replaced `chatSessions/*.json` in newer VS Code / Copilot Chat builds. */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, it, expect, beforeEach } from 'vitest';
+import { parseTranscriptFile } from './parser-vscode-transcripts';
+import { getParseWarningCounts, resetParseWarnings } from './parser-shared';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-engineer-coach-transcript-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeTranscript(events: Array<Record<string, unknown>>): string {
+  const dir = makeTempDir();
+  const fp = path.join(dir, 'transcript.jsonl');
+  fs.writeFileSync(fp, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  return fp;
+}
+
+const REPO_FILE_A = '/home/user/go/src/example/iam/onboarding_service/organization.go';
+const REPO_FILE_B = '/home/user/go/src/example/iam/tenant_management_service/client.go';
+
+const SAMPLE_EVENTS: Array<Record<string, unknown>> = [
+  { type: 'session.start', timestamp: '2026-06-10T11:02:38.261Z', data: { sessionId: 'sess-abc', version: 1, producer: 'copilot-agent', copilotVersion: '0.51.1', vscodeVersion: '1.123.1', startTime: '2026-06-10T11:02:38.261Z' } },
+  { type: 'user.message', id: 'u1', timestamp: '2026-06-10T11:02:38.262Z', data: { content: 'fix the org lookup bug', attachments: [] } },
+  { type: 'assistant.turn_start', timestamp: '2026-06-10T11:02:38.300Z', data: { turnId: '0' } },
+  { type: 'tool.execution_start', timestamp: '2026-06-10T11:02:38.400Z', data: { toolCallId: 'call-1', toolName: 'read_file', arguments: { filePath: REPO_FILE_A, startLine: 1, endLine: 40 } } },
+  { type: 'tool.execution_complete', timestamp: '2026-06-10T11:02:38.500Z', data: { toolCallId: 'call-1', success: true } },
+  { type: 'tool.execution_start', timestamp: '2026-06-10T11:02:38.600Z', data: { toolCallId: 'call-2', toolName: 'replace_string_in_file', arguments: { filePath: REPO_FILE_A, oldString: 'old line', newString: 'new line\nsecond line' } } },
+  { type: 'tool.execution_complete', timestamp: '2026-06-10T11:02:38.700Z', data: { toolCallId: 'call-2', success: true } },
+  { type: 'assistant.message', id: 'a1', timestamp: '2026-06-10T11:02:51.307Z', data: { messageId: 'msg-1', content: 'Fixed the lookup bug.', toolRequests: [], reasoningText: '' } },
+  { type: 'assistant.turn_end', timestamp: '2026-06-10T11:02:51.307Z', data: { turnId: '0' } },
+];
+
+beforeEach(() => resetParseWarnings());
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('parseTranscriptFile', () => {
+  it('parses a well-formed transcript into a session', () => {
+    const fp = writeTranscript(SAMPLE_EVENTS);
+    const session = parseTranscriptFile(fp, 'ws-1', 'ws-1', 'Local Agent');
+
+    expect(session).not.toBeNull();
+    expect(session!.sessionId).toBe('sess-abc');
+    expect(session!.harness).toBe('Local Agent');
+    expect(session!.workspaceId).toBe('ws-1');
+    expect(session!.endReason).toBe('unknown');
+    expect(session!.requests).toHaveLength(1);
+
+    const req = session!.requests[0];
+    expect(req.messageText).toBe('fix the org lookup bug');
+    expect(req.responseText).toBe('Fixed the lookup bug.');
+    expect(req.toolsUsed).toEqual(expect.arrayContaining(['read_file', 'replace_string_in_file']));
+    expect(req.referencedFiles).toContain(REPO_FILE_A);
+    expect(req.editedFiles).toContain(REPO_FILE_A);
+    expect(req.endState).toBe('no-data');
+    expect(req.completionTokens).toBeNull();
+  });
+
+  it('derives workspaceRootPath from the common directory of edited files', () => {
+    const events: Array<Record<string, unknown>> = [
+      ...SAMPLE_EVENTS,
+      { type: 'user.message', timestamp: '2026-06-10T11:03:00.000Z', data: { content: 'also fix the client' } },
+      { type: 'tool.execution_start', timestamp: '2026-06-10T11:03:00.100Z', data: { toolCallId: 'call-3', toolName: 'create_file', arguments: { filePath: REPO_FILE_B, content: 'package tenant\n' } } },
+      { type: 'tool.execution_complete', timestamp: '2026-06-10T11:03:00.200Z', data: { toolCallId: 'call-3', success: true } },
+      { type: 'assistant.message', id: 'a2', timestamp: '2026-06-10T11:03:01.000Z', data: { content: 'Created the client file.' } },
+    ];
+    const fp = writeTranscript(events);
+    const session = parseTranscriptFile(fp, 'ws-1', 'ws-1', 'Local Agent');
+
+    expect(session!.workspaceRootPath).toBe('/home/user/go/src/example/iam');
+  });
+
+  it('does not commit a tool edit when the tool call failed', () => {
+    const events: Array<Record<string, unknown>> = [
+      { type: 'session.start', timestamp: '2026-01-01T00:00:00Z', data: { sessionId: 'sess-fail', startTime: '2026-01-01T00:00:00Z' } },
+      { type: 'user.message', timestamp: '2026-01-01T00:00:01Z', data: { content: 'edit this file' } },
+      { type: 'tool.execution_start', timestamp: '2026-01-01T00:00:02Z', data: { toolCallId: 'call-1', toolName: 'replace_string_in_file', arguments: { filePath: '/repo/a.ts', oldString: 'x', newString: 'y' } } },
+      { type: 'tool.execution_complete', timestamp: '2026-01-01T00:00:03Z', data: { toolCallId: 'call-1', success: false } },
+      { type: 'assistant.message', timestamp: '2026-01-01T00:00:04Z', data: { content: 'That failed.' } },
+    ];
+    const fp = writeTranscript(events);
+    const session = parseTranscriptFile(fp, 'ws-1', 'ws-1', 'Local Agent');
+
+    expect(session!.requests[0].editedFiles).toEqual([]);
+  });
+
+  it('handles multi_replace_string_in_file across several files', () => {
+    const events: Array<Record<string, unknown>> = [
+      { type: 'session.start', timestamp: '2026-01-01T00:00:00Z', data: { sessionId: 'sess-multi', startTime: '2026-01-01T00:00:00Z' } },
+      { type: 'user.message', timestamp: '2026-01-01T00:00:01Z', data: { content: 'refactor two files' } },
+      {
+        type: 'tool.execution_start',
+        timestamp: '2026-01-01T00:00:02Z',
+        data: {
+          toolCallId: 'call-1',
+          toolName: 'multi_replace_string_in_file',
+          arguments: {
+            replacements: [
+              { filePath: REPO_FILE_A, oldString: 'a', newString: 'b' },
+              { filePath: REPO_FILE_B, oldString: 'c', newString: 'd' },
+            ],
+          },
+        },
+      },
+      { type: 'tool.execution_complete', timestamp: '2026-01-01T00:00:03Z', data: { toolCallId: 'call-1', success: true } },
+      { type: 'assistant.message', timestamp: '2026-01-01T00:00:04Z', data: { content: 'Refactored.' } },
+    ];
+    const fp = writeTranscript(events);
+    const session = parseTranscriptFile(fp, 'ws-1', 'ws-1', 'Local Agent');
+
+    expect(session!.requests[0].editedFiles).toEqual(expect.arrayContaining([REPO_FILE_A, REPO_FILE_B]));
+  });
+
+  it('returns null and records a failed file when the path cannot be read', () => {
+    const dir = makeTempDir();
+    const missing = path.join(dir, 'does-not-exist.jsonl');
+
+    const session = parseTranscriptFile(missing, 'ws-1', 'ws-1', 'Local Agent');
+
+    expect(session).toBeNull();
+    expect(getParseWarningCounts().skippedFiles).toBe(1);
+  });
+
+  it('returns null for a transcript with no user/assistant turns', () => {
+    const fp = writeTranscript([{ type: 'some.unknown.event', data: {} }]);
+    const session = parseTranscriptFile(fp, 'ws-1', 'ws-1', 'Local Agent');
+    expect(session).toBeNull();
+  });
+
+  it('drops a trailing user message with no assistant response', () => {
+    const events: Array<Record<string, unknown>> = [
+      { type: 'session.start', timestamp: '2026-01-01T00:00:00Z', data: { sessionId: 'sess-open', startTime: '2026-01-01T00:00:00Z' } },
+      { type: 'user.message', timestamp: '2026-01-01T00:00:01Z', data: { content: 'still thinking...' } },
+    ];
+    const fp = writeTranscript(events);
+    const session = parseTranscriptFile(fp, 'ws-1', 'ws-1', 'Local Agent');
+    expect(session).toBeNull();
+  });
+});

--- a/src/core/parser-vscode-transcripts.ts
+++ b/src/core/parser-vscode-transcripts.ts
@@ -1,0 +1,368 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* GitHub Copilot Chat "transcript" parsing for VS Code session discovery.
+ *
+ * Newer VS Code / Copilot Chat builds no longer persist `chatSessions/*.json`. Instead each
+ * chat session is written as `GitHub.copilot-chat/transcripts/<sessionId>.jsonl`, one JSON
+ * event per line: `session.start`, `user.message`, `assistant.message`,
+ * `tool.execution_start`/`tool.execution_complete`, `assistant.turn_start`/`turn_end`.
+ *
+ * The event envelope matches the Copilot CLI's `events.jsonl` schema (see
+ * parser-vscode-cli.ts), but tool-call arguments use VS Code's built-in tool names and argument
+ * shapes (`filePath`, `oldString`/`newString`, `content`, ...) rather than the CLI's snake_case
+ * ones, so this gets its own turn accumulator instead of reusing the CLI parser.
+ *
+ * There is no `workspace.json` sidecar for these workspaceStorage entries (that mechanism was
+ * dropped along with `chatSessions`), so the workspace root is derived from the absolute file
+ * paths touched by edit tool calls in the transcript itself.
+ */
+
+import { Session, SessionRequest } from './types';
+import { createRequest, createSession, detectDevcontainerFromRequests, recordFailedFile } from './parser-shared';
+import { forEachJsonlLine } from './parser-vscode-files';
+import { EditLocIndex } from './edit-loc-diff';
+import {
+  FileEditLocMap,
+  mergeFileEditLoc,
+  mergeRequestEditLoc,
+  recordContentReplacement,
+  recordCreatedContent,
+} from './edit-tool-diff';
+
+interface TranscriptEvent {
+  type: string;
+  data?: Record<string, unknown>;
+  timestamp?: string;
+  id?: string;
+}
+
+/** Accumulated state for a single user turn (user.message → next user.message). */
+interface TurnState {
+  userMsg: string;
+  userTs: string | null;
+  responseChunks: string[];
+  toolNames: Set<string>;
+  editedFiles: Set<string>;
+  referencedFiles: Set<string>;
+  lastAssistantTs: string | null;
+  lastAssistantId: string | null;
+  editLocs: FileEditLocMap;
+  pendingToolEdits: Map<string, PendingToolEdit>;
+}
+
+interface PendingToolEdit {
+  editLocs: FileEditLocMap;
+  editedFiles: Set<string>;
+}
+
+interface TranscriptParseState {
+  sessionId: string;
+  startTime: string | null;
+  requests: SessionRequest[];
+  turn: TurnState | null;
+  editLocIndex?: EditLocIndex;
+  /** Absolute paths edited during the session, used to derive `workspaceRootPath`. */
+  editedPaths: string[];
+  /** Absolute paths merely read/referenced; used as a fallback when nothing was edited. */
+  referencedPaths: string[];
+}
+
+function freshTurn(userMsg: string, userTs: string | null): TurnState {
+  return {
+    userMsg,
+    userTs,
+    responseChunks: [],
+    toolNames: new Set(),
+    editedFiles: new Set(),
+    referencedFiles: new Set(),
+    lastAssistantTs: null,
+    lastAssistantId: null,
+    editLocs: new Map(),
+    pendingToolEdits: new Map(),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function recordArrayValue(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecord);
+}
+
+function parseTranscriptEventLine(line: string): TranscriptEvent | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    if (!isRecord(parsed) || typeof parsed.type !== 'string') return null;
+    return {
+      type: parsed.type,
+      data: recordValue(parsed.data),
+      timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : undefined,
+      id: typeof parsed.id === 'string' ? parsed.id : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Built-in tools that edit file content directly (vs. merely reading/searching). */
+const FILE_EDIT_TOOLS = new Set(['create_file', 'replace_string_in_file', 'edit_notebook_file']);
+
+function applyEdit(pending: PendingToolEdit, filePath: string, args: Record<string, unknown>, toolName: string): void {
+  pending.editedFiles.add(filePath);
+  if (toolName === 'create_file') {
+    const content = str(args.content);
+    if (content) recordCreatedContent(pending.editLocs, filePath, content);
+  } else if (toolName === 'replace_string_in_file') {
+    const oldString = str(args.oldString);
+    const newString = str(args.newString);
+    if (oldString || newString) recordContentReplacement(pending.editLocs, filePath, oldString, newString);
+  }
+}
+
+/** Extracts edited/referenced file paths from a tool call's arguments, by known tool name where
+ *  possible and falling back to a generic `filePath` lookup so unrecognized/future built-in
+ *  tools still contribute file references instead of being silently dropped. */
+function extractToolFilePaths(toolName: string, args: Record<string, unknown>, pending: PendingToolEdit, turn: TurnState): void {
+  if (toolName === 'multi_replace_string_in_file') {
+    for (const replacement of recordArrayValue(args.replacements)) {
+      const filePath = str(replacement.filePath);
+      if (filePath) applyEdit(pending, filePath, replacement, 'replace_string_in_file');
+    }
+    return;
+  }
+  const filePath = str(args.filePath);
+  if (!filePath) return;
+  if (FILE_EDIT_TOOLS.has(toolName)) {
+    applyEdit(pending, filePath, args, toolName);
+  } else {
+    // Read/search tools (read_file, list_dir, ...) and any unrecognized future built-in tool
+    // with a `filePath` argument are treated as references — better to under-attribute (no LOC
+    // delta) than to silently drop the file entirely.
+    turn.referencedFiles.add(filePath);
+  }
+}
+
+function commitToolEdit(turn: TurnState, edit: PendingToolEdit): void {
+  mergeFileEditLoc(turn.editLocs, edit.editLocs);
+  for (const file of edit.editedFiles) turn.editedFiles.add(file);
+}
+
+function flushTurn(state: TranscriptParseState): void {
+  const turn = state.turn;
+  state.turn = null;
+  if (!turn || (turn.responseChunks.length === 0 && turn.toolNames.size === 0)) return;
+  turn.pendingToolEdits.clear();
+
+  const msgTs = turn.userTs ? new Date(turn.userTs).getTime() : null;
+  const respTs = turn.lastAssistantTs ? new Date(turn.lastAssistantTs).getTime() : null;
+  const responseText = turn.responseChunks.filter(Boolean).join('\n\n');
+  const requestId = turn.lastAssistantId || `${state.sessionId}:vscode-transcript:${state.requests.length}`;
+
+  state.requests.push(createRequest({
+    requestId,
+    timestamp: msgTs,
+    messageText: turn.userMsg,
+    responseText,
+    agentMode: 'agent',
+    toolsUsed: [...turn.toolNames],
+    editedFiles: [...turn.editedFiles],
+    referencedFiles: [...turn.referencedFiles],
+    totalElapsed: msgTs && respTs ? respTs - msgTs : null,
+    // This transcript format never records token usage — a known, permanent parser-coverage
+    // gap (see SessionRequest.endState doc), not a transient in-progress state.
+    endState: 'no-data',
+  }));
+  mergeRequestEditLoc(state.editLocIndex, requestId, turn.editLocs);
+
+  for (const file of turn.editedFiles) state.editedPaths.push(file);
+  for (const file of turn.referencedFiles) state.referencedPaths.push(file);
+}
+
+function addAttachmentReferences(turn: TurnState, attachments: unknown): void {
+  for (const attachment of recordArrayValue(attachments)) {
+    const filePath = attachment.path;
+    if (typeof filePath === 'string') turn.referencedFiles.add(filePath);
+  }
+}
+
+function handleSessionStart(ev: TranscriptEvent, state: TranscriptParseState): void {
+  const data = ev.data || {};
+  state.sessionId = str(data.sessionId) || state.sessionId;
+  state.startTime = str(data.startTime) || ev.timestamp || null;
+}
+
+function handleUserMessage(ev: TranscriptEvent, state: TranscriptParseState): void {
+  flushTurn(state);
+  state.turn = freshTurn(str(ev.data?.content), ev.timestamp || null);
+  addAttachmentReferences(state.turn, ev.data?.attachments);
+}
+
+function handleToolExecutionStart(ev: TranscriptEvent, state: TranscriptParseState): void {
+  const turn = state.turn;
+  if (!turn) return;
+
+  const data = ev.data || {};
+  const toolName = str(data.toolName);
+  const args = recordValue(data.arguments) || {};
+
+  if (toolName) turn.toolNames.add(toolName);
+
+  const pending: PendingToolEdit = { editLocs: new Map(), editedFiles: new Set() };
+  extractToolFilePaths(toolName, args, pending, turn);
+
+  if (pending.editedFiles.size > 0) {
+    const toolCallId = str(data.toolCallId);
+    if (toolCallId) turn.pendingToolEdits.set(toolCallId, pending);
+    else commitToolEdit(turn, pending);
+  }
+}
+
+function handleToolExecutionComplete(ev: TranscriptEvent, state: TranscriptParseState): void {
+  const turn = state.turn;
+  if (!turn) return;
+  const data = ev.data || {};
+  const toolCallId = str(data.toolCallId);
+  const pending = toolCallId ? turn.pendingToolEdits.get(toolCallId) : undefined;
+  if (pending) {
+    if (data.success !== false) commitToolEdit(turn, pending);
+    turn.pendingToolEdits.delete(toolCallId);
+  }
+}
+
+function handleAssistantMessage(ev: TranscriptEvent, state: TranscriptParseState): void {
+  const turn = state.turn;
+  if (!turn) return;
+  const data = ev.data || {};
+  const content = str(data.content);
+  if (content) turn.responseChunks.push(content);
+  turn.lastAssistantTs = ev.timestamp || turn.lastAssistantTs;
+  turn.lastAssistantId = str(ev.id) || turn.lastAssistantId;
+
+  for (const request of recordArrayValue(data.toolRequests)) {
+    const toolName = str(request.toolName) || str(request.name);
+    if (toolName) turn.toolNames.add(toolName);
+  }
+}
+
+function handleTranscriptEvent(ev: TranscriptEvent, state: TranscriptParseState): void {
+  switch (ev.type) {
+    case 'session.start':
+      handleSessionStart(ev, state);
+      return;
+    case 'user.message':
+      handleUserMessage(ev, state);
+      return;
+    case 'tool.execution_start':
+      handleToolExecutionStart(ev, state);
+      return;
+    case 'tool.execution_complete':
+      handleToolExecutionComplete(ev, state);
+      return;
+    case 'assistant.message':
+      handleAssistantMessage(ev, state);
+      return;
+  }
+}
+
+/** Minimum number of non-empty path segments a derived workspace root must have, so we never
+ *  fall back to an overly broad root like `/home/alice` or `/`. */
+const MIN_WORKSPACE_ROOT_SEGMENTS = 3;
+
+function commonDirPrefix(paths: string[]): string | null {
+  if (paths.length === 0) return null;
+  const segmentLists = paths.map(p => p.replaceAll('\\', '/').split('/').slice(0, -1));
+  let common = segmentLists[0];
+  for (const segments of segmentLists.slice(1)) {
+    let i = 0;
+    while (i < common.length && i < segments.length && common[i] === segments[i]) i++;
+    common = common.slice(0, i);
+    if (common.length === 0) break;
+  }
+  const nonEmpty = common.filter(Boolean).length;
+  if (nonEmpty < MIN_WORKSPACE_ROOT_SEGMENTS) return null;
+  return common.join('/');
+}
+
+/** Derives a workspace root from touched file paths: edits are a stronger signal than reads
+ *  (read-only exploration, e.g. a subagent, may span unrelated repos in the same session). */
+function deriveWorkspaceRootPath(state: TranscriptParseState): string | undefined {
+  return commonDirPrefix(state.editedPaths) ?? commonDirPrefix(state.referencedPaths) ?? undefined;
+}
+
+function finalizeSession(
+  state: TranscriptParseState,
+  wsId: string,
+  wsName: string,
+  harness: string,
+  customInstructionsBytes?: number,
+): Session | null {
+  flushTurn(state);
+  if (state.requests.length === 0) return null;
+
+  const creationDate = state.startTime ? new Date(state.startTime).getTime() : null;
+  return createSession({
+    sessionId: state.sessionId,
+    workspaceId: wsId,
+    workspaceName: wsName,
+    location: 'panel',
+    harness,
+    creationDate: creationDate ?? undefined,
+    requests: state.requests,
+    // No shutdown/close event exists in this format, and token usage is never recorded — treat
+    // as a genuine, permanent parser-coverage gap rather than guessing "active" or "aborted".
+    endReason: 'unknown',
+    customInstructionsBytes,
+    hasDevcontainer: detectDevcontainerFromRequests(state.requests),
+    workspaceRootPath: deriveWorkspaceRootPath(state),
+  });
+}
+
+export function parseTranscriptFile(
+  transcriptPath: string,
+  wsId: string,
+  wsName: string,
+  harness: string,
+  customInstructionsBytes?: number,
+  editLocIndex?: EditLocIndex,
+): Session | null {
+  const state: TranscriptParseState = {
+    sessionId: wsId,
+    startTime: null,
+    requests: [],
+    turn: null,
+    editLocIndex,
+    editedPaths: [],
+    referencedPaths: [],
+  };
+
+  let sawAnyEvent = false;
+  try {
+    forEachJsonlLine(transcriptPath, (line) => {
+      if (!line.trim()) return;
+      const event = parseTranscriptEventLine(line);
+      if (event) {
+        handleTranscriptEvent(event, state);
+        sawAnyEvent = true;
+      }
+    });
+  } catch (e) {
+    recordFailedFile('parser-vscode-transcripts', transcriptPath, e);
+    return null;
+  }
+
+  if (!sawAnyEvent) return null;
+  return finalizeSession(state, wsId, wsName, harness, customInstructionsBytes);
+}

--- a/src/core/parser-vscode.test.ts
+++ b/src/core/parser-vscode.test.ts
@@ -665,6 +665,86 @@ describe('scanVsCodeDirs — Copilot session state', () => {
   });
 });
 
+describe('processWorkspaceEntry — GitHub.copilot-chat/transcripts', () => {
+  const makeContext = (): ParseContext => ({
+    workspaces: new Map(),
+    sessions: [],
+    editLocIndex: new Map(),
+    sessionSourceIndex: new Map(),
+    aiLoc: 0,
+  });
+
+  function writeTranscriptWorkspace(logsDir: string, wsId: string): void {
+    const dir = path.join(logsDir, wsId, 'GitHub.copilot-chat', 'transcripts');
+    fs.mkdirSync(dir, { recursive: true });
+    const events = [
+      { type: 'session.start', timestamp: '2026-01-01T00:00:00Z', data: { sessionId: 'sess-t1', startTime: '2026-01-01T00:00:00Z' } },
+      { type: 'user.message', timestamp: '2026-01-01T00:00:01Z', data: { content: 'hello' } },
+      { type: 'tool.execution_start', timestamp: '2026-01-01T00:00:02Z', data: { toolCallId: 'c1', toolName: 'create_file', arguments: { filePath: '/home/user/proj/myrepo/src/index.ts', content: 'x' } } },
+      { type: 'tool.execution_complete', timestamp: '2026-01-01T00:00:03Z', data: { toolCallId: 'c1', success: true } },
+      { type: 'tool.execution_start', timestamp: '2026-01-01T00:00:04Z', data: { toolCallId: 'c2', toolName: 'create_file', arguments: { filePath: '/home/user/proj/myrepo/test/index.test.ts', content: 'y' } } },
+      { type: 'tool.execution_complete', timestamp: '2026-01-01T00:00:05Z', data: { toolCallId: 'c2', success: true } },
+      { type: 'assistant.message', id: 'a1', timestamp: '2026-01-01T00:00:06Z', data: { content: 'done' } },
+    ];
+    fs.writeFileSync(path.join(dir, 'sess-t1.jsonl'), events.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  }
+
+  it('parses transcripts when there is no chatSessions dir or workspace.json (sync)', () => {
+    const logsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-engineer-coach-transcripts-'));
+    try {
+      writeTranscriptWorkspace(logsDir, 'ws-hash-1');
+      const ctx = makeContext();
+
+      const wsName = processWorkspaceEntry(logsDir, 'ws-hash-1', 'Local Agent', ctx);
+
+      expect(wsName).toBe('ws-hash-1');
+      expect(ctx.sessions).toHaveLength(1);
+      expect(ctx.sessions[0].sessionId).toBe('sess-t1');
+      expect(ctx.sessionSourceIndex.get('sess-t1')?.kind).toBe('vscode-transcript');
+      // The derived workspace root upgrades the placeholder hash-based name/path.
+      expect(ctx.workspaces.get('ws-hash-1')).toEqual({ id: 'ws-hash-1', name: 'myrepo', path: '/home/user/proj/myrepo' });
+    } finally {
+      fs.rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses transcripts when there is no chatSessions dir or workspace.json (async)', async () => {
+    const logsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-engineer-coach-transcripts-async-'));
+    try {
+      writeTranscriptWorkspace(logsDir, 'ws-hash-2');
+      const ctx = makeContext();
+
+      const wsName = await processWorkspaceEntryAsync(logsDir, 'ws-hash-2', 'Local Agent', ctx);
+
+      expect(wsName).toBe('ws-hash-2');
+      expect(ctx.sessions).toHaveLength(1);
+      expect(ctx.sessionSourceIndex.get('sess-t1')?.kind).toBe('vscode-transcript');
+      expect(ctx.workspaces.get('ws-hash-2')).toEqual({ id: 'ws-hash-2', name: 'myrepo', path: '/home/user/proj/myrepo' });
+    } finally {
+      fs.rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the workspace.json-derived name when one is present', () => {
+    const logsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-engineer-coach-transcripts-wsjson-'));
+    try {
+      writeTranscriptWorkspace(logsDir, 'ws-hash-3');
+      fs.writeFileSync(
+        path.join(logsDir, 'ws-hash-3', 'workspace.json'),
+        JSON.stringify({ folder: 'file:///home/user/proj/named-workspace' }),
+      );
+      const ctx = makeContext();
+
+      const wsName = processWorkspaceEntry(logsDir, 'ws-hash-3', 'Local Agent', ctx);
+
+      expect(wsName).toBe('named-workspace');
+      expect(ctx.workspaces.get('ws-hash-3')?.name).toBe('named-workspace');
+    } finally {
+      fs.rmSync(logsDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('parseSessionFile — skill detection', () => {
   it('detects skills from promptFile variables pointing to SKILL.md', () => {
     const data = {

--- a/src/core/parser-vscode.ts
+++ b/src/core/parser-vscode.ts
@@ -14,6 +14,7 @@ import { debugCore, warnCore } from './log';
 import { canonicalizeReasoningEffort } from './helpers';
 import { parseRawRequest, normalizeSessionMode, type RawRequest } from './parser-vscode-request';
 import { parseCLIEventsFile, parseCLIEventsFileAsync } from './parser-vscode-cli';
+import { parseTranscriptFile } from './parser-vscode-transcripts';
 import { parseCLIWorkspaceName, parseWorkspaceName, parseWorkspaceFolderPath, parseCLIWorkspaceFolderPath, readFile, reconstructFromJsonl, stripImageData } from './parser-vscode-files';
 
 export function harnessFromPath(logsDir: string): string {
@@ -156,6 +157,34 @@ function listEditStateFiles(esDir: string): string[] {
   } catch {
     return [];
   }
+}
+
+/** `GitHub.copilot-chat/transcripts/*.jsonl` — the session format that replaced `chatSessions`
+ *  in newer VS Code / Copilot Chat builds (no `workspace.json` sidecar is written for it). */
+function listTranscriptFiles(entryPath: string): string[] {
+  return listChatSessionFiles(path.join(entryPath, 'GitHub.copilot-chat', 'transcripts'));
+}
+
+/** Picks the most common `workspaceRootPath` among newly parsed sessions and, if the workspace
+ *  name is still just the raw storage-folder id (no `workspace.json` found), upgrades the
+ *  workspace's display name/path to the derived root so it shows up as a real folder name. */
+function upgradeWorkspaceFromSessionRoots(
+  workspaces: ParseContext['workspaces'],
+  wsId: string,
+  wsName: string,
+  newSessions: Session[],
+): void {
+  if (wsName !== wsId) return;
+  const counts = new Map<string, number>();
+  for (const session of newSessions) {
+    const root = session.workspaceRootPath;
+    if (root) counts.set(root, (counts.get(root) ?? 0) + 1);
+  }
+  if (counts.size === 0) return;
+  const [bestRoot] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+  const name = bestRoot.replaceAll('\\', '/').split('/').pop();
+  if (!name) return;
+  workspaces.set(wsId, { id: wsId, name, path: bestRoot });
 }
 
 function sessionFileExists(filePath: string): boolean {
@@ -322,6 +351,22 @@ export function processWorkspaceEntry(
     parseEditStateFile(stateFile, editLocIndex);
   }
 
+  const transcriptStartIdx = sessions.length;
+  for (const transcriptFile of listTranscriptFiles(entryPath)) {
+    const session = parseTranscriptFile(transcriptFile, wsId, wsName, harness, customInstructionsBytes, editLocIndex);
+    if (session) {
+      sessions.push(session);
+      sessionSourceIndex.set(session.sessionId, {
+        kind: 'vscode-transcript',
+        filePath: transcriptFile,
+        workspaceId: wsId,
+        workspaceName: wsName,
+        harness,
+      });
+    }
+  }
+  upgradeWorkspaceFromSessionRoots(workspaces, wsId, wsName, sessions.slice(transcriptStartIdx));
+
   // Strip the heavy text from sessions added by this workspace immediately, so full-text
   // does not accumulate across every workspace during a cold parse (issue #106).
   stripSessionsFrom(sessions, startIdx);
@@ -375,9 +420,11 @@ export async function processWorkspaceEntryAsync(
 
   const chatFiles = listChatSessionFiles(path.join(entryPath, 'chatSessions'));
   const editStateFiles = listEditStateFiles(path.join(entryPath, 'chatEditingSessions'));
-  const totalUnits = Math.max(1, chatFiles.length + editStateFiles.length);
+  const transcriptFiles = listTranscriptFiles(entryPath);
+  const totalUnits = Math.max(1, chatFiles.length + editStateFiles.length + transcriptFiles.length);
   const chatEvery = chunkInterval(chatFiles.length);
   const editEvery = chunkInterval(editStateFiles.length);
+  const transcriptEvery = chunkInterval(transcriptFiles.length);
   let completed = 0;
 
   for (let i = 0; i < chatFiles.length; i++) {
@@ -447,6 +494,35 @@ export async function processWorkspaceEntryAsync(
     }
     await yieldToLoop();
   }
+
+  const transcriptStartIdx = sessions.length;
+  for (let i = 0; i < transcriptFiles.length; i++) {
+    const tTranscript = Date.now();
+    const session = parseTranscriptFile(transcriptFiles[i], wsId, wsName, harness, customInstructionsBytes, editLocIndex);
+    addParseTiming('transcript', Date.now() - tTranscript);
+    if (session) {
+      stripSingleSession(session);
+      sessions.push(session);
+      sessionSourceIndex.set(session.sessionId, {
+        kind: 'vscode-transcript',
+        filePath: transcriptFiles[i],
+        workspaceId: wsId,
+        workspaceName: wsName,
+        harness,
+      });
+    }
+    completed++;
+    if (shouldReportChunk(i, transcriptFiles.length, transcriptEvery)) {
+      onProgress?.({
+        wsName,
+        detail: `transcripts ${i + 1}/${transcriptFiles.length}`,
+        completed,
+        total: totalUnits,
+      });
+    }
+    await yieldToLoop();
+  }
+  upgradeWorkspaceFromSessionRoots(workspaces, wsId, wsName, sessions.slice(transcriptStartIdx));
 
   // Strip the heavy text from sessions added by this workspace immediately, so full-text
   // does not accumulate across every workspace during a cold parse (issue #106).

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -206,19 +206,25 @@ async function collectWorkspaceSessionTiles(
   fallbackMtime: number,
 ): Promise<Array<{ mtime: number; size: number; date?: string }>> {
   const tiles: Array<{ mtime: number; size: number; date?: string }> = [];
-  const chatDir = path.join(logsDir, wsId, 'chatSessions');
 
-  try {
-    const entries = await fs.promises.readdir(chatDir, { withFileTypes: true });
-    const files = entries.filter(entry => entry.isFile() && (entry.name.endsWith('.json') || entry.name.endsWith('.jsonl')));
-    const stats = await Promise.allSettled(files.map(async entry => {
-      const stat = await fs.promises.stat(path.join(chatDir, entry.name));
-      return { mtime: stat.mtimeMs, size: stat.size, date: stat.mtimeMs > 0 ? toDateStr(stat.mtimeMs) : undefined };
-    }));
-    for (const result of stats) {
-      if (result.status === 'fulfilled') tiles.push(result.value);
-    }
-  } catch { /* no chat sessions dir */ }
+  async function collectFrom(dir: string): Promise<void> {
+    try {
+      const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+      const files = entries.filter(entry => entry.isFile() && (entry.name.endsWith('.json') || entry.name.endsWith('.jsonl')));
+      const stats = await Promise.allSettled(files.map(async entry => {
+        const stat = await fs.promises.stat(path.join(dir, entry.name));
+        return { mtime: stat.mtimeMs, size: stat.size, date: stat.mtimeMs > 0 ? toDateStr(stat.mtimeMs) : undefined };
+      }));
+      for (const result of stats) {
+        if (result.status === 'fulfilled') tiles.push(result.value);
+      }
+    } catch { /* dir does not exist */ }
+  }
+
+  await collectFrom(path.join(logsDir, wsId, 'chatSessions'));
+  // GitHub.copilot-chat/transcripts is the session format that replaced chatSessions in newer
+  // VS Code / Copilot Chat builds.
+  await collectFrom(path.join(logsDir, wsId, 'GitHub.copilot-chat', 'transcripts'));
 
   if (tiles.length === 0) {
     tiles.push({ mtime: fallbackMtime, size: 0, date: fallbackMtime > 0 ? toDateStr(fallbackMtime) : undefined });
@@ -644,7 +650,7 @@ export async function parseAllLogsAsyncDetailed(
   const logParseBreakdown = (mode: string): void => {
     const t = getParseTiming();
     runtimeDebug('parser', 'cold-parse-breakdown',
-      `mode=${mode} chatMs=${t.chatMs} editMs=${t.editMs} cliMs=${t.cliMs} ` +
+      `mode=${mode} chatMs=${t.chatMs} editMs=${t.editMs} cliMs=${t.cliMs} transcriptMs=${t.transcriptMs} ` +
       `chatFiles=${t.chatFiles} editFiles=${t.editFiles} forcedGc=${t.forcedGc}`);
   };
 


### PR DESCRIPTION
## Description

### Root cause
Your VS Code / Copilot Chat build (1.123+/0.51+) no longer writes the legacy chatSessions/*.json files (or workspace.json) that the extension's parser expects. Sessions are now stored as GitHub.copilot-chat/transcripts/<sessionId>.jsonl under each workspaceStorage/<hash>/ folder — a completely different event-log format the parser had zero support for. That's true for every workspace on this machine, including iam; only your Copilot CLI sessions were showing up because that's a separate, still-supported format.

### Fix
Added parser-vscode-transcripts.ts, a new parser for the transcripts/*.jsonl format (session.start/user.message/assistant.message/tool.execution_* events), and wired it into parser-vscode.ts's processWorkspaceEntry/processWorkspaceEntryAsync. Since there's no workspace.json anymore, the workspace name/path is now inferred from the common directory of files edited in each session (falls back to the raw storage-folder id when a session only did read-only exploration, e.g. via a subagent).

Also updated:

cache.ts — new vscode-transcript session-source kind, disk-cache fingerprinting for the transcripts folder.
parser.ts — calendar-tile date collection now includes transcript files.
parser-shared.ts — added a transcript timing bucket for the existing perf-logging.
Added tests: parser-vscode-transcripts.test.ts, plus new cases in parser-vscode.test.ts and cache.test.ts.
Documented the new format in supported-tools.md.
Verified against your real data: a probe run found 37 previously-invisible chat sessions across your VS Code workspaces on this machine, including sessions correctly attributed to iam. npm run typecheck and npm test (1341 tests) pass; npm run lint/npm run spellcheck are blocked by pre-existing environment issues unrelated to this change (Node 20 here vs. required ≥22.18, and a broken ESLint/unicorn-plugin combo that also fails on a clean checkout).

## Related Issues

<!-- Link related issues: Fixes #123, Relates to #456 -->

## Checklist

- [ ] `npm run check` passes (typecheck + lint + spellcheck + knip + tests)
- [ ] Changes are covered by tests (if applicable)
- [ ] Documentation updated (if applicable)
