### PR TITLE
fix: guard Output page against stale async chart renders (#101)

### DIFF
--- a/src/webview/page-output.ts
+++ b/src/webview/page-output.ts
@@ -117,6 +117,13 @@ type OutputTab = 'production' | 'token-usage';
 let activeRangeDays = 0;
 let activeTab: OutputTab = 'production';
 
+// Bumped on every render attempt (page mount, tab switch, or range change).
+// A render in flight compares its captured generation against this value
+// after its async gap (the `await rpc(...)` call) and bails out if a newer
+// render started in the meantime — otherwise a slow, superseded response
+// could still build charts against stale/detached/mismatched DOM (see #101).
+let renderGeneration = 0;
+
 export async function renderOutput(container: HTMLElement, currentFilter: DateFilter): Promise<void> {
   if (!FF_TOKEN_REPORTING_ENABLED && activeTab === 'token-usage') {
     activeTab = 'production';
@@ -248,11 +255,12 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
   // owner of #outputRange's children (avoids duplicate buttons).
   refreshRangeBar();
 
-  async function renderProductionTab(): Promise<void> {
+  async function renderProductionTab(gen: number): Promise<void> {
     const target = document.getElementById('output-tab-content')!;
     render(html`<div class="loading-spinner"></div>`, target);
 
     const prod = await rpc<ProdData>('getCodeProduction', buildRangeFilter());
+    if (gen !== renderGeneration) return; // superseded by a newer render (tab/range/nav change)
     const s = prod.summary;
     const level = aggregationLevel(activeRangeDays);
     const chartTitle = level === 'weekly' ? 'Weekly AI Code Output' : level === 'monthly' ? 'Monthly AI Code Output' : 'Daily AI Code Output';
@@ -733,11 +741,12 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
     `, target);
   }
 
-  async function renderTokenUsageTab(): Promise<void> {
+  async function renderTokenUsageTab(gen: number): Promise<void> {
     const target = document.getElementById('output-tab-content')!;
     render(html`<div class="loading-spinner"></div>`, target);
 
     const data = await rpc<AiCreditRpcData>('getAiCredits', buildRangeFilter());
+    if (gen !== renderGeneration) return; // superseded by a newer render (tab/range/nav change)
 
     const { missingLabel, partialLabel, pendingLabel, noDataLabel } = buildCreditCoverageSummary(data);
     if (renderAiCreditsEmptyState(target, data)) return;
@@ -787,12 +796,13 @@ export async function renderOutput(container: HTMLElement, currentFilter: DateFi
 
 
   async function renderActiveTab(): Promise<void> {
+    const gen = ++renderGeneration;
     if (!FF_TOKEN_REPORTING_ENABLED && activeTab === 'token-usage') {
       activeTab = 'production';
     }
-    if (activeTab === 'production') await renderProductionTab();
+    if (activeTab === 'production') await renderProductionTab(gen);
     else if (!FF_TOKEN_REPORTING_ENABLED) renderTokenUsageGated();
-    else await renderTokenUsageTab();
+    else await renderTokenUsageTab(gen);
   }
 
   /** Shown when token-usage is gated behind the feature flag. */

--- a/src/webview/shared.ts
+++ b/src/webview/shared.ts
@@ -372,12 +372,21 @@ export function createChart(
   type: ChartType,
   data: { labels: (string | number)[]; datasets: Record<string, unknown>[] },
   options?: Record<string, unknown>,
-): Chart {
+): Chart | null {
+  const el = document.getElementById(canvasId) as HTMLCanvasElement | null;
+  if (!el) {
+    // The canvas isn't in the live DOM — most likely a stale async render
+    // (the user navigated away, switched tabs, or re-triggered a load
+    // before this chart's data finished fetching). Skip it instead of
+    // letting Chart.js dereference a null element and crash the page.
+    console.warn(`createChart: canvas '${canvasId}' not in DOM (stale render?)`);
+    return null;
+  }
   const defaults: Record<string, unknown> = {
     responsive: true,
     maintainAspectRatio: false,
   };
-  const c = new Chart(document.getElementById(canvasId) as HTMLCanvasElement, {
+  const c = new Chart(el, {
     type,
     data: data as never,
     options: { ...defaults, ...options } as never,


### PR DESCRIPTION
## Summary

Fixes #101 — the Output page's intermittent `⚠️ Failed to render Output — Cannot read properties of undefined/null (reading …)` error boundary crash.

## Root cause

`createChart()` in `src/webview/shared.ts` passed `document.getElementById(canvasId)` straight into `new Chart(...)` with no null check. `renderOutput`/`renderProductionTab`/`renderTokenUsageTab` in `src/webview/page-output.ts` render a spinner, `await rpc(...)`, then re-render tab markup and call `createChart(...)` — with no cancellation of stale in-flight renders across that async gap.

If the user switched nav pages, toggled the Code Output ↔ Token Usage tab, or clicked date-range buttons rapidly while a request was still in flight, the stale promise would eventually resolve and either:
- find its expected canvas missing from the live DOM (Chart.js dereferences the null element and throws), or
- find the canvas still present but belonging to a *different* tab that has since been rendered, silently clobbering it with stale data.

## Fix (two layers, per the repro/fix notes in #101)

1. **`createChart` (`src/webview/shared.ts`)** — now checks `document.getElementById(canvasId)` for `null` and returns `null` with a `console.warn` instead of handing a null element to `new Chart(...)`. Return type updated to `Chart | null`; no call site used the return value, so this is a safe, non-breaking change.
2. **`page-output.ts`** — added a module-level `renderGeneration` counter, bumped once per render attempt (initial mount, tab switch, or range change) in `renderActiveTab()`. `renderProductionTab`/`renderTokenUsageTab` capture the generation at entry and bail out immediately after their `await rpc(...)` if a newer render has since started, so a slow/superseded response never touches the DOM again.

## Testing

Ran the full repo check suite from the worktree:
- `npm run typecheck` ✅
- `npm run lint` ✅ (0 errors; pre-existing warnings only, none introduced)
- `npm run spellcheck` ✅
- `npm run knip` ✅
- `npm test` (vitest) — 1341 passed; 7 failures in `src/core/github-app-analytics.test.ts` are **pre-existing and unrelated** (verified by stashing this change and re-running the same file — identical failures on `main`).
- `npm run build` + `npx playwright test` (full e2e suite) — 37 passed, 7 skipped (pre-existing feature-flag gating), 0 failures, including all applicable `tests/e2e/output.spec.ts` cases.

## Notes

- No dependency, config, or public API changes.
- `createChart`'s new `Chart | null` return type doesn't affect any existing caller (none of the ~30 call sites across the webview capture the return value).