### PR TITLE
fix: use Copilot Auto model router and handle empty LLM responses (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- Fix "LLM returned invalid JSON after 3 attempts" on all AI features (#91):
+  model selection now prefers Copilot's built-in "Auto" router so requests are
+  routed to a model actually enabled for the user's plan/org, instead of a
+  hardcoded model family that can be selectable yet silently return empty
+  responses. Empty responses are now detected and reported with an actionable
+  message instead of being misreported as an "invalid JSON" parse failure
 - Fix parse-worker out-of-memory on large log sets (#106): parsing now runs in a
   forked child process with a capped heap and streams results back in per-session
   chunks using ack-window backpressure to avoid native IPC buffer growth

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,30 +14,30 @@
         "htm": "3.1.1",
         "leo-profanity": "1.9.0",
         "preact": "10.29.8",
-        "zod": "4.5.4"
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@playwright/test": "1.62.1",
-        "@types/node": "26.4.0",
+        "@types/node": "26.2.0",
         "@types/vscode": "1.125.0",
         "@vitest/coverage-v8": "4.1.11",
         "@vscode/vsce": "3.9.2",
-        "cspell": "10.1.1",
+        "cspell": "10.1.0",
         "esbuild": "0.28.2",
-        "eslint": "10.9.1",
+        "eslint": "10.9.0",
         "eslint-plugin-import-x": "4.17.1",
         "eslint-plugin-no-unsanitized": "4.1.5",
-        "eslint-plugin-unicorn": "74.0.0",
+        "eslint-plugin-unicorn": "73.0.0",
         "husky": "9.1.7",
         "jsdom": "29.1.1",
-        "knip": "6.33.0",
-        "lint-staged": "17.4.1",
+        "knip": "6.32.2",
+        "lint-staged": "17.3.0",
         "lockfile-lint": "5.0.1",
         "preact-render-to-string": "6.7.0",
         "serve": "14.2.6",
         "typescript": "6.0.3",
-        "typescript-eslint": "8.68.0",
+        "typescript-eslint": "8.67.0",
         "vitest": "4.1.11"
       },
       "engines": {
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.1.1.tgz",
-      "integrity": "sha512-EvPFPWwEPbPn2pIAD4D6PRRFbuM5OCiYfY0GhmpQyWWteCwR4gRmRs06UOWqfSRKHYBL/rUqcr3OAfiF5ctAjw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-10.1.0.tgz",
+      "integrity": "sha512-CBnYuR7tMlLwWq6FL3IOQ0mM+d8r6d7t+BMH6qWtk9SMz8KzBO7dB5Ya+o3QI/lsqwR75qCPW6JPYapBogFq1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -426,7 +426,7 @@
         "@cspell/dict-markdown": "^2.0.18",
         "@cspell/dict-monkeyc": "^1.1.0",
         "@cspell/dict-node": "^5.0.9",
-        "@cspell/dict-npm": "^5.2.47",
+        "@cspell/dict-npm": "^5.2.46",
         "@cspell/dict-php": "^4.1.1",
         "@cspell/dict-powershell": "^5.0.15",
         "@cspell/dict-public-licenses": "^2.0.16",
@@ -450,22 +450,22 @@
       }
     },
     "node_modules/@cspell/cspell-json-reporter": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.1.1.tgz",
-      "integrity": "sha512-6makYERzgDCBGeOG7jSgZBOWxJKxBV6k0UQ60xDBZNrccACP45q8zO9YIXdHAYLmHB52l3Iz2vifeG7zhue7jA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-json-reporter/-/cspell-json-reporter-10.1.0.tgz",
+      "integrity": "sha512-q4YhCcqncLyf9XVJ7DnCLMPoTSyK3MpC7A8jxbdMM2ytQ2/pNrFKhUWPpoxzqLP5fmpwW8ieb5ip4JWcHfGwfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "10.1.1"
+        "@cspell/cspell-types": "10.1.0"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/@cspell/cspell-performance-monitor": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.1.1.tgz",
-      "integrity": "sha512-M3Bq+K0jmbnAE2dWB8vG/TljagcKWuILTpcf6sIMB/jTaT7QH9FyzVp0Q6srlN3GEdSBwFBqrfWCorkjRUd0cQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-performance-monitor/-/cspell-performance-monitor-10.1.0.tgz",
+      "integrity": "sha512-a0uHD0hrM9LC078pkMrJIC84FOdyg2i9nkRXp7kvus3k+/jSCun9XykSET0IoeZoom/8cB8Y9BVgnrbjE3q0Vg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.1.1.tgz",
-      "integrity": "sha512-WOuL9zdcl38b9P5Kpco3c1vg5v82bSWZ7LVeARbyrOmW60HxS8uP4nkbCGeU6pINvJCs0JUQxEZCRMHuEF0dfQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-10.1.0.tgz",
+      "integrity": "sha512-ZZL//x5zRHOlNn9DtTHBrrskEdjc7RtNB8XXnzjnTdcOjC9sI2YtqtVyXIAH7HKGyraLU1wi89S0XMGaENeflA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.1.1.tgz",
-      "integrity": "sha512-bbsykc5c7dDdPTDFdsY0GKwXlflDDaTUycAegziFLCcp8b/q1txQmqBxx95ok1pjpU10sWxiJztZZRayFcM5sg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-10.1.0.tgz",
+      "integrity": "sha512-I5BwclXK/9sbq+T1wADHG64PRaFMoDahhVKZbJCbK5bzsYF9rFEv9P5Quw3WZdgx8eUyGJcSqKuXYsDqx55yEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -496,9 +496,9 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.1.1.tgz",
-      "integrity": "sha512-Z3BUsVllqyAoJSGXcyFp0hXtBVKEfrxVcSy3UPoSoLW9gZZjXmFwOorhga3+fMseC9VRK3L6mKSccn9YGAjsnA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-10.1.0.tgz",
+      "integrity": "sha512-OM8c5IDtwQvHgJ0RYxckr3jaUt1NOLPAk7y/I8dvDba6iuBXkrCVUD2BMrUHFrHBBfWM5oMwioVOnNtg4nSvPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.1.1.tgz",
-      "integrity": "sha512-lsc+/pazJQ47Zy7qyuFiQRZzco+kBSUmAtCzbmT96pFpAVxR+b4A8qRBoTdiq4OXBRXRT+CqWMNynSiwQJWM6g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-10.1.0.tgz",
+      "integrity": "sha512-k5TzE4fKRbZUPv5Z2EKUXR5QoDF4LPlWo9OnXdQVx8YGi0GQosUzwag2uyHoN5uAOSnoJwyhwRcr+/EFqNkfrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -516,13 +516,13 @@
       }
     },
     "node_modules/@cspell/cspell-worker": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.1.1.tgz",
