### PR TITLE
docs: document OpenCode SQLite (opencode.db) session storage support

### DIFF
--- a/docs/content/getting-started/supported-tools.md
+++ b/docs/content/getting-started/supported-tools.md
@@ -32,7 +32,7 @@ Reads session history from OpenAI's Codex terminal agent. Captures prompts, comp
 
 ## OpenCode
 
-Parses session logs from the open-source OpenCode terminal tool that supports multiple LLM backends.
+Parses session logs from the open-source OpenCode terminal tool that supports multiple LLM backends. Current OpenCode versions store sessions in a SQLite database (`opencode.db`), which is read in read-only mode; older installs that still use the legacy JSON storage layout continue to work.
 
 ## GitHub Copilot for Xcode
 

--- a/src/core/parser-opencode.ts
+++ b/src/core/parser-opencode.ts
@@ -5,10 +5,17 @@
 
 /* OpenCode session parser
  *
- * Data layout (macOS):
+ * Data layout (macOS, legacy JSON storage):
  *   ~/.local/share/opencode/storage/session/global/<session-id>.json   -- session metadata
  *   ~/.local/share/opencode/storage/message/<session-id>/<msg-id>.json -- message metadata
  *   ~/.local/share/opencode/storage/part/<msg-id>/<part-id>.json       -- content parts (text, tool, step-start/finish)
+ *
+ * Current OpenCode versions instead store the same data in a SQLite database:
+ *   ~/.local/share/opencode/opencode.db (or opencode-<id>.db)
+ * with `session`, `message`, and `part` tables. `message`/`part` rows carry their JSON payload
+ * in a `data` column, with id/session/message linkage in dedicated columns. The database is
+ * opened read-only via `node:sqlite` (Node >= 22.5); when unavailable, only the legacy layout
+ * is read. Both layouts describe the same shapes below.
  *
  * Sessions have: id, slug, version, projectID, directory, title, time.created/updated
  * Messages have: id, sessionID, role (user|assistant), time, agent, model {providerID, modelID}, tokens, cost


### PR DESCRIPTION
## Description

Fixes the documentation gap behind #238. The actual bug — AI Engineer Coach not finding OpenCode sessions once OpenCode migrated to SQLite storage (`opencode.db`) — was already fixed on `main` by earlier commits (`ca96efb2`, `4a33511d`) that added `parseOpenCodeDatabase()` / `loadSqlite()` to `parser-opencode.ts`, reading `opencode.db` read-only via the built-in `node:sqlite` module, with the legacy JSON `storage/` layout kept as a fallback.

However, that work was never reflected in:
- `docs/content/getting-started/supported-tools.md` — the OpenCode section still only described the old JSON-file behavior (same wording as before the SQLite support existed).
- The header comment in `src/core/parser-opencode.ts` — only documented the legacy macOS JSON layout, not the current SQLite one.

This left the docs (and the still-open issue) looking like OpenCode/SQLite support didn't exist, even though it does.

## Changes

- `docs/content/getting-started/supported-tools.md`: OpenCode section now states that current OpenCode versions store sessions in `opencode.db`, read read-only, with legacy JSON installs continuing to work — matching the existing wording style used for the GitHub Copilot for Xcode entry.
- `src/core/parser-opencode.ts`: header comment now documents both the legacy JSON layout and the current SQLite (`opencode.db`) layout/tables, so the comment matches what the code actually does.

**No functional/logic changes** — docs and comments only.

## Verification

- Confirmed against a real OpenCode install (Windows): `opencode.db` lives at `~/.local/share/opencode/opencode.db` (OpenCode uses this Unix-style path on every OS, anchored on `HOME`/`USERPROFILE` — not `%LOCALAPPDATA%`), which `findOpenCodeDirs()` already searches.
- Read the live `opencode.db` directly (read-only) and confirmed the `session`/`message`/`part` table columns and JSON payload shapes match exactly what `parser-opencode.ts` expects (model id, token breakdown, tool/text parts, etc.).
- Since this PR only touches comments/prose, `npm run check`/tests are unaffected; "SQLite" already appears elsewhere in the touched doc file (Xcode section) so spellcheck should be unaffected.

## Requested validation

@aymenfurter — could you validate on macOS that the doc/comment wording matches your experience with `opencode.db` there too (paths, table names)? This was verified against a real Windows install only.

Refs #238