-      "integrity": "sha512-X9Ehif6c/9BRIODBjWMr0paHQrY3Jw7q0FWeSdxPZrnKhgJ+cX4vtvqlSD1dGXMV2/fGh10p1HznuDhNlQ4tjg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-worker/-/cspell-worker-10.1.0.tgz",
+      "integrity": "sha512-gEJ1bU1sOMgDwtewfI7SPdIs2MNakhKPr4WbGh8nfE/bszO4vT3YoQap2+v76/s2VjGs2Kzn6M1M2N5tmGuo3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cspell-lib": "10.1.1"
+        "cspell-lib": "10.1.0"
       },
       "engines": {
         "node": ">=22.18.0"
@@ -637,9 +637,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-en_us": {
-      "version": "4.4.37",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.37.tgz",
-      "integrity": "sha512-rMKyPrk2SKmDU+Bj0U0ixsv4Du93oijwovc8XlUin0zwKOJZb0/PFG5Df4P8CrM2CrLeovpaFvhoI98DigxBLw==",
+      "version": "4.4.36",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.36.tgz",
+      "integrity": "sha512-2yOhI/+7d1DbfvMljGW4jw8pLqDEsVmnvUXBOCFXtLU2BWgQkrqOJDCNseYjEiEbTp0OtdrWEWWPFSP1TNugQw==",
       "dev": true,
       "license": "MIT"
     },
@@ -651,9 +651,9 @@
       "license": "CC BY-SA 4.0"
     },
     "node_modules/@cspell/dict-en-gb-mit": {
-      "version": "3.1.26",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.26.tgz",
-      "integrity": "sha512-F9Y/45+1oIPzfL/pyWLp4kzX+vddHPAYpIpIF+45bdc65AebeEiQHKzSmKgGGTd3qbQc3fATw2kAFdLryiQpjQ==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb-mit/-/dict-en-gb-mit-3.1.25.tgz",
+      "integrity": "sha512-zGODptk24CMrXi49ieG2SUm94CKxEsVF0dYNF+1ZYH0MSsQDZ/PKDlrrbvtBqSupKdPSj0Z9sjOmMNfHHW9ZSg==",
       "dev": true,
       "license": "MIT"
     },
@@ -825,9 +825,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-npm": {
-      "version": "5.2.47",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.47.tgz",
-      "integrity": "sha512-r5ePbkmRtpMwiv+MHd6be1xIRLuXoEwaSLIZLu3mY+qtPVo0LUj/kVl4YeIxHONiwyef75zqS3gnT+s5UF7diQ==",
+      "version": "5.2.46",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.46.tgz",
+      "integrity": "sha512-Z5GG59c17UEk6BPZ3lVD/++GvPBI+O05OTGm4sRA/0I/qszbstuYRw+j2//5f8SWzOFXKaGYI8kygwKX9EQZ9Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -853,9 +853,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-python": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.5.0.tgz",
-      "integrity": "sha512-O1lSuFXoX8p+4hvJMbqvg3blbn0Zx8LHqdPQSNaOxFZGf7hmq6pc8sfta+98E7Q/WtDooAnU3XpBxBXcn0r94g==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.4.0.tgz",
+      "integrity": "sha512-49Eju/a97V6ExAeMJDM2Tk4jsYr0pm+kQzqQrKLAZdrRd6VrLIgseI481EQSmgoVkPPdsuwK1xj9ZlpDQIF4qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -898,9 +898,9 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dict-software-terms": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.4.2.tgz",
-      "integrity": "sha512-C2tS1JjxqHef9TpPRm08a6n+PJCrKrD6FsmPEyXb2J6TFef4FFnKRcGOf3pFnd+a6/oyQgXZWeKiECH6lBFjQA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.4.1.tgz",
+      "integrity": "sha512-tY88gnOWj2ax6h+i7BjU7dIH1f3fvY4WypS0a+TpjBgXC318AdOMmy0zK1SzxGNOjhWJfCeCZNVoLFM/DuOG4g==",
       "dev": true,
       "license": "MIT"
     },
@@ -954,13 +954,13 @@
       "license": "MIT"
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.1.1.tgz",
-      "integrity": "sha512-bNI+Gp0Rnx/WyOvni4TksvNWeQvCfyQAhZRIGMt+9bbLyniVagnftnoahV/yoF9h3WWxU3tL2eaVZx9B5dijuQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-10.1.0.tgz",
+      "integrity": "sha512-tZMsczw03/cT7hupr6+vIdJhPvJw4hmh7gGqAgeU+j1bc556VT/GviKrj/Xfa6+EK6Q3Uev7tb8WR1mkIpI5Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.1.1",
+        "@cspell/url": "10.1.0",
         "import-meta-resolve": "^4.2.0"
       },
       "engines": {
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@cspell/filetypes": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.1.1.tgz",
-      "integrity": "sha512-sSREdKF4roC4QM2n0qUgv10W74nUO7CUhDTCz3Sd3mHlUM46WI8QqbAIZFNTm5U4SuVaVAmXzsZvM69O/rOjvQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/filetypes/-/filetypes-10.1.0.tgz",
+      "integrity": "sha512-cTWbtrH00tNkjBkcH9ElSaaVxFbtp/XFqElUmiGS57SnvxgWlOhXChvhj5DIPwOT0c8uRjmx/0XQWjnlat4dwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -978,9 +978,9 @@
       }
     },
     "node_modules/@cspell/rpc": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.1.1.tgz",
-      "integrity": "sha512-sWQ++D8++6pAv8FSCfJOpc/t/yoK1r0xwcBb23SenOA9nvcmI7CwAp2FK2oByLnDTe+Bh6mQWtRRZSr3gfoGhQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/rpc/-/rpc-10.1.0.tgz",
+      "integrity": "sha512-Zo7e/L+b5hujFj8XG+ayVGf9z0YAQWEf9aBCMesPBzMMczFnV4ZQzOqrSKMBrc5J1ztVwft3IjVSUY5My++UIg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.1.1.tgz",
-      "integrity": "sha512-s7PsRDfZO5J1dB0gtlaeNxwaibDUCYIFlbdzMawlUejR/UNrhDgDIr48OScoOt5SaUHijEVpFDkrWVyCs5R7oQ==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-10.1.0.tgz",
+      "integrity": "sha512-FVqhMN38u44divmgVnR+qgOJAu5S89hkxdJNXAeK9ZTOXBKT8BGmYRtlFll4TMqeaS+513mmGhOaAnTLXNnObA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/@cspell/url": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.1.1.tgz",
-      "integrity": "sha512-5O2bZ5H/zPomc4qshTpfCbIltallsdQNwlw6j/Gl+eVElrlFsgc0kzuYJdk1BMnpA0ZXPXYH7XVKCGIKzLcr2g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cspell/url/-/url-10.1.0.tgz",
+      "integrity": "sha512-MxQyFUYX+M2GJEuPuA0l1aXHmRh52Qd/hTA1aahjUgvgujSghv+rOFhIzqFiVtIa0w/r1RgdCKHF32wNKfGnFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
-      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1746,13 +1746,13 @@
       }
     },
     "node_modules/@eslint/css-tree": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.5.tgz",
-      "integrity": "sha512-iPmijIAq4hlIJB86PYmY/fcZORHtjphSqICDbwuw32A/JmkhZQ/K/6TjHE03zqf3n5yABpVcbRAMG8Mi9ojy8g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.4.tgz",
+      "integrity": "sha512-nxMparyhqVWQvadx9x8dIfubfIPOE+X2b2waua8fzdnM9vdp9rgVtwEZlG0TmCwEUz/d/f40fzvO/eqBwdxz0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.29.0",
+        "mdn-data": "2.28.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@eslint/css-tree/node_modules/mdn-data": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.29.0.tgz",
-      "integrity": "sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==",
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.28.1.tgz",
+      "integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.147.0.tgz",
-      "integrity": "sha512-fOtoGvIoirkvxQVw9J1WJPxz571XPgLsPf9uhRD+PJteUnvrJHMDmK9pw2yZEGGyismtRoEsp+JcXUdF/JDMDw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.143.0.tgz",
+      "integrity": "sha512-n9uozULWflPqBtdmI8lAabLqGKNgLVNN0ZH8HfgCwpKGNtzRzauB76jTiW/3YLkcA7N1zskpi9GdVnZuu1SAvg==",
       "cpu": [
         "arm"
       ],
@@ -1990,9 +1990,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.147.0.tgz",
-      "integrity": "sha512-emjQHOYJaomo4ykaXQ1EItunr/I94Nk01oqBmU4dSkKSTupIDx6OysVDf2e8Eytm77rb+4ZxzgElyWP7rcEX7A==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.143.0.tgz",
+      "integrity": "sha512-9BbdjHETk6O3zH/DDid9IgBtF0GlpLabNKN231uraXpRDSfY+iiZxTP5bk1Z63GBownVdhdINFIeddmMz4MzpQ==",
       "cpu": [
         "arm64"
       ],
@@ -2007,9 +2007,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.147.0.tgz",
-      "integrity": "sha512-kXvBPJL7RmDPJ2mze/vXPPVQimCDtFr9OFLjf7dyhV5Dx64cgcXh9KKrA1sMWvCObvJll9CZZUO0FBlFwD0l6A==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.143.0.tgz",
+      "integrity": "sha512-gh+6ecoHUy4/sUcolBl/1qPXKBbYNxFY0Pk0ujgQvINTMSftJY7o4yb8gOkDJPeZeB8+a+u7xTe6umoP8N5HFA==",
       "cpu": [
         "arm64"
       ],
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.147.0.tgz",
-      "integrity": "sha512-mgFF8pLU6R64LbT27lSrtVRspVC/3IcZ0qyIikzmi78Y3Ik2OPnlAHHI0UEBRcC3qmNgtjaef7zkFt7/uPxIcw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.143.0.tgz",
+      "integrity": "sha512-qd1hl2d+lXgHv/VQ/M9qm8TrMC5T4RqDBwtOnl+1D0QMjwcz+8AaB4JSg8STgeag0GP6a6L74XEGAsrTSJWNzQ==",
       "cpu": [
         "x64"
       ],
@@ -2041,9 +2041,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.147.0.tgz",
-      "integrity": "sha512-v38aiF11qufOTBcCAKL4skgQf0zJ4NEvRlivq7B5kHrlyvjCLjvNrMtNWDTz1SDUL6/xVsJRmLDxv2e+Cp4oWw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.143.0.tgz",
+      "integrity": "sha512-M5XXcNa7aOqLPKTR41msfghKu2yQ4xWvCm11/gwU0JzOzHNk5sgW//rVEjJ+LO48+VDAMzXTSzurUVxIDKwozw==",
       "cpu": [
         "x64"
       ],
@@ -2058,9 +2058,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.147.0.tgz",
-      "integrity": "sha512-AeIiBbwUaP0H1+4/qGW9l5qHecS/+XA5iMuieVcGb1T+tyc2dVGspFW13BWk/XrLsiGP/CiDJTJqAPLLCzZHkw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.143.0.tgz",
+      "integrity": "sha512-T/GXusuOkPNQhCQCSBbcU/N8j0rAypuDBl1IyFK+lyYT594XsVz80clPC/OtbSSpBGyJxj8uYEfctxVuxVYoww==",
       "cpu": [
         "arm"
       ],
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.147.0.tgz",
-      "integrity": "sha512-/41MKPW4RgPY4DJco0NCF0RYX3IMZaVlRNMNzvhaxRavc7tN3Txm+qllZbh0aMRs0VHdgUlbI8TcAOiTai4TKg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.143.0.tgz",
+      "integrity": "sha512-oKu4RcBlXSqo3OC62dp6YTnQaZIurNDpCX3BnAM3+bJxt7s8J2TJKMnC0UYer1qhlRaDCg6wkTaTw+2IlsZ12w==",
       "cpu": [
         "arm"
       ],
@@ -2092,9 +2092,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.147.0.tgz",
-      "integrity": "sha512-bmpw/RPhVXgZbtb3xBDuwW5s8+LvZYdqcDSX/sP2ltL77aTio3DP/B5ZTwwgoJ6Mr9vJs4RrmgEKW9XkLNUU1g==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.143.0.tgz",
+      "integrity": "sha512-WJBbD186AZmMGaSIhlktC+rPl8L3peCTXAh88Ih9uEvK0en2mPojGyCGYiL6mHtV1RPV3JyfJW5t6n5hh0lXhA==",
       "cpu": [
         "arm64"
       ],
@@ -2112,9 +2112,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.147.0.tgz",
-      "integrity": "sha512-gd7VX/FDVOw6mjQcu45iIcp4QkgybgJwh3a0OFG2NxmPCj628mQWD96QGu1kK8+mZF9qK4b/gIEyC63vQoB7+Q==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.143.0.tgz",
+      "integrity": "sha512-t1AcYOwEzgceadT4v5e+vaCCb0AncCA3v5AyzfBAz/tMq11qzVccXKzNHtkWdjBsgvTKwRkaUF3QvT4kot8vcQ==",
       "cpu": [
         "arm64"
       ],
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.147.0.tgz",
-      "integrity": "sha512-HnAzcfki7dSUNHf510Q2NmbJlz8Ys7rn8l9l588Pkx0tYe1BHLZnmELIgqizJ4WPhHGSwN8Ce+B/menVxS3odA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.143.0.tgz",
+      "integrity": "sha512-RsnO/NoD8376LMJq8JS8TwI0ieNaFRTuNe2GVJntQg6gwZNMENZsEbknHdVwjpOmxdGLGodcwaGSbAeRr5Bgjw==",
       "cpu": [
         "ppc64"
       ],
@@ -2152,9 +2152,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.147.0.tgz",
-      "integrity": "sha512-qlkOL6wT44U+fT5s/+sR6Shx0OdwvQF83JyIPZUxG/ovqZF5/7atOtjH+JPZ5/7ATQLbFBBSmghcy/+2NVB/ew==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.143.0.tgz",
+      "integrity": "sha512-48fSVfR9TZi5CASZFyv0VC6z6BCoeihFsX031mAD/oSH7d9PYsPgIqza7d9mjP7Z2KTEpTFyH6SIu0Ui6R1vdg==",
       "cpu": [
         "riscv64"
       ],
@@ -2172,9 +2172,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.147.0.tgz",
-      "integrity": "sha512-DlefD7L7sMXs/3hIBH23Egk0phj8kG0SA81dVGOQ3S1ekjOlmTLH2E+F2Thwfh1slKx6aH+lNc5fQYAw0GU7/g==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.143.0.tgz",
+      "integrity": "sha512-T8CpdD+SfE01DnIOD4HpVxu0ZJOfMJ/VhCvikKfaXAxkZ+9veyLM/D2hpi7Y2hFUyPmVQO3FNZHmYzV/WlVR4g==",
       "cpu": [
         "riscv64"
       ],
@@ -2192,9 +2192,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.147.0.tgz",
-      "integrity": "sha512-Xqpagk/031IvZ4svrk2FF01YEqM/iN3MJV3SVZadKg/CsGlDCGoREqKHXYnoV5+8SfGe/m6RM1szXFLusTu/Uw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.143.0.tgz",
+      "integrity": "sha512-QLdeMsCcacenPEFsfxnBUDF1y6opyz5+fmOz9bfD5Y7fiGCMupUCuB3KTPQhNwshIG1P9fPqar9MHxuBDd4bwQ==",
       "cpu": [
         "s390x"
       ],
@@ -2212,9 +2212,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.147.0.tgz",
-      "integrity": "sha512-QioQOeUbI4ATUr0S2z88uA3Cds2R3Mm5Ge7U8XNYtlTb2GJF3rWlcj70z0AJhhOlbdm0YgVjqPBldUNbFylDIg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.143.0.tgz",
+      "integrity": "sha512-659ujfqLy6k7cuH3sbzhd8b+ztSq+i6E2E9pG78Q0BmHjAExfGIdgc8cGgMdwAozDXeZFHkJ+LXYJdWsaGdgyw==",
       "cpu": [
         "x64"
       ],
@@ -2232,9 +2232,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.147.0.tgz",
-      "integrity": "sha512-NXy1tv/OdC+pPTwf9RiCZWPK53V/Xq/2cjSnjOSyKopajdaDqMIkgtDY+jXZemp2e8px5FeWfY2L2LwhKZQovg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.143.0.tgz",
+      "integrity": "sha512-/Mw/9j4TfZcnKphPrzOE6t4MMknXadcAAuVUlDRTF/ETWB5xOgQvOJV2Mh9We/bWxZdoxaGAdc+hy4GuYwQ2yQ==",
       "cpu": [
         "x64"
       ],
@@ -2252,9 +2252,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.147.0.tgz",
-      "integrity": "sha512-GpGWZ6oKz4bjCWW9Mz5pCaGPyk2Aaze6zEoaslIQqpSLtpx5pXj/ap5gUNb5Jn2LIbqWyjkGLX9yv3NMuNcBVQ==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.143.0.tgz",
+      "integrity": "sha512-8rIKWR2BFuifbIK/1XB9wTaSdtuJ25dlE7ZQYDnEwj/2xH2vHsxnvIjHT3ZjSVuLLwGGlSslIG/fbOJ8TV8rTw==",
       "cpu": [
         "arm64"
       ],
@@ -2269,9 +2269,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.147.0.tgz",
-      "integrity": "sha512-a8mlt7CC8z7LUdCfaxhff4kCd+vSjE+NEFL0cxA8ukfuSnvAto/pWTjytW4BuVLnQGcCVdHJwcRKOfs++H+tjw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.143.0.tgz",
+      "integrity": "sha512-5U9kQYMfRRI6Zq7KDxgbIP0RMnKrfn3gLepRMgJuRkPSUALTiRCk9d/uyhb4lGDjUdzwK7mBkKqhLgzBPCmLpQ==",
       "cpu": [
         "arm64"
       ],
@@ -2286,9 +2286,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.147.0.tgz",
-      "integrity": "sha512-M5ViVDBcFLnl2632AuuWuP35zEL5oikK1jTx8r3+902VEDeSNHxFZAB6RZyfZ7MU6Oi5QTOG8MmMkIeHsudSaw==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.143.0.tgz",
+      "integrity": "sha512-25P7AaHk4R88Yv2XH4gToDVmh0cOu+bEURQU10CRrmvgabfRArSGAP5osmwUKeSUHj0VS50upbpbRWWW/m7mHA==",
       "cpu": [
         "ia32"
       ],
@@ -2303,9 +2303,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.147.0.tgz",
-      "integrity": "sha512-DUaE13OwnUSlHpLZNcC/nuT10ivlWqc5EZgsfgXuAmWYw0r3nDxGeLD1zlGwYwIgVk1/ZMAxoXpV+05stvbHaA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.143.0.tgz",
+      "integrity": "sha512-ORMh3JE1s6V7ySicdRK7vgaDQnn5o+UHg9ct989PlWHbel8O9ARrmWXM6kZjrBMtNucxNayQ8g69G0VfWzhANw==",
       "cpu": [
         "x64"
       ],
@@ -3248,9 +3248,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3279,17 +3279,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.68.0.tgz",
-      "integrity": "sha512-WASHDpCm6qO5jj9g1a+8NiW5+GCkAyLReR56/4VruYmNgfUmqpxOfZ2Yfb8xGfJPWv5Qi6LSD8sXdces3vbp/Q==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/type-utils": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3302,7 +3302,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.68.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -3318,16 +3318,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.68.0.tgz",
-      "integrity": "sha512-fHq2VC1kpyYfvEcbiMjOpySY4WS7voEp89yAThrHRX5sm9j2lzYppCb2umFMEed4fWcyeLjHxrz0mpjNBaBxMQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3343,14 +3343,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.68.0.tgz",
-      "integrity": "sha512-5GQtWZCXFcFYux955pvoS02WLc49pXNlvIxocKjS0clvwo3in1RdlzVKyiqQH9vE5AKWFLTaUgeQkOrTS+0Qxw==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.68.0",
-        "@typescript-eslint/types": "^8.68.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3365,14 +3365,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.68.0.tgz",
-      "integrity": "sha512-T5eXpcaJNg8bhjHJ8Rjp68Vq/QBteYtTKY8TZqVNPaUbuz0f6jI9t6aDkylwvalpAB9XTTFeFOjrjXAZ3YvmVA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3383,9 +3383,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.68.0.tgz",
-      "integrity": "sha512-F7zrGQfiJHojPwi8vhxZQC1tWtJzvL74cK/nqri2lk8YUXvYaYwl263xOJ69jDWPUk1hmcdoayFwk9lX09npVw==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3400,15 +3400,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.68.0.tgz",
-      "integrity": "sha512-X77zqoY1EjeWGs/0JNxeaMfp5C5lIz4Tw8y66F1Ne8Faq6g424sBNYM6xBAqElfGZPLpWS+CZAp0DXyKDzWiHg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3425,9 +3425,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.68.0.tgz",
-      "integrity": "sha512-9RnpsGJjrAllCMefGVVsImJM24YurhC0Q1h4UbvivtvOqXmR/vEJge2OoE++z9m6hyg8T1Q8t5SNT6tHSbrxcg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3439,16 +3439,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.68.0.tgz",
-      "integrity": "sha512-OKKsD0tYmoNiU5PW2zehO1yO56jYOm1ShYlxon/Z0SJNidAkdVg86eg9ruRuoXf8xfnuWZGbwDsStkoXbZtIIA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.68.0",
-        "@typescript-eslint/tsconfig-utils": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/visitor-keys": "8.68.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3506,16 +3506,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.68.0.tgz",
-      "integrity": "sha512-PB5gJMMOg0Q5P1tsgWtEAqQacJXq0qEqRHDX/YJ4FaTMLfZPpHB3gjl2EJuiZyPABxmj4ZQYiY9m1bdAJ5y7tQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.68.0",
-        "@typescript-eslint/types": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3530,13 +3530,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.68.0.tgz",
-      "integrity": "sha512-YR65gGdGvTUAWLldC3xLOvOzamdGzB4A5/N8rehEaHs3Zvoe39BhgY+u0SPch1OvrVTfLcc55wsSgK2NcnTS/A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.68.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4474,9 +4474,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
-      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4669,9 +4669,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -4689,11 +4689,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4839,9 +4839,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001810",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
-      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -5291,16 +5291,13 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
-      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.7"
-      },
-      "engines": {
-        "node": ">=6.4.0"
+        "browserslist": "^4.28.1"
       },
       "funding": {
         "type": "opencollective",
@@ -5406,29 +5403,29 @@
       }
     },
     "node_modules/cspell": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.1.1.tgz",
-      "integrity": "sha512-imoZaB1+9gHMyFFMDBY7VbtIdDwkRJXQjs3bIfo1H+AUJnw/vMxLwXk8mnPmH7ziw2m2kyGF+rPAVUE93VEAAA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-10.1.0.tgz",
+      "integrity": "sha512-sCGe2PWuA7H8pJTYSSkq5G5u3FXJr8igAcVEsSAqdAdTArkOxCca4kPNfeRhno2Dy1QEz7KGnoVFggvIaCv01g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-json-reporter": "10.1.1",
-        "@cspell/cspell-performance-monitor": "10.1.1",
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-types": "10.1.1",
-        "@cspell/cspell-worker": "10.1.1",
-        "@cspell/dynamic-import": "10.1.1",
-        "@cspell/url": "10.1.1",
+        "@cspell/cspell-json-reporter": "10.1.0",
+        "@cspell/cspell-performance-monitor": "10.1.0",
+        "@cspell/cspell-pipe": "10.1.0",
+        "@cspell/cspell-types": "10.1.0",
+        "@cspell/cspell-worker": "10.1.0",
+        "@cspell/dynamic-import": "10.1.0",
+        "@cspell/url": "10.1.0",
         "ansi-regex": "^6.3.0",
         "chalk": "^6.0.0",
         "chalk-template": "^1.1.2",
         "commander": "^15.0.0",
-        "cspell-config-lib": "10.1.1",
-        "cspell-dictionary": "10.1.1",
-        "cspell-gitignore": "10.1.1",
-        "cspell-glob": "10.1.1",
-        "cspell-io": "10.1.1",
-        "cspell-lib": "10.1.1",
+        "cspell-config-lib": "10.1.0",
+        "cspell-dictionary": "10.1.0",
+        "cspell-gitignore": "10.1.0",
+        "cspell-glob": "10.1.0",
+        "cspell-io": "10.1.0",
+        "cspell-lib": "10.1.0",
         "fast-json-stable-stringify": "^2.1.0",
         "flatted": "^3.4.4",
         "semver": "^7.8.5",
@@ -5446,13 +5443,13 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.1.1.tgz",
-      "integrity": "sha512-/AgOcOxO0jmAJCkShhaPQqSNrx+QUkEOncTf2uFnIx4/gRxFwiRZ0Zrv6PyHNBTC5vY82+qB6scT5Pj30n174A==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-10.1.0.tgz",
+      "integrity": "sha512-xWfyGRtu819BNnJ42SwvRsMdd4jgz+4eV4RaKUaM7uo5hsOI9o+LCulYWD8F4MPDb/izDopvC9qV8E3UVUe08g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-types": "10.1.1",
+        "@cspell/cspell-types": "10.1.0",
         "comment-json": "^5.0.0",
         "smol-toml": "^1.8.0",
         "yaml": "^2.9.0"
@@ -5462,16 +5459,16 @@
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.1.1.tgz",
-      "integrity": "sha512-94eW96hjAa3ASAjtmWkC1h1S7GLNHEoDftViilZ/nQzHxeYHp8kU73/0Jqjawr3tzfNvdKV0Bq/8zgeEp1LNrA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-10.1.0.tgz",
+      "integrity": "sha512-ZzBWuPkWfY5uXmKh6wEbG24jhm3reeUnqsVDwsmduazjf+hGjlxi1B7fS3Xr0I4xufN98lNCuynZpNOydDLEEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-performance-monitor": "10.1.1",
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-types": "10.1.1",
-        "cspell-trie-lib": "10.1.1",
+        "@cspell/cspell-performance-monitor": "10.1.0",
+        "@cspell/cspell-pipe": "10.1.0",
+        "@cspell/cspell-types": "10.1.0",
+        "cspell-trie-lib": "10.1.0",
         "fast-equals": "^6.0.2"
       },
       "engines": {
@@ -5479,15 +5476,15 @@
       }
     },
     "node_modules/cspell-gitignore": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.1.1.tgz",
-      "integrity": "sha512-vYQjziKDH8qQzj/gHHJPKwmAqwfQIHBvyqukR0Uf1WzY1X08Ns9jMl5JDRUL7ffcosDYsReIhLxy2KJrxRkrng==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-10.1.0.tgz",
+      "integrity": "sha512-kSnPsgmMuN2Uj7VJ3RP315o2Jt66pkFlcvGYswKXgixo06ZuiQmOJ9n4j1VS3Tu2uhVXBIKz/CP1r1lJenpoBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.1.1",
-        "cspell-glob": "10.1.1",
-        "cspell-io": "10.1.1"
+        "@cspell/url": "10.1.0",
+        "cspell-glob": "10.1.0",
+        "cspell-io": "10.1.0"
       },
       "bin": {
         "cspell-gitignore": "bin.mjs"
@@ -5497,13 +5494,13 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.1.1.tgz",
-      "integrity": "sha512-+xRfPD/KHU3JCMPK3Blt3AchW6KAzsyrNUdNns9mmkDRiej5Vl19kdN3eKh7B/0XoAKnX/v67tucCu/jr8MTug==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-10.1.0.tgz",
+      "integrity": "sha512-6n+NcnbDbe8Yz1RXwfsvC3K7OrFtu1Zx+c8VZORKwqpl1CDVEBY1zMyooS6VoqIu6C97iRWfwfP+Ad5dk2m1Qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/url": "10.1.1",
+        "@cspell/url": "10.1.0",
         "picomatch": "^4.0.5"
       },
       "engines": {
@@ -5511,9 +5508,9 @@
       }
     },
     "node_modules/cspell-glob/node_modules/picomatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
-      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5524,14 +5521,14 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.1.1.tgz",
-      "integrity": "sha512-mOHufusJEld/q8ZfC+AhequR515QIOHC0LdD1z6PU+Mpn3GRBGJBWK56iUwHH4XX935GsUMJFIQuOoMXXcbAsw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-10.1.0.tgz",
+      "integrity": "sha512-sE6Y2cJeFReAeyCMwNL0Htffv8LweeVnkn1RSUiCZ7nPmEO8gzp6tFC6IeTFtJdpt1uzXW/JZl+tmuTQkOOLfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-types": "10.1.1"
+        "@cspell/cspell-pipe": "10.1.0",
+        "@cspell/cspell-types": "10.1.0"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -5541,42 +5538,42 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.1.1.tgz",
-      "integrity": "sha512-Gcl2B2hKOJBqi+nf1ZnZ2XZj+VWN+AZLfQZR5dxxny3Ggy51vW8AfJX8lF8Ev/c559AkC5G7KkO2jkVuZ4SVsA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-10.1.0.tgz",
+      "integrity": "sha512-On6bXkt4z3B+1lEjROWIXrH8yLfAYQQawpalMpQHl9v++h8NsFrqVC+1MNHw0qXiHfv8pqn/cy4Fk0xKEJA+4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-service-bus": "10.1.1",
-        "@cspell/url": "10.1.1"
+        "@cspell/cspell-service-bus": "10.1.0",
+        "@cspell/url": "10.1.0"
       },
       "engines": {
         "node": ">=22.18.0"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.1.1.tgz",
-      "integrity": "sha512-jckdiCU/3pkvJ21G77R2fl93R6JjpYwP+wj8qQNUewYlTl9bdhMJi8xgLb4os7CJnHD5kA59ow8tNvh45d3zDw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-10.1.0.tgz",
+      "integrity": "sha512-9Rpx2ziuM6AxPjTfhQ+Q8rNkQREdgq7RBT7FATqJOEo65xVDjbVoSfvuaP4MlGQEWiQgvFye9ZQXnqtdcAZAGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "10.1.1",
-        "@cspell/cspell-performance-monitor": "10.1.1",
-        "@cspell/cspell-pipe": "10.1.1",
-        "@cspell/cspell-resolver": "10.1.1",
-        "@cspell/cspell-types": "10.1.1",
-        "@cspell/dynamic-import": "10.1.1",
-        "@cspell/filetypes": "10.1.1",
-        "@cspell/rpc": "10.1.1",
-        "@cspell/strong-weak-map": "10.1.1",
-        "@cspell/url": "10.1.1",
-        "cspell-config-lib": "10.1.1",
-        "cspell-dictionary": "10.1.1",
-        "cspell-glob": "10.1.1",
-        "cspell-grammar": "10.1.1",
-        "cspell-io": "10.1.1",
-        "cspell-trie-lib": "10.1.1",
+        "@cspell/cspell-bundled-dicts": "10.1.0",
+        "@cspell/cspell-performance-monitor": "10.1.0",
+        "@cspell/cspell-pipe": "10.1.0",
+        "@cspell/cspell-resolver": "10.1.0",
+        "@cspell/cspell-types": "10.1.0",
+        "@cspell/dynamic-import": "10.1.0",
+        "@cspell/filetypes": "10.1.0",
+        "@cspell/rpc": "10.1.0",
+        "@cspell/strong-weak-map": "10.1.0",
+        "@cspell/url": "10.1.0",
+        "cspell-config-lib": "10.1.0",
+        "cspell-dictionary": "10.1.0",
+        "cspell-glob": "10.1.0",
+        "cspell-grammar": "10.1.0",
+        "cspell-io": "10.1.0",
+        "cspell-trie-lib": "10.1.0",
         "env-paths": "^4.0.0",
         "gensequence": "^8.0.8",
         "import-fresh": "^4.0.0",
@@ -5590,16 +5587,16 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.1.1.tgz",
-      "integrity": "sha512-4ico1ebFl9lvP1Yr4pD+FxOYRS7Ct+ImV8v0KcEclxMixqNku4NoVP/CvmE1AyyVB3FN16fITN0vo3ZAR79PFw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-10.1.0.tgz",
+      "integrity": "sha512-qzWzQuvl3tgulJXC8ILDmzAoKzNGXTKXO+Yh0hTAqnxpI1wtSFzjIf2Md4M6YhcITNBpp5h+xhjccsro5IB5ug==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@cspell/cspell-types": "10.1.1"
+        "@cspell/cspell-types": "10.1.0"
       }
     },
     "node_modules/cspell/node_modules/chalk": {
@@ -5937,9 +5934,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.416",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
-      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -6149,9 +6146,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
-      "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.0.tgz",
+      "integrity": "sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -6319,22 +6316,22 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "74.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-74.0.0.tgz",
-      "integrity": "sha512-AGnsGi2SxHg1HEAXxn9nSnZfyjvTWkxm8E8hpd/9tD6dLjBUdcD7+D6ZN64HmmCXTSXlrwVyUqe20Uyb2CaurA==",
+      "version": "73.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-73.0.0.tgz",
+      "integrity": "sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.10.1",
-        "@eslint/css-tree": "^4.0.5",
-        "browserslist": "^4.28.8",
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@eslint/css-tree": "^4.0.4",
+        "browserslist": "^4.28.4",
         "change-case": "^5.4.4",
         "ci-info": "^4.4.0",
-        "core-js-compat": "^3.50.0",
+        "core-js-compat": "^3.49.0",
         "detect-indent": "^7.0.2",
-        "entities": "^8.0.0",
+        "entities": "^4.5.0",
         "find-up-simple": "^1.0.1",
-        "globals": "^17.11.0",
+        "globals": "^17.7.0",
         "indent-string": "^5.0.0",
         "is-builtin-module": "^5.0.0",
         "is-identifier": "^1.1.0",
@@ -6354,19 +6351,6 @@
       },
       "peerDependencies": {
         "eslint": ">=10.4"
-      }
-    },
-    "node_modules/eslint-plugin-unicorn/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/eslint-scope": {
@@ -6813,14 +6797,13 @@
       }
     },
     "node_modules/formatly": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.7.0.tgz",
-      "integrity": "sha512-7CXJtIIA0zy/u12StsYk25qVKxvdLA2ep2sTNxK3ov0mGNIIDqIvAXDSgTnAfDJFsPfWjuz0WjfYSdpvnLA5Tg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fd-package-json": "^2.0.0",
-        "package-manager-detector": "^1.8.0"
+        "fd-package-json": "^2.0.0"
       },
       "bin": {
         "formatly": "bin/index.mjs"
@@ -6970,9 +6953,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
-      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7087,9 +7070,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
-      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7979,9 +7962,9 @@
       }
     },
     "node_modules/knip": {
-      "version": "6.33.0",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-6.33.0.tgz",
-      "integrity": "sha512-gMXWV2bqgJcdZKsaRgl1oH5V2J0VumhJ2ujfP4M6b9ftpca2BNpvlX3Dq++vVtEey7sU67EXCvZGNkQfG2w1RQ==",
+      "version": "6.32.2",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-6.32.2.tgz",
+      "integrity": "sha512-WXTXbmocrw7gqm1A1TQvFN0OgJ7hUSU6E1g6SPRIzzHFogUBhXByc7cYeOFVtJ2uODg7DP4VbESYBYnfbtBYsg==",
       "dev": true,
       "funding": [
         {
@@ -7996,16 +7979,16 @@
       "license": "ISC",
       "dependencies": {
         "fdir": "^6.5.0",
-        "formatly": "^0.7.0",
-        "get-tsconfig": "4.14.3",
+        "formatly": "^0.3.0",
+        "get-tsconfig": "4.14.1",
         "jiti": "^2.7.0",
-        "oxc-parser": "^0.147.0",
+        "oxc-parser": "^0.143.0",
         "oxc-resolver": "11.24.2",
-        "picomatch": "^4.0.7",
-        "smol-toml": "^1.8.0",
+        "picomatch": "^4.0.5",
+        "smol-toml": "^1.7.1",
         "strip-json-comments": "5.0.3",
         "tinyglobby": "^0.2.17",
-        "unbash": "^4.0.10",
+        "unbash": "^4.0.9",
         "yaml": "^2.9.0",
         "zod": "^4.4.3"
       },
@@ -8036,9 +8019,9 @@
       }
     },
     "node_modules/knip/node_modules/picomatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
-      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8386,15 +8369,15 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
-      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
+      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.7",
+        "picomatch": "^4.0.5",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.3.0"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -8410,9 +8393,9 @@
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
-      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8886,9 +8869,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.54",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
-      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9063,13 +9046,13 @@
       }
     },
     "node_modules/oxc-parser": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.147.0.tgz",
-      "integrity": "sha512-5xaug6t7GfV3BO5Iv+xHW1rmQkDEQ3BEu3L8g3InsvWO5i8CYGc4tCZ2X985QcwWNycFJam+aOns6Nr2XAThTA==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.143.0.tgz",
+      "integrity": "sha512-ov0NzaDCOInknS7mP1cwKdJERt3utPW8ldjtdUXQ8Ty0GEFD08wk422vCUN0d7pST6kqtV7dxoI9w1Zi0l/9TA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.147.0"
+        "@oxc-project/types": "^0.143.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -9078,31 +9061,31 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.147.0",
-        "@oxc-parser/binding-android-arm64": "0.147.0",
-        "@oxc-parser/binding-darwin-arm64": "0.147.0",
-        "@oxc-parser/binding-darwin-x64": "0.147.0",
-        "@oxc-parser/binding-freebsd-x64": "0.147.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.147.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.147.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.147.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.147.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.147.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.147.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.147.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.147.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.147.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.147.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.147.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.147.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.147.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.147.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.143.0",
+        "@oxc-parser/binding-android-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-arm64": "0.143.0",
+        "@oxc-parser/binding-darwin-x64": "0.143.0",
+        "@oxc-parser/binding-freebsd-x64": "0.143.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.143.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.143.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.143.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.143.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.143.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.143.0"
       }
     },
     "node_modules/oxc-parser/node_modules/@oxc-project/types": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
-      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9213,13 +9196,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/package-manager-detector": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
-      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10734,9 +10710,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10967,16 +10943,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.68.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.68.0.tgz",
-      "integrity": "sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.68.0",
-        "@typescript-eslint/parser": "8.68.0",
-        "@typescript-eslint/typescript-estree": "8.68.0",
-        "@typescript-eslint/utils": "8.68.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11090,9 +11066,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
-      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -11400,16 +11376,16 @@
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.14.tgz",
-      "integrity": "sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.2.0.tgz",
-      "integrity": "sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11754,9 +11730,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
-      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -331,25 +331,25 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@playwright/test": "1.62.1",
-    "@types/node": "26.4.0",
+    "@types/node": "26.2.0",
     "@types/vscode": "1.125.0",
     "@vitest/coverage-v8": "4.1.11",
     "@vscode/vsce": "3.9.2",
-    "cspell": "10.1.1",
+    "cspell": "10.1.0",
     "esbuild": "0.28.2",
-    "eslint": "10.9.1",
+    "eslint": "10.9.0",
     "eslint-plugin-import-x": "4.17.1",
     "eslint-plugin-no-unsanitized": "4.1.5",
-    "eslint-plugin-unicorn": "74.0.0",
+    "eslint-plugin-unicorn": "73.0.0",
     "husky": "9.1.7",
     "jsdom": "29.1.1",
-    "knip": "6.33.0",
-    "lint-staged": "17.4.1",
+    "knip": "6.32.2",
+    "lint-staged": "17.3.0",
     "lockfile-lint": "5.0.1",
     "preact-render-to-string": "6.7.0",
     "serve": "14.2.6",
     "typescript": "6.0.3",
-    "typescript-eslint": "8.68.0",
+    "typescript-eslint": "8.67.0",
     "vitest": "4.1.11"
   },
   "dependencies": {
@@ -358,7 +358,7 @@
     "htm": "3.1.1",
     "leo-profanity": "1.9.0",
     "preact": "10.29.8",
-    "zod": "4.5.4"
+    "zod": "4.4.3"
   },
   "overrides": {
     "smol-toml": "1.7.1"

--- a/src/webview/panel-llm.ts
+++ b/src/webview/panel-llm.ts
@@ -334,11 +334,23 @@ const LLM_FAMILY = 'gpt-5.4-mini';
 const LLM_REQUEST_TIMEOUT_MS = 90_000;
 
 /**
- * Pick a Copilot chat model. Tries the preferred family first, then a short
- * fallback list, then any available model. Throws a descriptive error when
- * nothing is available so callers can surface a useful message.
+ * Pick a Copilot chat model. Prefers Copilot's own "Auto" router (the same
+ * `{ id: 'auto', vendor: 'copilot' }` selector VS Code's built-in Copilot Chat
+ * uses for its Auto mode), which picks whichever model is actually enabled for
+ * the caller's plan/org. A hardcoded family can be *selectable* yet disabled
+ * for the user (e.g. by org policy) — such models don't fail selection, they
+ * silently return empty responses, which previously surfaced as a confusing
+ * "invalid JSON" error (see #91). Falls back to a short family allowlist and
+ * then any available model for older Copilot versions that don't recognize
+ * the `id: 'auto'` selector. Throws a descriptive error when nothing is
+ * available so callers can surface a useful message.
  */
 async function selectModel(): Promise<vscode.LanguageModelChat> {
+  try {
+    const auto = await vscode.lm.selectChatModels({ id: 'auto', vendor: 'copilot' });
+    if (auto.length > 0) return auto[0];
+  } catch { /* older Copilot versions may not support the id: 'auto' selector */ }
+
   const families = [LLM_FAMILY, 'gpt-5-mini', 'gpt-4.1-mini', 'gpt-4.1'];
   for (const family of families) {
     const models = await vscode.lm.selectChatModels({ family });
@@ -402,6 +414,38 @@ export async function callLlm(messages: vscode.LanguageModelChatMessage[]): Prom
   throw lastError;
 }
 
+/** How a single failed `callLlmJson` attempt should be recorded and reacted to. */
+interface LlmFailureClassification {
+  /** The model streamed back nothing at all (e.g. it's disabled for the caller's plan/org). */
+  isEmptyResponse: boolean;
+  /** The response was non-empty but couldn't be parsed as JSON. */
+  isParseFailure: boolean;
+  /** Structured output should be dropped so the next attempt can recover in plain mode. */
+  dropStructuredOutput: boolean;
+}
+
+function classifyLlmFailure(err: unknown, text: string, structuredOutputActive: boolean): LlmFailureClassification {
+  const isEmptyResponse = text.trim().length === 0;
+  const message = err instanceof Error ? err.message : String(err);
+  const looksJsonRelated = /response_format|modelOptions|not supported|JSON|parse/i.test(message);
+  return {
+    isEmptyResponse,
+    isParseFailure: !isEmptyResponse && /JSON|parse/i.test(message),
+    dropStructuredOutput: structuredOutputActive && looksJsonRelated,
+  };
+}
+
+/** Build the final error message once all retries are exhausted. */
+function buildLlmJsonFailureMessage(modelId: string, emptyResponses: number, parseFailures: number, lastError: unknown): string {
+  if (emptyResponses > 0 && parseFailures === 0) {
+    return `The "${modelId}" AI model returned an empty response after ${LLM_MAX_RETRIES + 1} attempts. ` +
+      'This can happen when the model is disabled for your Copilot plan or organization. ' +
+      'Try again, or pick a different chat model as your default in VS Code and retry.';
+  }
+  if (parseFailures > 0) return `LLM returned invalid JSON after ${LLM_MAX_RETRIES + 1} attempts. Please try again.`;
+  return lastError instanceof Error ? lastError.message : 'LLM request failed after retries';
+}
+
 export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[], jsonSchema?: JsonSchemaSpec): Promise<T> {
   const model = await selectModel();
 
@@ -411,6 +455,7 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
 
   let lastError: unknown;
   let parseFailures = 0;
+  let emptyResponses = 0;
   const retryMessages = [...redactMessages(messages)];
 
   for (let attempt = 0; attempt <= LLM_MAX_RETRIES; attempt++) {
@@ -419,6 +464,11 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
     try {
       const response = await model.sendRequest(retryMessages, options, cts.token);
       for await (const chunk of response.text) text += chunk;
+      // A model can be *selectable* yet disabled for the caller's plan/org —
+      // rather than failing selection it silently streams back nothing. Treat
+      // that as its own failure mode instead of letting it masquerade as an
+      // "invalid JSON" parse error (see #91).
+      if (text.trim().length === 0) throw new Error('LLM returned an empty response');
       try {
         return JSON.parse(text.trim()) as T;
       } catch {
@@ -431,13 +481,13 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
         `schema=${schemaName} attempt=${attempt + 1} structured=${options.modelOptions !== undefined} ` +
         `model=${model.id} textLen=${text.length} error=${err instanceof Error ? err.message : String(err)}`);
       if (err instanceof vscode.CancellationError) { cts.dispose(); throw err; }
-      // Drop structured output so later attempts can recover in plain mode.
-      if (jsonSchema && options.modelOptions && lastError instanceof Error &&
-          /response_format|modelOptions|not supported|JSON|parse/i.test(lastError.message)) {
-        options.modelOptions = undefined;
-      }
-      // On parse failures, nudge the model to return valid JSON on the next attempt
-      if (lastError instanceof Error && /JSON|parse/i.test(lastError.message)) {
+
+      const failure = classifyLlmFailure(err, text, options.modelOptions !== undefined);
+      if (failure.dropStructuredOutput) options.modelOptions = undefined;
+      if (failure.isEmptyResponse) {
+        emptyResponses++;
+      } else if (failure.isParseFailure) {
+        // On parse failures, nudge the model to return valid JSON on the next attempt
         parseFailures++;
         if (retryMessages.length === messages.length) {
           retryMessages.push(vscode.LanguageModelChatMessage.User(
@@ -450,8 +500,5 @@ export async function callLlmJson<T>(messages: vscode.LanguageModelChatMessage[]
     }
   }
 
-  const label = parseFailures > 0
-    ? `LLM returned invalid JSON after ${LLM_MAX_RETRIES + 1} attempts. Please try again.`
-    : (lastError instanceof Error ? lastError.message : 'LLM request failed after retries');
-  throw new Error(label);
+  throw new Error(buildLlmJsonFailureMessage(model.id, emptyResponses, parseFailures, lastError));
 }


### PR DESCRIPTION
## Description

Fixes #91 — `Error: LLM returned invalid JSON after 3 attempts. Please try again.` on every AI-driven feature (Skill Finder, Generate Quiz, Slop or Not, rule compilation, etc.).

### Root cause

All AI features go through `callLlmJson()` in `src/webview/panel-llm.ts`, which picked a model once via `selectModel()` using a **hardcoded family list** (`gpt-5.4-mini` → `gpt-5-mini` → `gpt-4.1-mini` → `gpt-4.1` → any).

A model in that list can be **selectable** via `vscode.lm.selectChatModels` yet be **disabled for the caller's Copilot plan/org**. In that case it doesn't fail selection — it just silently streams back an **empty response**. Because `callLlmJson` reused the same (broken) model for every retry, the empty text failed JSON parsing three times in a row, and the user saw the generic, misleading `LLM returned invalid JSON after 3 attempts` error for every AI feature, with no indication of what was actually wrong.

This matches the maintainer's own diagnosis on the closed/unmerged PR #102, which suggested trying `selectChatModels({ family: 'auto' })` as a simpler fix (https://github.com/microsoft/AI-Engineering-Coach/pull/102#issuecomment-4757325545). I confirmed via VS Code's own Copilot extension source that the selector its internal "Auto" router actually uses is `{ id: 'auto', vendor: 'copilot' }` (not `family: 'auto'`).

### Fix

- **`selectModel()`** now tries `vscode.lm.selectChatModels({ id: 'auto', vendor: 'copilot' })` first (wrapped in try/catch), so Copilot routes the request to whichever model is actually enabled for the user's plan/org. Falls back to the existing hardcoded family list, then any available model, unchanged — so behavior is preserved on older Copilot versions that don't recognize the `id: 'auto'` selector.
- **`callLlmJson()`** now detects an empty streamed response as its own failure mode (instead of letting it masquerade as a JSON parse error). When every retry attempt comes back empty, it throws a clear, actionable message explaining this can happen when the model is disabled for the user's plan/org, and suggesting they pick a different default chat model. Genuine JSON parse failures keep the original message/behavior.
- Small refactor (`classifyLlmFailure` / `buildLlmJsonFailureMessage` helpers) to keep `callLlmJson` readable given the extra branching.
- `CHANGELOG.md` entry.

This is intentionally a small, targeted fix — it does not reintroduce the model-picker UI / `aiEngineerCoach.preferredModel` setting from the closed PR #102, per the maintainer's own follow-up steering towards the simpler `auto`-selector approach.

## Related Issues

Fixes #91

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors; no new warnings introduced)
- [x] `npm run spellcheck` passes
- [x] `npm test` — all pass except a pre-existing, environment-sensitive failure in `src/core/github-app-analytics.test.ts` that also fails on a clean, unmodified `main` checkout (confirmed), unrelated to this change
- [x] Documentation updated — `CHANGELOG.md`